### PR TITLE
Fix nativeMethods.performanceNow in IE9 (closes #670)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/client/sandbox/native-methods.js
+++ b/src/client/sandbox/native-methods.js
@@ -122,7 +122,8 @@ class NativeMethods {
             var nativePerformance    = win.performance;
             var nativePerformanceNow = win.performance.now || win.Performance.prototype.now;
 
-            this.performanceNow = (...args) => nativePerformanceNow.apply(nativePerformance, args);
+            if (nativePerformanceNow)
+                this.performanceNow = (...args) => nativePerformanceNow.apply(nativePerformance, args);
         }
 
         // Fetch

--- a/test/client/fixtures/sandbox/native-methods-test.js
+++ b/test/client/fixtures/sandbox/native-methods-test.js
@@ -1,0 +1,12 @@
+var nativeMethods = hammerhead.nativeMethods;
+
+test('performanceNow', function () {
+    if (!nativeMethods.performanceNow) {
+        expect(0);
+        return;
+    }
+
+    var now = nativeMethods.performanceNow();
+
+    ok(!isNaN(parseFloat(now)));
+});

--- a/test/client/fixtures/sandbox/native-methods-test.js
+++ b/test/client/fixtures/sandbox/native-methods-test.js
@@ -1,12 +1,9 @@
 var nativeMethods = hammerhead.nativeMethods;
 
-test('performanceNow', function () {
-    if (!nativeMethods.performanceNow) {
-        expect(0);
-        return;
-    }
+if (nativeMethods.performanceNow) {
+    test('performanceNow', function () {
+        var now = nativeMethods.performanceNow();
 
-    var now = nativeMethods.performanceNow();
-
-    ok(!isNaN(parseFloat(now)));
-});
+        ok(!isNaN(parseFloat(now)));
+    });
+}


### PR DESCRIPTION
/cc @churkin @miherlosev 