### PR TITLE
Update to v6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": "https://github.com/DevExpress/testcafe-hammerhead/issues",
   "license": "https://github.com/DevExpress/testcafe-hammerhead/blob/master/LICENSE",


### PR DESCRIPTION
We have to increase the major version because of a breaking change in the https://github.com/DevExpress/testcafe-hammerhead/issues/410

We've checked there are no regression failures in `health-monitor`, so we can publish the new version

/cc @inikulin 