### PR TITLE
update publish workflow (close #588)

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -1,0 +1,18 @@
+{
+  "validations": {
+    "vulnerableDependencies": true,
+    "uncommittedChanges": true,
+    "untrackedFiles": true,
+    "sensitiveData": {
+      "ignore": [
+        "src/client/sandbox/backup.js",
+        "test/client/fixtures/sandbox/backup-test.js"
+      ]
+    },
+    "branch": "master",
+    "gitTag": true
+  },
+  "confirm": true,
+  "publishTag": "latest",
+  "prePublishScript": "gulp test-server"
+}

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -14,7 +14,6 @@ var uglify       = require('gulp-uglify');
 var gulpif       = require('gulp-if');
 var util         = require('gulp-util');
 var ll           = require('gulp-ll');
-var publish      = require('publish-please');
 var path         = require('path');
 
 ll
@@ -212,9 +211,3 @@ gulp.task('playground', ['build'], function () {
 });
 
 gulp.task('travis', [process.env.GULP_TASK || '']);
-
-
-// Publish
-gulp.task('publish', ['test-server'], function () {
-    return publish();
-});

--- a/package.json
+++ b/package.json
@@ -3,12 +3,16 @@
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
   "version": "8.3.1",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
-  "bugs": "https://github.com/DevExpress/testcafe-hammerhead/issues",
+  "bugs": {
+    "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"
+  },
   "license": "https://github.com/DevExpress/testcafe-hammerhead/blob/master/LICENSE",
-  "author": "Developer Express Inc.",
+  "author": {
+    "name": "Developer Express Inc."
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/DevExpress/testcafe-hammerhead.git"
+    "url": "git+https://github.com/DevExpress/testcafe-hammerhead.git"
   },
   "dependencies": {
     "babel-runtime": "^6.3.19",
@@ -58,7 +62,7 @@
     "gulp-util": "3.0.6",
     "gulp-webmake": "0.0.4",
     "multiline": "^1.0.2",
-    "publish-please": "^1.0.1",
+    "publish-please": "^2.0.0",
     "request": "~2.27.0",
     "self-signed-https": "^1.0.5",
     "tmp": "0.0.26"
@@ -71,6 +75,9 @@
     "lib"
   ],
   "scripts": {
-    "test": "gulp travis"
-  }
+    "test": "gulp travis",
+    "publish-please": "publish-please",
+    "prepublish": "publish-please guard"
+  },
+  "readme": "ERROR: No README data found!"
 }


### PR DESCRIPTION
For publish we will use command `npm run publish-please` instead of `gulp publish`.
@inikulin @churkin