### PR TITLE
Hammerhead crashes if client-side code contains document.cookie = null or document.cookie = undefined (close #444)

### DIFF
--- a/src/client/sandbox/code-instrumentation/properties/index.js
+++ b/src/client/sandbox/code-instrumentation/properties/index.js
@@ -109,7 +109,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             cookie: {
                 condition: doc => domUtils.isDocument(doc),
                 get:       () => this.cookieSandbox.getCookie(),
-                set:       (doc, cookie) => this.cookieSandbox.setCookie(doc, cookie)
+                set:       (doc, cookie) => this.cookieSandbox.setCookie(doc, String(cookie))
             },
 
             data: {

--- a/test/client/fixtures/sandbox/cookie-test.js
+++ b/test/client/fixtures/sandbox/cookie-test.js
@@ -173,3 +173,29 @@ test('delete (B239496)', function () {
     transport.queuedAsyncServiceMsg = savedQueuedAsyncServiceMsg;
     urlUtils.parseProxyUrl          = savedUrlUtilParseProxyUrl;
 });
+
+test('hammerhead crashes if client-side code contains "document.cookie=null" or "document.cookie=undefined" (GH-444, T349254).', function () {
+    settings.get().cookie = '';
+
+    var savedQueuedAsyncServiceMsg = transport.queuedAsyncServiceMsg;
+
+    transport.queuedAsyncServiceMsg = function () {
+    };
+
+    setCookie(null);
+    strictEqual(getCookie(), '');
+
+    setCookie(void 0);
+    strictEqual(getCookie(), '');
+
+    setCookie(true);
+    strictEqual(getCookie(), '');
+
+    setCookie('');
+    strictEqual(getCookie(), '');
+
+    setCookie(123);
+    strictEqual(getCookie(), '');
+
+    transport.queuedAsyncServiceMsg = savedQueuedAsyncServiceMsg;
+});


### PR DESCRIPTION
\cc @inikulin @LavrovArtem 