### PR TITLE
fix xhr issues (close #545, close #552)

### DIFF
--- a/src/request-pipeline/index.js
+++ b/src/request-pipeline/index.js
@@ -108,7 +108,7 @@ function createReqOpts (ctx) {
         ctx.reqBody = bodyWithUploads;
 
     // NOTE: All headers, including 'content-length', are built here.
-    var headers = headerTransforms.forRequest(ctx, this);
+    var headers = headerTransforms.forRequest(ctx);
 
     return {
         url:         ctx.dest.url,


### PR DESCRIPTION
@churkin @LavrovArtem 

1)Xhr request without credentials should not send cookie and authorization headers to the destination server (#545)
2)We should remove our xhr headers before sending request (#552)