### PR TITLE
Hammerhead client proxy handle document.location set incorrectly (close #290)

### DIFF
--- a/src/client/sandbox/code-instrumentation/properties/index.js
+++ b/src/client/sandbox/code-instrumentation/properties/index.js
@@ -288,7 +288,8 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
                         if (window.self !== window.top)
                             location = destLocation.resolveUrl(location, window.top.document);
 
-                        var resourceType = owner !== window.top ? urlUtils.IFRAME : null;
+                        var ownerWindow  = domUtils.isWindow(owner) ? owner : owner.defaultView;
+                        var resourceType = ownerWindow !== window.top ? urlUtils.IFRAME : null;
 
                         owner.location = urlUtils.getProxyUrl(location, null, null, null, resourceType);
 


### PR DESCRIPTION
Unfortunately, we can not write a client-test for this bug, since the bug is associated with a changing location property of the top window (If we set `document.location` for the top window, it always proxied with 'iframe' resource type).

\cc @inikulin @AlexanderMoskovkin 