### PR TITLE
The onDocumentCleaned event is raised wrongly after document.write is called for a document that is still being loaded (fix #253)

### DIFF
--- a/test/client/data/node-sandbox/iframe-without-document-cleaned-event.html
+++ b/test/client/data/node-sandbox/iframe-without-document-cleaned-event.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+    <meta charset="utf-8">
+    <script src="/hammerhead.js" class="script-hammerhead-shadow-ui"></script>
+</head>
+<body>
+<script type="text/javascript">
+    var hammerhead = window['%hammerhead%'];
+
+    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.start({ crossDomainProxyPort: 2000 });
+    hammerhead.shadowUI.getRoot();
+</script>
+<script>
+    var INSTRUCTION = hammerhead.get('../processing/script/instruction');
+    var mutation = hammerhead.sandbox.node.mutation;
+    var postMessage = hammerhead.sandbox.event.message.postMessage;
+
+    var isDocumentCleanedCalled = false;
+
+    mutation.on(mutation.DOCUMENT_CLEANED_EVENT, function () {
+        isDocumentCleanedCalled = true;
+
+        postMessage(window.top, ['fail', '*']);
+    });
+
+    window.addEventListener('load', function () {
+        if (!isDocumentCleanedCalled)
+            postMessage(window.top, ['success', '*']);
+    });
+
+    eval(window[INSTRUCTION.processScript]('document.write(\'<div id="test-div">Hello!</div>\');'));
+</script>
+</body>
+</html>

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -256,3 +256,21 @@ test('document.write with __begin$, __end$ parameters (T232454)', function () {
 
     strictEqual(result, 'w1w2w3wl1wl2wl3');
 });
+
+asyncTest('the onDocumentCleaned event is not raised after calling document.write (GH-253)', function () {
+    expect(1);
+
+    var iframeSrc = window.QUnitGlobals.getResourceUrl('../../../data/node-sandbox/iframe-without-document-cleaned-event.html');
+
+    window.addEventListener('message', function (e) {
+        var iframe = e.source.frameElement;
+
+        strictEqual(e.data, 'success');
+
+        iframe.parentNode.removeChild(iframe);
+
+        start();
+    });
+
+    $('<iframe></iframe>').attr('src', iframeSrc).appendTo('body');
+});


### PR DESCRIPTION
/cc @inikulin @churkin 