### PR TITLE
fix 'HH opens new window if the form target attribute points to a nonexistent window name' (close #247)

### DIFF
--- a/src/client/sandbox/index.js
+++ b/src/client/sandbox/index.js
@@ -20,12 +20,14 @@ import StorageSandbox from './storages';
 import { isIE, isWebKit } from '../utils/browser';
 import { create as createSandboxBackup, get as getSandboxBackup } from './backup';
 import urlResolver from '../utils/url-resolver';
+import { add as addWindowToStorage } from './windows-storage';
 
 export default class Sandbox extends SandboxBase {
     constructor () {
         super();
 
         createSandboxBackup(window, this);
+        addWindowToStorage(window);
 
         var listeners             = new Listeners();
         var nodeMutation          = new NodeMutation();

--- a/src/client/sandbox/windows-storage.js
+++ b/src/client/sandbox/windows-storage.js
@@ -1,0 +1,41 @@
+import { getTopSameDomainWindow } from '../utils/dom';
+
+const WINDOWS_STORAGE = 'hammerhead|windows-storage';
+
+function getStorage () {
+    var topSameDomainWindow = getTopSameDomainWindow(window);
+    var storage             = topSameDomainWindow[WINDOWS_STORAGE];
+
+    if (!storage) {
+        storage = [];
+        topSameDomainWindow[WINDOWS_STORAGE] = storage;
+    }
+
+    return storage;
+}
+
+export function add (wnd) {
+    var storage = getStorage();
+
+    if (storage.indexOf(wnd) === -1)
+        storage.push(wnd);
+}
+
+export function remove (wnd) {
+    var storage   = getStorage();
+    var index     = storage.indexOf(wnd);
+
+    if (index !== -1)
+        storage.splice(index, 1);
+}
+
+export function findByName (name) {
+    var storage = getStorage();
+
+    for (var i = 0; i < storage.length; i++) {
+        if (storage[i].name === name)
+            return storage[i];
+    }
+
+    return null;
+}

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -457,7 +457,12 @@ test('element.innerHTML', function () {
 test('anchor with target attribute', function () {
     var anchor   = document.createElement('a');
     var url      = 'http://url.com/';
+    var iframe   = document.createElement('iframe');
     var proxyUrl = urlUtils.getProxyUrl(url, null, null, null, 'i');
+
+    iframe.id   = 'test_unique_id_e16w9jnv5';
+    iframe.name = 'iframeName';
+    document.body.appendChild(iframe);
 
     anchor.setAttribute('target', 'iframeName');
 
@@ -471,12 +476,22 @@ test('anchor with target attribute', function () {
     strictEqual(nativeMethods.getAttribute.call(anchor, domProcessor.getStoredAttrName('href')), url);
     strictEqual(anchor.getAttribute('href'), url);
     strictEqual(urlUtils.parseProxyUrl(nativeHref).resourceType, 'i');
+
+    iframe.parentNode.removeChild(iframe);
+});
+
+test('case insensitive target="_blank"', function () {
+    var link = document.createElement('a');
+
+    link.setAttribute('target', '_Blank');
+    ok(!link.getAttribute('target'));
 });
 
 module('regression');
 
 test('change href after target attribute changed (GH-534)', function () {
-    var check = function (setTarget, clearTarget) {
+    var iframe = document.createElement('iframe');
+    var check  = function (setTarget, clearTarget) {
         var form = document.createElement('form');
         var link = document.createElement('a');
         var base = document.createElement('base');
@@ -514,23 +529,35 @@ test('change href after target attribute changed (GH-534)', function () {
         strictEqual(urlUtils.parseProxyUrl(area.href).resourceType, null);
     };
 
+    iframe.id   = 'test_unique_id_ispt7enuo';
+    iframe.name = 'test-window';
+    document.body.appendChild(iframe);
+
     check(function (el) {
-        el.setAttribute('target', 'fake-window');
+        el.setAttribute('target', 'test-window');
     }, function (el) {
         el.removeAttribute('target');
     });
 
     check(function (el) {
-        el.setAttribute('target', 'fake-window');
+        el.setAttribute('target', 'test-window');
     }, function (el) {
         el.setAttribute('target', '');
     });
 
     check(function (el) {
-        setProperty(el, 'target', 'fake-window');
+        setProperty(el, 'target', 'test-window');
     }, function (el) {
         setProperty(el, 'target', '');
     });
+
+    check(function (el) {
+        el.setAttribute('target', 'test-window');
+    }, function (el) {
+        el.setAttribute('target', '_Self');
+    });
+
+    iframe.parentNode.removeChild(iframe);
 });
 
 test('setting function to the link.href attribute value (T230764)', function () {

--- a/test/client/fixtures/sandbox/windows-storage-test.js
+++ b/test/client/fixtures/sandbox/windows-storage-test.js
@@ -1,0 +1,75 @@
+var iframeSandbox = hammerhead.sandbox.iframe;
+
+QUnit.testStart(function () {
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+});
+
+QUnit.testDone(function () {
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+});
+
+test('iframe.name', function () {
+    var iframe = document.createElement('iframe');
+    var form   = document.createElement('form');
+
+    iframe.id   = 'test_unique_id_eWRhpRV';
+    iframe.name = 'test';
+    document.body.appendChild(iframe);
+
+    form.setAttribute('target', 'non_existing_window_name');
+    strictEqual(form.getAttribute('target'), '_self');
+
+    form.setAttribute('target', 'test');
+    strictEqual(form.getAttribute('target'), 'test');
+
+    iframe.parentNode.removeChild(iframe);
+});
+
+test('window.name', function () {
+    var storedWindowName = window.name;
+    var form             = document.createElement('form');
+
+    window.name = 'test';
+    form.setAttribute('target', 'non_existing_window_name');
+    strictEqual(form.getAttribute('target'), '_self');
+
+    form.setAttribute('target', 'test');
+    strictEqual(form.getAttribute('target'), 'test');
+
+    window.name = storedWindowName;
+});
+
+test('keyword target', function () {
+    var iframe = document.createElement('iframe');
+    var form   = document.createElement('form');
+
+    iframe.id   = 'test_unique_id_6urumqy9s';
+    iframe.name = 'test';
+    document.body.appendChild(iframe);
+
+    form.setAttribute('target', '_top');
+    strictEqual(form.getAttribute('target'), '_top');
+
+    form.setAttribute('target', '_Parent');
+    strictEqual(form.getAttribute('target'), '_Parent');
+
+    iframe.parentNode.removeChild(iframe);
+});
+
+test('remove iframe from DOM', function () {
+    var iframe = document.createElement('iframe');
+    var form   = document.createElement('form');
+
+    iframe.id   = 'test_unique_id_ea366my0l';
+    iframe.name = 'test';
+    document.body.appendChild(iframe);
+
+    form.setAttribute('target', 'test');
+    strictEqual(form.getAttribute('target'), 'test');
+
+    iframe.parentNode.removeChild(iframe);
+
+    form.setAttribute('target', 'test');
+    strictEqual(form.getAttribute('target'), '_self');
+});


### PR DESCRIPTION
After discussion with @churkin we decide to implement the partial fix:
If `element.target` contains non-existing window name then we set to target `_self` value.
Now, we don't update existing element's url after changing set of the avalible window names.
Because it may cause perfomance problem - we need to update all `form.action` and `a.href` attribute values for all windows in the page.