### PR TITLE
fixed blur and focus methods in focusBlurSandbox

### DIFF
--- a/src/client/sandbox/event/listeners.js
+++ b/src/client/sandbox/event/listeners.js
@@ -240,7 +240,17 @@ export default class Listeners extends EventEmitter {
     }
 
     initDocumentBodyListening (doc) {
-        this.initElementListening(doc.body, DOM_EVENTS);
+        var nativeAddEventListener = Listeners._getNativeAddEventListener(doc.body);
+
+        this.listeningCtx.addListeningElement(doc.body, DOM_EVENTS);
+
+        for (var i = 0; i < DOM_EVENTS.length; i++)
+            nativeAddEventListener.call(doc.body, DOM_EVENTS[i], this._createEventHandler(), true);
+
+        var overridedMethods = this._createDocumentBodyOverridedMethods(doc);
+
+        doc.body.addEventListener    = overridedMethods.addEventListener;
+        doc.body.removeEventListener = overridedMethods.removeEventListener;
     }
 
     restartElementListening (el) {

--- a/src/client/sandbox/event/listeners.js
+++ b/src/client/sandbox/event/listeners.js
@@ -240,12 +240,7 @@ export default class Listeners extends EventEmitter {
     }
 
     initDocumentBodyListening (doc) {
-        listeningCtx.addListeningElement(doc.body, DOM_EVENTS);
-
-        var overridedMethods = this._createDocumentBodyOverridedMethods(doc);
-
-        doc.body.addEventListener    = overridedMethods.addEventListener;
-        doc.body.removeEventListener = overridedMethods.removeEventListener;
+        this.initElementListening(doc.body, DOM_EVENTS);
     }
 
     restartElementListening (el) {

--- a/test/client/before-test.js
+++ b/test/client/before-test.js
@@ -137,4 +137,8 @@
     };
 
     QUnit.config.testTimeout = 30000;
+
+    document.addEventListener('DOMContentLoaded', function () {
+        hammerhead.sandbox.node.raiseBodyCreatedEvent();
+    });
 })();

--- a/test/client/fixtures/sandbox/event/focus-blur-change-test.js
+++ b/test/client/fixtures/sandbox/event/focus-blur-change-test.js
@@ -852,6 +852,65 @@ asyncTest('check that scrolling does not happen when focus is set (after mouse e
     }, false, true);
 });
 
+// NOTE: blur and focus events are raised for the body only in IE
+if (browserUtils.isIE && !browserUtils.isMSEdge) {
+    asyncTest('Blur event should be raised earlier than focus if el.focus() is called only programmatically', function () {
+        var eventStorage = [];
+
+        function addEventToStorage (e) {
+            eventStorage.push(e.type + ' ' + e.target.tagName.toLowerCase());
+        }
+
+        document.body.addEventListener('focus', addEventToStorage, true);
+        document.body.addEventListener('blur', addEventToStorage, true);
+
+        document.body.focus();
+
+        setTimeout(function () {
+            input1.focus();
+
+            setTimeout(function () {
+                equal(eventStorage.length, 2);
+                equal(eventStorage[0], 'blur body');
+                equal(eventStorage[1], 'focus input');
+
+                document.body.removeEventListener('focus', addEventToStorage);
+                document.body.removeEventListener('blur', addEventToStorage);
+
+                start();
+            }, 100);
+        }, 100);
+    });
+
+    asyncTest('Focus event should be raised for the body if el.blur() is called only programmatically', function () {
+        var eventStorage = [];
+
+        function addEventToStorage (e) {
+            eventStorage.push(e.type + ' ' + e.target.tagName.toLowerCase());
+        }
+
+        input1.focus();
+
+        setTimeout(function () {
+            document.body.addEventListener('focus', addEventToStorage, true);
+            document.body.addEventListener('blur', addEventToStorage, true);
+
+            input1.blur();
+
+            setTimeout(function () {
+                equal(eventStorage.length, 2);
+                equal(eventStorage[0], 'blur input');
+                equal(eventStorage[1], 'focus body');
+
+                document.body.removeEventListener('focus', addEventToStorage);
+                document.body.removeEventListener('blur', addEventToStorage);
+
+                start();
+            }, 100);
+        }, 100);
+    });
+}
+
 module('regression');
 
 test('querySelector must return active element even when browser is not focused (T285078)', function () {


### PR DESCRIPTION
\cc @churkin, @AlexanderMoskovkin, @miherlosev 

We faced with next two scenarios while investigating ASPx tests in IE. Suppose that, we have a page only with an input element and:
1. document body is focused. Then we call programmatically `input.focus()`
2. input element is focused. Then we call programmatically `input.blur()`

In the first case without hammerhead events raising in next order:
`[
	'blur body',
	'focus input'
]`
 With hammerhead 
`[
	'blur body',
	'focus input',
	'blur body'
]`
In the second case without hammerhead order is next: 
`[
	'blur input',
	'focus body'
]`
With hammerhead
`[
	'focus body'
	'blur input'
]`
