### PR TITLE
Expose `isScriptProcessed` method, rename `wrapDomAcessors` to `processScript`. Fix line endings in script test. Bump version (closes #600)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "8.3.1",
+  "version": "9.0.0",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 import Proxy from './proxy';
 import Session from './session';
-import { processScript } from './processing/script';
+import { processScript, isScriptProcessed } from './processing/script';
 
 export default {
-    Proxy:            Proxy,
-    Session:          Session,
-    wrapDomAccessors: code => processScript(code, false)
+    Proxy,
+    Session,
+    processScript,
+    isScriptProcessed
 };

--- a/src/processing/script/index.js
+++ b/src/processing/script/index.js
@@ -107,12 +107,7 @@ function isArrayDataScript (ast) {
            ast.body[0].expression.type === Syntax.ArrayExpression;
 }
 
-
-export function isScriptProcessed (code) {
-    return PROCESSED_SCRIPT_RE.test(code);
-}
-
-export function applyChanges (script, changes, isObject) {
+function applyChanges (script, changes, isObject) {
     var indexOffset = isObject ? -1 : 0;
     var chunks      = [];
     var index       = 0;
@@ -138,6 +133,11 @@ export function applyChanges (script, changes, isObject) {
     chunks.push(script.substring(index));
 
     return chunks.join('');
+}
+
+
+export function isScriptProcessed (code) {
+    return PROCESSED_SCRIPT_RE.test(code);
 }
 
 export function processScript (src, withHeader) {

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -24,6 +24,10 @@ function trim (str) {
     return str.replace(/^\s+|\s+$/g, '');
 }
 
+function normalizeNewLine (str) {
+    return str.replace(/\r\n/g, '\n');
+}
+
 function normalizeCode (code) {
     return trim(code
         .replace(/(\r\n|\n|\r)/gm, ' ')
@@ -710,7 +714,7 @@ describe('Proxy', function () {
             request(proxy.openSession('http://127.0.0.1:2000/script', session), function (err, res, body) {
                 var expected = fs.readFileSync('test/server/data/script/expected.js').toString();
 
-                expect(body).eql(expected);
+                expect(normalizeNewLine(body)).eql(normalizeNewLine(expected));
                 done();
             });
         });


### PR DESCRIPTION
\cc @churkin @miherlosev 