### PR TITLE
remove unnecessary convertHostToLowerCase call 

### DIFF
--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -134,8 +134,6 @@ export default class Proxy extends Router {
         session.proxy                 = this;
         this.openSessions[session.id] = session;
 
-        url = urlUtils.convertHostToLowerCase(url);
-
         return urlUtils.getProxyUrl(url, {
             proxyHostname: this.server1Info.hostname,
             proxyPort:     this.server1Info.port,

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -91,7 +91,7 @@ export function sameOriginCheck (location, checkedUrl, rejectForSubdomains) {
 }
 
 // NOTE: Convert the destination protocol and hostname to the lower case. (GH-1)
-export function convertHostToLowerCase (url) {
+function convertHostToLowerCase (url) {
     var parsedUrl             = parseUrl(url);
     var protocolHostSeparator = parsedUrl.protocol === 'about:' ? '' : '//';
 


### PR DESCRIPTION
`getProxyUrl` already contains `convertHostToLowerCase` call.
@churkin @LavrovArtem 