### PR TITLE
`preventScrolling` argument has been added to FocusBlurSandbox.focus() method (closes #886)

### DIFF
--- a/src/client/sandbox/event/focus-blur.js
+++ b/src/client/sandbox/event/focus-blur.js
@@ -198,7 +198,7 @@ export default class FocusBlurSandbox extends SandboxBase {
             callback();
     }
 
-    focus (el, callback, silent, forMouseEvent, isNativeFocus) {
+    focus (el, callback, silent, forMouseEvent, isNativeFocus, preventScrolling) {
         if (this.shouldDisableOuterFocusHandlers && !domUtils.isShadowUIElement(el))
             return null;
 
@@ -248,7 +248,7 @@ export default class FocusBlurSandbox extends SandboxBase {
                 else
                     this._callFocusCallback(callback, el);
 
-            }, withoutHandlers || silent, isAsync, forMouseEvent);
+            }, withoutHandlers || silent, isAsync, forMouseEvent, preventScrolling);
         };
 
         if (isNativeFocus && browserUtils.isIE) {

--- a/test/client/fixtures/sandbox/event/focus-blur-change-test.js
+++ b/test/client/fixtures/sandbox/event/focus-blur-change-test.js
@@ -852,6 +852,33 @@ asyncTest('check that scrolling does not happen when focus is set (after mouse e
     }, false, true);
 });
 
+asyncTest("focus() must not scroll to the element if 'preventScrolling' argument is true", function () {
+    var div = document.createElement('input');
+
+    $(div)
+        .css({
+            backgroundColor: 'grey',
+            width:           '500px',
+            height:          '500px',
+            top:             '2500px',
+            position:        'absolute'
+        })
+        .attr('tabIndex', 1);
+
+    document.body.appendChild(div);
+
+    var oldWindowScroll = styleUtil.getElementScroll(window);
+
+    focusBlur.focus(div, function () {
+        var currentWindowScroll = styleUtil.getElementScroll(window);
+
+        deepEqual(currentWindowScroll, oldWindowScroll);
+
+        document.body.removeChild(div);
+        start();
+    }, false, true, false, true);
+});
+
 module('regression');
 
 test('querySelector must return active element even when browser is not focused (T285078)', function () {


### PR DESCRIPTION
\cc @churkin, @AlexanderMoskovkin, @miherlosev 