### PR TITLE
fix linting error for node 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint": "2.x",
     "eslint-plugin-babel": "^3.2.0",
     "eslint-plugin-hammerhead": "^0.0.5",
-    "eslint-plugin-import": "^1.6.1",
+    "eslint-plugin-import": "1.10.0",
     "express": "3.2.5",
     "gulp": "^3.8.7",
     "gulp-babel": "^6.1.1",


### PR DESCRIPTION
see https://travis-ci.org/testcafe-build-bot/testcafe-hammerhead/jobs/142151311
@churkin @LavrovArtem 
The latest `eslint-plugin-import` version (1.10.1) doesn't support node `0.10`.
