### PR TITLE
fix 'Script error for https://www.pixnet.net/' (close #778)

### DIFF
--- a/src/client/utils/url.js
+++ b/src/client/utils/url.js
@@ -15,6 +15,9 @@ export function getProxyUrl (url, opts) {
     // NOTE: Resolves relative URLs.
     url = destLocation.resolveUrl(url);
 
+    if (!sharedUrlUtils.isValidUrl(url))
+        return url;
+
     var proxyHostname = opts && opts.proxyHostname || location.hostname;
     var proxyPort     = opts && opts.proxyPort || location.port.toString();
     var sessionId     = opts && opts.sessionId || settings.get().sessionId;

--- a/src/processing/dom/index.js
+++ b/src/processing/dom/index.js
@@ -9,9 +9,7 @@ import styleProcessor from '../../processing/style';
 import * as urlUtils from '../../utils/url';
 import { XML_NAMESPACE } from './namespaces';
 
-const CDATA_REG_EX = /^(\s)*\/\/<!\[CDATA\[([\s\S]*)\/\/\]\]>(\s)*$/;
-// NOTE: Ignore '//:0/' url (http://www.myntra.com/).
-const EMPTY_URL_REG_EX                   = /^(\w+:)?\/\/\:0/;
+const CDATA_REG_EX                       = /^(\s)*\/\/<!\[CDATA\[([\s\S]*)\/\/\]\]>(\s)*$/;
 const HTML_COMMENT_POSTFIX_REG_EX        = /(\/\/[^\n]*|\n\s*)-->[^\n]*([\n\s]*)?$/;
 const HTML_COMMENT_PREFIX_REG_EX         = /^(\s)*<!--[^\n]*\n/;
 const HTML_COMMENT_SIMPLE_POSTFIX_REG_EX = /-->\s*$/;
@@ -423,8 +421,7 @@ export default class DomProcessor {
 
             // NOTE: Page resource URL with proxy URL.
             if ((resourceUrl || resourceUrl === '') && !processedOnServer) {
-                if ((urlUtils.isSupportedProtocol(resourceUrl) || isSpecialPage) &&
-                    !EMPTY_URL_REG_EX.test(resourceUrl)) {
+                if (urlUtils.isSupportedProtocol(resourceUrl) || isSpecialPage) {
                     var elTagName = this.adapter.getTagName(el);
                     var isIframe  = elTagName === 'iframe';
                     var isScript  = elTagName === 'script';

--- a/src/processing/resources/index.js
+++ b/src/processing/resources/index.js
@@ -21,6 +21,9 @@ function getResourceUrlReplacer (ctx) {
 
         resolvedUrl = urlUtil.ensureTrailingSlash(resourceUrl, resolvedUrl);
 
+        if (!urlUtil.isValidUrl(resolvedUrl))
+            return resolvedUrl;
+
         return ctx.toProxyUrl(resolvedUrl, false, resourceType, charsetStr);
     };
 }

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -309,3 +309,18 @@ export function isRelativeUrl (url) {
 
     return !parsedUrl.host;
 }
+
+function isValidPort (port) {
+    var parsedPort = parseInt(port, 10);
+
+    return parsedPort > 0 && parsedPort <= 65535;
+}
+
+export function isValidUrl (url) {
+    var parsedUrl = parseUrl(url);
+
+    if (!parsedUrl.hostname || parsedUrl.port && !isValidPort(parsedUrl.port))
+        return false;
+
+    return true;
+}

--- a/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
@@ -340,3 +340,17 @@ test('script.innerHtml must be cleaned up (T226885)', function () {
     notEqual(script.innerHTML.replace(/^\s*|\s*$/g, ''), code);
     strictEqual(eval(processScript('script.innerHTML')).replace(/^\s*|\s*$/g, ''), code);
 });
+
+test('should not create proxy url for invalid url (GH-778)', function () {
+    var link       = document.createElement('a');
+    var nativeLink = nativeMethods.createElement.call(document, 'a');
+
+    var testCases = ['//:0', '//:0/', 'http://test:0', 'http://test:123456789'];
+
+    for (var i = 0; i < testCases.length; i++) {
+        var linkVal       = link.setAttribute('href', testCases[i]);
+        var nativeLinkVal = nativeLink.setAttribute('href', testCases[i]);
+
+        strictEqual(linkVal, nativeLinkVal);
+    }
+});

--- a/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
@@ -345,9 +345,30 @@ test('should not create proxy url for invalid url (GH-778)', function () {
     var link       = document.createElement('a');
     var nativeLink = nativeMethods.createElement.call(document, 'a');
 
-    var testCases = ['//:0', '//:0/', 'http://test:0', 'http://test:123456789'];
+    var testCases = [
+        {
+            value:     '//:0',
+            skipForIE: false
+        },
+        {
+            value:     '//:0/',
+            skipForIE: false
+        },
+        {
+            value:     'http://test:0',
+            skipForIE: false
+        },
+        {
+            value:     'http://test:123456789',
+            skipForIE: true
+        }
+    ];
 
     for (var i = 0; i < testCases.length; i++) {
+        // NOTE: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/9513048/
+        if (browserUtils.isIE && testCases[i].skipForIE)
+            continue;
+
         var linkVal       = link.setAttribute('href', testCases[i]);
         var nativeLinkVal = nativeLink.setAttribute('href', testCases[i]);
 

--- a/test/server/data/page/expected.html
+++ b/test/server/data/page/expected.html
@@ -126,4 +126,8 @@ __set$(window,"location",'test'); (function(){return __set$Loc(location,'test')|
     <use xlink:href="http://127.0.0.1:1836/sessionId/http://domain.com/test.svg#rect" xlink:href-hammerhead-stored-value="http://domain.com/test.svg#rect"></use>
 </svg>
 <div xlink:href="http://domain.com/test.svg#rect"></div>
+<a id="wrong-url-1" href="http://:0" href-hammerhead-stored-value="//:0"></a>
+<a id="wrong-url-2" href="http://:0/" href-hammerhead-stored-value="//:0/"></a>
+<a id="wrong-url-3" href="http://test:0" href-hammerhead-stored-value="http://test:0"></a>
+<a id="wrong-url-4" href="http://test:123456789" href-hammerhead-stored-value="http://test:123456789"></a>
 </body></html>

--- a/test/server/data/page/src.html
+++ b/test/server/data/page/src.html
@@ -100,5 +100,9 @@
     <use xlink:href="http://domain.com/test.svg#rect"></use>
 </svg>
 <div xlink:href="http://domain.com/test.svg#rect"></div>
+<a id="wrong-url-1" href="//:0"></a>
+<a id="wrong-url-2" href="//:0/"></a>
+<a id="wrong-url-3" href="http://test:0"></a>
+<a id="wrong-url-4" href="http://test:123456789"></a>
 </body>
 </html>

--- a/test/server/dom-processor-test.js
+++ b/test/server/dom-processor-test.js
@@ -18,7 +18,10 @@ function process (html, isIframe) {
     var root             = parser.parse(html);
     var testDomProcessor = new DomProcessor(new DomAdapter(isIframe, testCrossDomainPort));
     var urlReplacer      = function (url, resourceType) {
-        url = url.indexOf('/') === 0 ? 'http://example.com' + url : url;
+        if (url.indexOf('//') === 0)
+            url = 'http:' + url;
+        else if (url.indexOf('/') === 0)
+            url = 'http://example.com' + url;
 
         return urlUtils.getProxyUrl(url, {
             proxyHostname: 'localhost',
@@ -85,24 +88,6 @@ describe('DOM processor', function () {
 
         expect(domAdapter.getAttr(img, 'src')).eql('about:blank');
         expect(domAdapter.getAttr(img, domProcessor.getStoredAttrName('src'))).eql('about:blank');
-    });
-
-    it('Should process malformed <img> src', function () {
-        var cases = [
-            { html: '<img src="//:0/">', expectedSrc: '//:0/' },
-            { html: '<img src="//:0">', expectedSrc: '//:0' },
-            { html: '<img src="http://:0/">', expectedSrc: 'http://:0/' },
-            { html: '<img src="https://:0">', expectedSrc: 'https://:0' }
-        ];
-
-        cases.forEach(function (testCase) {
-            var root = process(testCase.html);
-
-            var img = parse5Utils.findElementsByTagNames(root, 'img').img[0];
-
-            expect(domAdapter.getAttr(img, 'src')).eql(testCase.expectedSrc);
-            expect(domAdapter.getAttr(img, domProcessor.getStoredAttrName('src'))).to.be.null;
-        });
     });
 
     it.skip('Should process <iframe> with src', function () {


### PR DESCRIPTION
@churkin @LavrovArtem @VasilyStrelyaev 
The problem occurred due url '//:0'.
We already have check for the same case - https://github.com/DevExpress/testcafe-hammerhead/blob/master/src/processing/dom/index.js#L14.

Fix : don't create proxy url for url without host or for url with host and wrong port value.