### PR TITLE
Quotes in the cookies are not escaped when a task script for an iframe is built on the client (close #366)

### DIFF
--- a/src/client/sandbox/iframe.js
+++ b/src/client/sandbox/iframe.js
@@ -77,7 +77,7 @@ export default class IframeSandbox extends SandboxBase {
         // If it is needed elsewhere in a certain place, we should consider using Mustache.
         var taskScriptTemplate = settings.get().iframeTaskScriptTemplate;
         var taskScript         = taskScriptTemplate
-            .replace('{{{cookie}}}', this.cookieSandbox.getCookie())
+            .replace('{{{cookie}}}', JSON.stringify(this.cookieSandbox.getCookie()))
             .replace('{{{referer}}}', settings.get().referer || this.window.location.toString())
             .replace('{{{iframeTaskScriptTemplate}}}', JSON.stringify(taskScriptTemplate));
 

--- a/src/client/task.js.mustache
+++ b/src/client/task.js.mustache
@@ -1,5 +1,5 @@
 window['%hammerhead%'].start({
-    cookie                       : '{{{cookie}}}',
+    cookie                       : {{{cookie}}},
     sessionId                    : '{{{sessionId}}}',
     serviceMsgUrl                : '{{{serviceMsgUrl}}}',
     isFirstPageLoad              : {{{isFirstPageLoad}}},

--- a/src/session/index.js
+++ b/src/session/index.js
@@ -65,7 +65,7 @@ export default class Session extends EventEmitter {
     }
 
     getTaskScript (referer, cookieUrl, serverInfo, isIframe, withPayload) {
-        var cookies       = this.cookies.getClientString(cookieUrl).replace(/'/g, "\\'");
+        var cookies       = JSON.stringify(this.cookies.getClientString(cookieUrl));
         var payloadScript = '';
 
         if (withPayload)

--- a/test/client/before-test.js
+++ b/test/client/before-test.js
@@ -12,6 +12,7 @@
     var INTERNAL_PROPS = hammerhead.get('../processing/dom/internal-properties');
     var INSTRUCTION    = hammerhead.get('../processing/script/instruction');
     var destLocation   = hammerhead.get('./utils/destination-location');
+    var settings       = hammerhead.get('./settings');
 
     destLocation.forceLocation('http://localhost/sessionId/https://example.com');
 
@@ -19,7 +20,7 @@
         'window["%hammerhead%"].get("./utils/destination-location").forceLocation("{{{location}}}");',
         'window["%hammerhead%"].start({',
         '    referer : "{{{referer}}}",',
-        '    cookie: "{{{cookie}}}",',
+        '    cookie: {{{cookie}}},',
         '    serviceMsgUrl : "{{{serviceMsgUrl}}}",',
         '    sessionId : "sessionId",',
         '    iframeTaskScriptTemplate: {{{iframeTaskScriptTemplate}}}',
@@ -31,14 +32,15 @@
             .replace('{{{referer}}}', referer || '')
             .replace('{{{serviceMsgUrl}}}', serviceMsgUrl || '')
             .replace('{{{location}}}', location || '')
-            .replace('{{{cookie}}}', cookie || '');
+            .replace('{{{cookie}}}', JSON.stringify(cookie || ''));
     };
 
     window.initIframeTestHandler = function (e) {
         var referer          = "http://localhost/sessionId/https://example.com";
         var location         = "http://localhost/sessionId/https://example.com";
         var serviceMsgUrl    = "/service-msg/100";
-        var iframeTaskScript = window.getIframeTaskScript(referer, serviceMsgUrl, location).replace(/"/g, '\\"');
+        var cookie           = settings.get().cookie || '';
+        var iframeTaskScript = JSON.stringify(window.getIframeTaskScript(referer, serviceMsgUrl, location, cookie));
 
         if (e.iframe.id.indexOf('test') !== -1) {
             e.iframe.contentWindow.eval.call(e.iframe.contentWindow, [
@@ -47,7 +49,8 @@
                 '    referer : "' + referer + '",',
                 '    serviceMsgUrl : "' + serviceMsgUrl + '",',
                 '    sessionId : "sessionId",',
-                '    iframeTaskScriptTemplate: "' + iframeTaskScript + '"',
+                '    cookie: ' + JSON.stringify(cookie) + ',',
+                '    iframeTaskScriptTemplate: ' + iframeTaskScript + '',
                 '});'
             ].join(''));
         }

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -1,4 +1,5 @@
-var urlUtils       = hammerhead.get('./utils/url');
+var urlUtils = hammerhead.get('./utils/url');
+var settings = hammerhead.get('./settings');
 
 var iframeSandbox = hammerhead.sandbox.iframe;
 var nativeMethods = hammerhead.nativeMethods;
@@ -64,7 +65,7 @@ asyncTest('element.setAttribute', function () {
     var src    = browserUtils.isFirefox ? 'javascript:"<html><body></body></html>"' : '';
     var iframe = document.createElement('iframe');
 
-    iframe.id  = 'test20';
+    iframe.id = 'test20';
     iframe.setAttribute('src', src);
     window.QUnitGlobals.waitForIframe(iframe)
         .then(function () {
@@ -74,9 +75,9 @@ asyncTest('element.setAttribute', function () {
             iframeIframeSandbox.on(iframeIframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
             iframeIframeSandbox.off(iframeIframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
 
-            var iframeDocument   = iframe.contentDocument;
-            var iframeBody       = iframeDocument.body;
-            var nestedIframe     = iframeDocument.createElement('iframe');
+            var iframeDocument = iframe.contentDocument;
+            var iframeBody     = iframeDocument.body;
+            var nestedIframe   = iframeDocument.createElement('iframe');
 
             nestedIframe.id = 'test21';
 
@@ -198,6 +199,23 @@ asyncTest('native methods are properly initialized in an iframe without src (GH-
             iframe.parentNode.removeChild(iframe);
             start();
         });
+    document.body.appendChild(iframe);
+});
+
+asyncTest('quotes in the cookies are not escaped when a task script for an iframe is built on the client (GH-366)', function () {
+    var iframe = document.createElement('iframe');
+    var cookie = '""\'\'';
+
+    iframe.id             = 'test_cookie';
+    settings.get().cookie = cookie;
+
+    window.QUnitGlobals.waitForIframe(iframe)
+        .then(function () {
+            strictEqual(iframe.contentWindow['%hammerhead%'].get('./settings').get().cookie, cookie);
+            iframe.parentNode.removeChild(iframe);
+            start();
+        });
+
     document.body.appendChild(iframe);
 });
 


### PR DESCRIPTION
\сс @LavrovArtem @miherlosev 

