### PR TITLE
fix Object.define in fetchSundbox. Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/client/sandbox/fetch.js
+++ b/src/client/sandbox/fetch.js
@@ -72,22 +72,18 @@ export default class FetchSandbox extends SandboxBase {
                     throw new TypeError();
 
                 Object.defineProperty(response, 'type', {
-                    get: function () {
-                        return FetchSandbox._getResponseType(response);
-                    },
-                    set: () => void 0
+                    get:          () => FetchSandbox._getResponseType(response),
+                    set:          () => void 0,
+                    configurable: true
                 });
 
                 var responseStatus = response.status === SAME_ORIGIN_CHECK_FAILED_STATUS_CODE ? 0 : response.status;
 
                 Object.defineProperty(response, 'status', {
-                    get: function () {
-                        return responseStatus;
-                    },
-                    set: () => void 0
+                    get:          () => responseStatus,
+                    set:          () => void 0,
+                    configurable: true
                 });
-
-                arguments[0] = response;
 
                 return originalThenHandler.apply(this, arguments);
             };


### PR DESCRIPTION
@churkin @LavrovArtem 
It needs for https://github.com/DevExpress/testcafe/pull/548

Description of the problem:
There are two chains for fetch promise. The first one - in the customer code, second - in the testcafe's request barrier. So, the overriding of the `fetchPromise.then`([see](https://github.com/DevExpress/testcafe-hammerhead/blob/master/src/client/sandbox/fetch.js#L70)) handler arguments is called two times. And then we perform `Object.defineProperty` the second time we getting a client error `TypeError: Cannot redefine property 'type'`.
Since `Object.defineProperty` the `configurable` property has `false` value by default ([see] (https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty))

