### PR TITLE
querySelector behavior fixed (closes #922)

### DIFF
--- a/src/client/sandbox/node/index.js
+++ b/src/client/sandbox/node/index.js
@@ -9,7 +9,7 @@ import * as domUtils from '../../utils/dom';
 import getNativeQuerySelectorAll from '../../utils/get-native-query-selector-all';
 
 const ATTRIBUTE_SELECTOR_REG_EX          = /\[([\w-]+)(\^?=.+?)]/g;
-const ATTRIBUTE_OPERATOR_WITH_HASH_VALUE = /^\W+#/;
+const ATTRIBUTE_OPERATOR_WITH_HASH_VALUE = /^\W+\s*#/;
 
 export default class NodeSandbox extends SandboxBase {
     constructor (nodeMutation, iframeSandbox, eventSandbox, uploadSandbox, shadowUI) {

--- a/src/client/sandbox/node/index.js
+++ b/src/client/sandbox/node/index.js
@@ -8,7 +8,8 @@ import domProcessor from '../../dom-processor';
 import * as domUtils from '../../utils/dom';
 import getNativeQuerySelectorAll from '../../utils/get-native-query-selector-all';
 
-const ATTRIBUTE_SELECTOR_REG_EX = /\[([\w-]+)(\^?=.+?)]/g;
+const ATTRIBUTE_SELECTOR_REG_EX          = /\[([\w-]+)(\^?=.+?)]/g;
+const ATTRIBUTE_OPERATOR_WITH_HASH_VALUE = /^\W+#/;
 
 export default class NodeSandbox extends SandboxBase {
     constructor (nodeMutation, iframeSandbox, eventSandbox, uploadSandbox, shadowUI) {
@@ -104,7 +105,7 @@ export default class NodeSandbox extends SandboxBase {
             return selector;
 
         return selector.replace(ATTRIBUTE_SELECTOR_REG_EX, (str, name, operatorWithValue) => {
-            if (domProcessor.URL_ATTRS.indexOf(name) !== -1) {
+            if (domProcessor.URL_ATTRS.indexOf(name) !== -1 && !ATTRIBUTE_OPERATOR_WITH_HASH_VALUE.test(operatorWithValue)) {
                 name = domProcessor.getStoredAttrName(name);
 
                 return '[' + name + operatorWithValue + ']';

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -551,10 +551,12 @@ test('an iframe should not contain self-removing scripts after document.close (G
 test('querySelector should return an element if a selector contains the href attribute with hash as a value (GH-922)', function () {
     var testDiv = document.createElement('div');
 
-    testDiv.innerHTML = '<a href="#/"> Hash link </a>';
+    testDiv.innerHTML = '<a href="  #/"> Hash link </a>';
     document.body.appendChild(testDiv);
 
-    var element = document.querySelector('[href="#/"]');
+    ok(testDiv['hammerhead|element-processed']);
+
+    var element = document.querySelector('[href="  #/"]');
 
     ok(element);
 

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -548,7 +548,7 @@ test('an iframe should not contain self-removing scripts after document.close (G
     strictEqual(nativeMethods.querySelectorAll.call(document, '.' + SHADOW_UI_CLASSNAME.selfRemovingScript).length, 0);
 });
 
-test('querySelector should return element if selector contains href attribute with hash as value (GH-922)', function () {
+test('querySelector should return an element if a selector contains the href attribute with hash as a value (GH-922)', function () {
     var testDiv = document.createElement('div');
 
     testDiv.innerHTML = '<a href="#/"> Hash link </a>';

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -547,3 +547,16 @@ test('an iframe should not contain self-removing scripts after document.close (G
 
     strictEqual(nativeMethods.querySelectorAll.call(document, '.' + SHADOW_UI_CLASSNAME.selfRemovingScript).length, 0);
 });
+
+test('querySelector should return element if selector contains href attribute with hash as value (GH-922)', function () {
+    var testDiv = document.createElement('div');
+
+    testDiv.innerHTML = '<a href="#/"> Hash link </a>';
+    document.body.appendChild(testDiv);
+
+    var element = document.querySelector('[href="#/"]');
+
+    ok(element);
+
+    document.body.removeChild(testDiv);
+});


### PR DESCRIPTION
\cc @churkin, @AlexanderMoskovkin, @VasilyStrelyaev 