### PR TITLE
Event simulator must pass 'key' and 'keyIdentifier' event options for "key" methods

### DIFF
--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -155,9 +155,11 @@ export default class EventSimulator {
         var opts = options || {};
 
         return extend(EventSimulator._getUIEventArgs(type, options), {
-            keyCode:  opts.keyCode || 0,
-            charCode: opts.charCode || 0,
-            which:    type === 'press' ? opts.charCode : opts.keyCode
+            key:           opts.key || '',
+            keyCode:       opts.keyCode || 0,
+            keyIdentifier: opts.keyIdentifier || '',
+            charCode:      opts.charCode || 0,
+            which:         type === 'press' ? opts.charCode : opts.keyCode
         });
     }
 
@@ -216,8 +218,10 @@ export default class EventSimulator {
             if (userOptions &&
                 (userOptions.keyCode !== void 0 || userOptions.charCode !== void 0)) {
                 opts = extend(opts, {
-                    keyCode:  userOptions.keyCode || 0,
-                    charCode: userOptions.charCode || 0
+                    key:           userOptions.key || '',
+                    keyCode:       userOptions.keyCode || 0,
+                    keyIdentifier: userOptions.keyIdentifier || '',
+                    charCode:      userOptions.charCode || 0
                 });
             }
 
@@ -343,6 +347,8 @@ export default class EventSimulator {
                 shiftKey:         args.shiftKey,
                 metaKey:          args.metaKey,
                 keyCode:          args.keyCode,
+                key:              args.key,
+                keyIdentifier:    args.keyIdentifier,
                 charCode:         args.charCode,
                 which:            args.which
             });

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -360,8 +360,8 @@ export default class EventSimulator {
         }
 
         if (ev) {
-            // NOTE: the window.event.keyCode, window.event.charCode and window.event.which
-            // properties are not assigned after KeyboardEvent is created
+            // NOTE: the window.event.keyCode, window.event.charCode, window.event.which and
+            // window.event.key properties are not assigned after KeyboardEvent is created
             Object.defineProperty(ev, 'keyCode', {
                 get: () => args.keyCode
             });
@@ -372,6 +372,10 @@ export default class EventSimulator {
 
             Object.defineProperty(ev, 'which', {
                 get: () => args.which
+            });
+
+            Object.defineProperty(ev, 'key', {
+                get: () => args.key
             });
 
             var prevented   = false;

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -272,6 +272,27 @@ if (eventUtils.hasPointerEvents) {
     });
 }
 
+
+asyncTest("keyboard methods should pass 'key' and 'keyIdentifier' event options", function () {
+    var eventOptions = browserUtils.isSafari || browserUtils.isAndroid ?
+                       { keyCode: 13, keyIdentifier: 'Enter' } : { keyCode: 13, key: 'Enter' };
+
+    var checkEvent = function (event) {
+        equal(browserUtils.isSafari || browserUtils.isAndroid ? event.keyIdentifier : event.key, 'Enter');
+    };
+
+    domElement.addEventListener('keydown', checkEvent);
+    domElement.addEventListener('keypress', checkEvent);
+    domElement.addEventListener('keyup', checkEvent);
+
+    eventSimulator.keydown(domElement, eventOptions);
+    eventSimulator.keypress(domElement, eventOptions);
+    eventSimulator.keyup(domElement, eventOptions);
+
+    window.setTimeout(start, 50);
+});
+
+
 module('regression');
 
 if (browserUtils.isIE) {


### PR DESCRIPTION
\cc @miherlosev, @AlexanderMoskovkin, @MarinaRukavitsyna 