### PR TITLE
fetch barrier (part of #498)

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -37,7 +37,8 @@ class Hammerhead {
             evalIframeScript:   this.sandbox.iframe.EVAL_EXTERNAL_SCRIPT,
             xhrCompleted:       this.sandbox.xhr.XHR_COMPLETED_EVENT,
             xhrError:           this.sandbox.xhr.XHR_ERROR_EVENT,
-            xhrSend:            this.sandbox.xhr.XHR_SEND_EVENT
+            xhrSend:            this.sandbox.xhr.XHR_SEND_EVENT,
+            fetchSend:          this.sandbox.fetch.FETCH_REQUEST_SEND_EVENT
         };
 
         this.EventEmitter = EventEmitter;
@@ -111,6 +112,9 @@ class Hammerhead {
 
             case this.EVENTS.beforeFormSubmit:
                 return this.sandbox.node.element;
+
+            case this.EVENTS.fetchSend:
+                return this.sandbox.fetch;
 
             default:
                 return null;

--- a/src/client/sandbox/fetch-barrier.js
+++ b/src/client/sandbox/fetch-barrier.js
@@ -1,0 +1,110 @@
+import EventEmitter from '../utils/event-emitter';
+import nativeMethods from './native-methods';
+import Promise from 'pinkie';
+
+const REQUESTS_COLLECTION_DELAY              = 300;
+const ADDITIONAL_REQUESTS_COLLECTION_DELAY   = 100;
+const PAGE_INITIAL_REQUESTS_COLLECTION_DELAY = 50;
+const FETCH_REQUESTS_FINISHED_EVENT          = 'fetch-requests-finished';
+
+export default class FetchBarrier extends EventEmitter {
+    // NOTE: after moving to testcafe the 'fetchSandbox' parameter will be deleted
+    constructor (fetchSandbox) {
+        super();
+
+        this.BARRIER_TIMEOUT = 3000;
+
+        this.passed                    = false;
+        this.collectingRequestPromises = true;
+        this.requestPromises           = [];
+        this.watchdog                  = null;
+
+        this.fetchSandbox = fetchSandbox;
+
+        this._init();
+    }
+
+    _init () {
+        var onFetchRequestSend = e => this._onFetchRequestSend(e);
+
+        this.fetchSandbox.on(this.fetchSandbox.FETCH_REQUEST_SEND_EVENT, onFetchRequestSend);
+
+        this._unbindHandler = () => {
+            this.fetchSandbox.off(this.fetchSandbox.FETCH_REQUEST_SEND_EVENT, onFetchRequestSend);
+        };
+    }
+
+    // Copy from https://github.com/DevExpress/testcafe/blob/master/src/client/core/utils/delay.js
+    // Will be removed after move to testcafe
+    delay (ms) {
+        return new Promise(resolve => nativeMethods.setTimeout.call(window, resolve, ms));
+    }
+
+    // Copy from https://github.com/churkin/testcafe/blob/master/src/client/core/utils/array.js
+    removeItem (arr, item) {
+        var index = arr.indexOf(item);
+
+        if (index > -1)
+            arr.splice(index, 1);
+    }
+
+    _onFetchRequestSend (requestPromise) {
+        if (this.collectingRequestPromises) {
+            this.requestPromises.push(requestPromise);
+
+            var onFetchRequestCompleted = () => this._onFetchRequestCompleted(requestPromise);
+            var onFetchRequestError     = () => this._onFetchRequestError(requestPromise);
+
+            requestPromise.then(onFetchRequestCompleted);
+            requestPromise.catch(onFetchRequestError);
+        }
+
+    }
+
+    _onFetchRequestCompleted (requestPromise) {
+        // NOTE: let the last real XHR handler finish its job and try to obtain
+        // any additional requests if they were initiated by this handler
+        this.delay(ADDITIONAL_REQUESTS_COLLECTION_DELAY)
+            .then(() => this._onFetchRequestFinished(requestPromise));
+    }
+
+    _onFetchRequestError (requestPromise) {
+        this._onFetchRequestFinished(requestPromise);
+    }
+
+    _onFetchRequestFinished (requestPromise) {
+        if (this.requestPromises.indexOf(requestPromise) !== -1) {
+            this.removeItem(this.requestPromises, requestPromise);
+
+            if (!this.collectingRequestPromises && !this.requestPromises.length)
+                this.emit(FETCH_REQUESTS_FINISHED_EVENT);
+        }
+    }
+
+    wait (isPageLoad) {
+        var sandbox = this;
+
+        return new Promise(resolve => {
+            sandbox.delay(isPageLoad ? PAGE_INITIAL_REQUESTS_COLLECTION_DELAY : REQUESTS_COLLECTION_DELAY)
+                .then(() => {
+                    sandbox.collectingRequestPromises = false;
+
+                    var onRequestsFinished = () => {
+                        if (sandbox.watchdog)
+                            nativeMethods.clearTimeout.call(window, sandbox.watchdog);
+
+                        sandbox._unbindHandler();
+                        resolve();
+                    };
+
+                    if (sandbox.requestPromises.length) {
+                        sandbox.watchdog = nativeMethods.setTimeout.call(window, onRequestsFinished, sandbox.BARRIER_TIMEOUT);
+                        sandbox.on(FETCH_REQUESTS_FINISHED_EVENT, onRequestsFinished);
+                    }
+                    else
+                        onRequestsFinished();
+                });
+        });
+    }
+
+}

--- a/src/client/sandbox/fetch.js
+++ b/src/client/sandbox/fetch.js
@@ -7,6 +7,11 @@ import { isFetchHeaders, isFetchRequest } from '../utils/dom';
 import { SAME_ORIGIN_CHECK_FAILED_STATUS_CODE } from '../../request-pipeline/xhr/same-origin-policy';
 
 export default class FetchSandbox extends SandboxBase {
+    constructor () {
+        super();
+
+        this.FETCH_REQUEST_SEND_EVENT = 'hammerhead|event|fetch-request-send-event';
+    }
 
     static _processRequestInit (init) {
         var defaultRequest     = new nativeMethods.Request('');
@@ -121,6 +126,8 @@ export default class FetchSandbox extends SandboxBase {
                 FetchSandbox._processArguments(args);
 
                 var fetchPromise = nativeMethods.fetch.apply(this, args);
+
+                sandbox.emit(sandbox.FETCH_REQUEST_SEND_EVENT, fetchPromise);
 
                 FetchSandbox._processFetchPromise(fetchPromise);
 

--- a/src/client/sandbox/index.js
+++ b/src/client/sandbox/index.js
@@ -20,6 +20,7 @@ import StorageSandbox from './storages';
 import { isIE, isWebKit } from '../utils/browser';
 import { create as createSandboxBackup, get as getSandboxBackup } from './backup';
 import urlResolver from '../utils/url-resolver';
+import FetchBarrier from './fetch-barrier';
 
 export default class Sandbox extends SandboxBase {
     constructor () {
@@ -39,6 +40,7 @@ export default class Sandbox extends SandboxBase {
         this.storageSandbox      = new StorageSandbox(listeners, unloadSandbox, eventSimulator);
         this.xhr                 = new XhrSandbox();
         this.fetch               = new FetchSandbox();
+        this.fetchBarrier        = FetchBarrier;
         this.cookie              = new CookieSandbox();
         this.iframe              = new IframeSandbox(nodeMutation, this.cookie);
         this.shadowUI            = new ShadowUI(nodeMutation, messageSandbox, this.iframe);

--- a/test/client/.eslintrc
+++ b/test/client/.eslintrc
@@ -9,7 +9,8 @@
     "no-eval": 0,
     "no-implied-eval": 0,
     "max-nested-callbacks": 0,
-    "no-script-url": 0
+    "no-script-url": 0,
+    "no-loop-func": 0
   },
   "globals": {
     /* Utils */

--- a/test/client/fixtures/sandbox/fetch-barrier-test.js
+++ b/test/client/fixtures/sandbox/fetch-barrier-test.js
@@ -1,0 +1,223 @@
+var FetchBarrier  = hammerhead.sandbox.fetchBarrier;
+var fetchSandbox  = hammerhead.sandbox.fetch;
+var iframeSandbox = hammerhead.sandbox.iframe;
+var Promise       = hammerhead.Promise;
+var nativeMethods = hammerhead.sandbox.nativeMethods;
+
+QUnit.testStart(function () {
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+});
+
+QUnit.testDone(function () {
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+});
+
+if (window.fetch) {
+    $(document).ready(function () {
+        // Copy from https://github.com/DevExpress/testcafe/blob/master/src/client/core/utils/delay.js
+        // Will be removed after moving to the testcafe
+        function delay (ms) {
+            return new Promise(function (resolve) {
+                nativeMethods.setTimeout.call(window, resolve, ms);
+            });
+        }
+
+        asyncTest('waitPageInitialRequests', function () {
+            var completeReqCount       = 0;
+            var reqCount               = 4;
+            var barrierTimeoutExceeded = false;
+
+            expect(1);
+
+            var fetchBarrier = new FetchBarrier(fetchSandbox);
+
+            for (var i = 0; i < reqCount; i++) {
+                fetch('/xhr-test/200')
+                    .then(function (response) {
+                        return response.text();
+                    })
+                    .then(function () {
+                        completeReqCount++;
+                    });
+            }
+
+            // NOTE: ignore slow connection on the testing
+            // farm that leads to unstable tests appearing
+            delay(fetchBarrier.BARRIER_TIMEOUT)
+                .then(function () {
+                    barrierTimeoutExceeded = true;
+                });
+
+            fetchBarrier
+                .wait(true)
+                .then(function () {
+                    ok(completeReqCount === reqCount || barrierTimeoutExceeded);
+                    start();
+                });
+        });
+
+        asyncTest('barrier - Wait requests complete', function () {
+            var completeReqCount       = 0;
+            var reqCount               = 2;
+            var barrierTimeoutExceeded = false;
+
+            expect(1);
+
+            var fetchBarrier = new FetchBarrier(fetchSandbox);
+
+            for (var i = 0; i < reqCount; i++) {
+                fetch('/xhr-test/1000')
+                    .then(function (response) {
+                        return response.text();
+                    }).then(function () {
+                        completeReqCount++;
+                    });
+            }
+
+            // NOTE: ignore slow connection on the testing
+            // farm that leads to unstable tests appearing
+            delay(fetchBarrier.BARRIER_TIMEOUT)
+                .then(function () {
+                    barrierTimeoutExceeded = true;
+                });
+
+            fetchBarrier
+                .wait()
+                .then(function () {
+                    /*eslint-disable no-console*/
+                    console.log('completeReqCount - ' + completeReqCount);
+                    console.log('reqCount' + reqCount);
+                    /*eslint-enable no-console*/
+                    ok(completeReqCount === reqCount || barrierTimeoutExceeded);
+                    start();
+                });
+        });
+
+        asyncTest('timeout', function () {
+            expect(1);
+
+            var fetchBarrier   = new FetchBarrier(fetchSandbox);
+            var reqIsCompleted = false;
+
+            fetchBarrier.BARRIER_TIMEOUT = 0;
+
+            fetch('/xhr-test/8000')
+                .then(function (response) {
+                    return response.text();
+                })
+                .then(function () {
+                    reqIsCompleted = true;
+                });
+
+            fetchBarrier
+                .wait()
+                .then(function () {
+                    ok(!reqIsCompleted);
+                    start();
+                });
+        });
+
+        asyncTest('should not wait pending requests', function () {
+            var firstRequestCompleted  = false;
+            var secondRequestCompleted = false;
+
+            fetch('/xhr-test/3000')
+                .then(function (response) {
+                    return response.text();
+                })
+                .then(function () {
+                    firstRequestCompleted = true;
+                    start();
+                });
+
+            expect(2);
+
+            var fetchBarrier = new FetchBarrier(fetchSandbox);
+
+            window.setTimeout(function () {
+                fetchBarrier
+                    .wait()
+                    .then(function () {
+                        ok(!firstRequestCompleted);
+                        ok(secondRequestCompleted);
+                    });
+
+                fetch('/xhr-test/200')
+                    .then(function (response) {
+                        return response.text();
+                    })
+                    .then(function () {
+                        secondRequestCompleted = true;
+                    });
+            }, 100);
+        });
+
+        asyncTest('barrier - creating new iframe without src (B236650)', function () {
+            var $iframe           = null;
+            var windowErrorRaised = false;
+
+            window.onerror = function () {
+                windowErrorRaised = true;
+            };
+
+            var action = function (callback) {
+                if ($iframe)
+                    $iframe.remove();
+
+                window.setTimeout(function () {
+                    $iframe = $('<iframe id="test_unique_id_ydnvbfq2">').attr('src', 'about:blank').appendTo('body');
+                }, 0);
+
+                callback();
+            };
+
+            var fetchBarrier = new FetchBarrier(fetchSandbox);
+
+            action.call(window, function () {
+                fetchBarrier
+                    .wait()
+                    .then(function () {
+                        ok(!windowErrorRaised);
+                    });
+            });
+
+            window.setTimeout(function () {
+                expect(1);
+                $iframe.remove();
+                start();
+            }, 1000);
+        });
+
+        asyncTest('B237815 - Test runner - can\'t execute simple test', function () {
+            var $iframe        = null;
+            var callbackRaised = false;
+
+            var action = function (callback) {
+                $iframe = $('<iframe id="test_unique_id_kmgvu67">').appendTo('body');
+
+                window.setTimeout(function () {
+                    $iframe.remove();
+                }, 50);
+
+                callback();
+            };
+
+            var fetchBarrier = new FetchBarrier(fetchSandbox);
+
+            action.call(window, function () {
+                fetchBarrier
+                    .wait()
+                    .then(function () {
+                        callbackRaised = true;
+                    });
+            });
+
+            window.setTimeout(function () {
+                ok(callbackRaised);
+                start();
+            }, 2000);
+        });
+    });
+}
+


### PR DESCRIPTION
Pull request contains two part of code - for hammerhead and for testcafe.
Code for hammerhead  - event `FETCH_REQUEST_SEND_EVENT`.
Code for testcafe - `fetchBarrier` implementation and tests.

Review it in the single pull request.
After it I will close this pull request and create two separate pull request - one for hammerhead and another for testcafe.

@inikulin @churkin @AlexanderMoskovkin 