### PR TITLE
Get rid of unhandled rejection on `about:blank` requests. Fix stale `about:blank` requests for non-processable resources (fixes #796)

### DIFF
--- a/src/request-pipeline/context.js
+++ b/src/request-pipeline/context.js
@@ -2,7 +2,6 @@ import XHR_HEADERS from './xhr/headers';
 import Charset from '../processing/encoding/charset';
 import * as urlUtils from '../utils/url';
 import * as contentTypeUtils from '../utils/content-type';
-import { isSpecialPage } from '../utils/url';
 
 const REDIRECT_STATUS_CODES = [301, 302, 303, 307];
 const HTTP_DEFAUL_PORT      = '80';
@@ -110,7 +109,7 @@ export default class RequestPipelineContext {
         this.isXhr         = !!this.req.headers[XHR_HEADERS.requestMarker];
         this.isPage        = !this.isXhr && acceptHeader && contentTypeUtils.isPage(acceptHeader);
         this.isIframe      = this.dest.isIframe;
-        this.isSpecialPage = isSpecialPage(this.dest.url);
+        this.isSpecialPage = urlUtils.isSpecialPage(this.dest.url);
     }
 
     // API

--- a/src/request-pipeline/context.js
+++ b/src/request-pipeline/context.js
@@ -2,6 +2,7 @@ import XHR_HEADERS from './xhr/headers';
 import Charset from '../processing/encoding/charset';
 import * as urlUtils from '../utils/url';
 import * as contentTypeUtils from '../utils/content-type';
+import { isSpecialPage } from '../utils/url';
 
 const REDIRECT_STATUS_CODES = [301, 302, 303, 307];
 const HTTP_DEFAUL_PORT      = '80';
@@ -106,9 +107,10 @@ export default class RequestPipelineContext {
     _initRequestNatureInfo () {
         var acceptHeader = this.req.headers['accept'];
 
-        this.isXhr    = !!this.req.headers[XHR_HEADERS.requestMarker];
-        this.isPage   = !this.isXhr && acceptHeader && contentTypeUtils.isPage(acceptHeader);
-        this.isIframe = this.dest.isIframe;
+        this.isXhr         = !!this.req.headers[XHR_HEADERS.requestMarker];
+        this.isPage        = !this.isXhr && acceptHeader && contentTypeUtils.isPage(acceptHeader);
+        this.isIframe      = this.dest.isIframe;
+        this.isSpecialPage = isSpecialPage(this.dest.url);
     }
 
     // API
@@ -134,10 +136,11 @@ export default class RequestPipelineContext {
             this.dest = parsedReqUrl.dest;
 
             // Browsers add a leading slash to the pathname part of url (GH-608)
-            // For example: url http://www.trovigo.com?gd=GID12082014 will be converted
-            // to http://www.trovigo.com/?gd=GID12082014
-            this.dest.partAfterHost = this.dest.partAfterHost[0] === '/' ? this.dest.partAfterHost : '/' +
-                                                                                                     this.dest.partAfterHost;
+            // For example: url http://www.example.com?gd=GID12082014 will be converted
+            // to http://www.example.com/?gd=GID12082014
+            this.dest.partAfterHost = this.dest.partAfterHost[0] === '/' ?
+                                      this.dest.partAfterHost :
+                                      '/' + this.dest.partAfterHost;
 
             this.dest.domain = urlUtils.getDomain(this.dest);
 

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -1309,6 +1309,42 @@ describe('Proxy', function () {
             }
         });
 
+        it('Should not send destination request for special pages (GH-796)', function (done) {
+            var rejectionReason = null;
+
+            var options = {
+                url: proxy.openSession('about:blank', session),
+
+                headers: {
+                    accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*!/!*;q=0.8'
+                }
+            };
+
+            process.once('unhandledRejection', function (reason) {
+                rejectionReason = reason;
+            });
+
+            request(options, function () {
+                expect(rejectionReason).to.be.null;
+                done();
+            });
+        });
+
+        it("Should handle `about:blank` requests for resources that doesn't require processing (GH-796)", function (done) {
+            var options = {
+                url: proxy.openSession('about:blank', session),
+
+                headers: {
+                    accept: 'application/font'
+                }
+            };
+
+            request(options, function (err, res, body) {
+                expect(body).eql('');
+                done();
+            });
+        });
+
         describe('Should not change a reponse body if it is empty (GH-762)', function () {
             it('script', function (done) {
                 var options = {


### PR DESCRIPTION
\cc @miherlosev @churkin 