### PR TITLE
Update to v8.0.0, add 'createNativeXHR' API method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "7.1.3",
+  "version": "8.0.0",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": "https://github.com/DevExpress/testcafe-hammerhead/issues",
   "license": "https://github.com/DevExpress/testcafe-hammerhead/blob/master/LICENSE",

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -2,6 +2,7 @@ import Promise from 'pinkie';
 import Sandbox from './sandbox';
 import CodeInstrumentation from './sandbox/code-instrumentation';
 import EventEmitter from './utils/event-emitter';
+import XhrSandbox from './sandbox/xhr';
 import settings from './settings';
 import transport from './transport';
 /*eslint-disable no-native-reassign*/
@@ -43,6 +44,7 @@ class Hammerhead {
         // Methods
         this.getOriginElementAttributes = CodeInstrumentation.getAttributesProperty;
         this.doUpload                   = (input, filePaths) => this.sandbox.upload.doUpload(input, filePaths);
+        this.createNativeXHR            = XhrSandbox.createNativeXHR;
 
         // NOTE: We should provide a function to retrieve modules, because hammerhead will be bundled into a single
         // file and we will not have access to the internal modules by default.


### PR DESCRIPTION
After the https://github.com/DevExpress/testcafe-hammerhead/commit/ab60a4f59057887b2363e3d154bd4c855b3af74e commit testcafe can not use the `nativeMethods.XMLHttpRequest` anymore, because we are now override a prototype methods, and it is not the really native. For this purpose, we add a new `createNativeXHR` API method.

\cc @AlexanderMoskovkin 