### PR TITLE
FETCH_SEND_EVENT should expose the overriden fetch promise. Bump version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/client/sandbox/fetch.js
+++ b/src/client/sandbox/fetch.js
@@ -130,9 +130,8 @@ export default class FetchSandbox extends SandboxBase {
 
                 var fetchPromise = nativeMethods.fetch.apply(this, args);
 
-                sandbox.emit(sandbox.FETCH_REQUEST_SEND_EVENT, fetchPromise);
-
                 FetchSandbox._processFetchPromise(fetchPromise);
+                sandbox.emit(sandbox.FETCH_REQUEST_SEND_EVENT, fetchPromise);
 
                 return fetchPromise;
             };


### PR DESCRIPTION
It needs for https://github.com/DevExpress/testcafe/pull/548
@churkin @LavrovArtem 