### PR TITLE
'isInputWithoutSelectionPropertiesInFirefox' method removed

### DIFF
--- a/src/client/sandbox/event/selection.js
+++ b/src/client/sandbox/event/selection.js
@@ -104,7 +104,7 @@ export default class Selection {
     }
 
     static _needChangeInputType (el) {
-        return domUtils.isInputElement(el) && (browserUtils.isWebKit && /^(number|email)$/.test(el.type));
+        return domUtils.isInputElement(el) && browserUtils.isWebKit && /^(number|email)$/.test(el.type);
     }
 
     setSelection (el, start, end, direction) {
@@ -134,20 +134,11 @@ export default class Selection {
             el.type = 'text';
         }
 
-        if (domUtils.isInputWithoutSelectionPropertiesInFirefox(el)) {
-            selection = {
-                start:     0,
-                end:       0,
-                direction: 'forward'
-            };
-        }
-        else {
-            selection = {
-                start:     el.selectionStart,
-                end:       el.selectionEnd,
-                direction: el.selectionDirection
-            };
-        }
+        selection = {
+            start:     el.selectionStart,
+            end:       el.selectionEnd,
+            direction: el.selectionDirection
+        };
 
         if (changeType) {
             el.type = savedType;

--- a/src/client/utils/dom.js
+++ b/src/client/utils/dom.js
@@ -439,11 +439,6 @@ export function isBodyElementWithChildren (el) {
     return isBodyElement(el) && el.children.length;
 }
 
-export function isInputWithoutSelectionPropertiesInFirefox (el) {
-    // NOTE: T101195, T133144, T101195
-    return isFirefox && matches(el, 'input[type=number]');
-}
-
 export function isMapElement (el) {
     return /^map$|^area$/i.test(getTagName(el));
 }


### PR DESCRIPTION
/cc @churkin 
we no longer need 'isInputWithoutSelectionPropertiesInFirefox' method, because bug with 'selectionStart/selectionEnd/selectionDirection' for input type = 'number' was fixed in Firefox