### PR TITLE
Fixed options for key events in event simulator, updated chrome version for OS X

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -93,8 +93,7 @@ var CLIENT_TESTS_BROWSERS = [
     },
     {
         browserName: 'chrome',
-        platform:    'OS X 10.11',
-        version:     '52.0'
+        platform:    'OS X 10.11'
     },
     {
         browserName: 'firefox',

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -152,15 +152,19 @@ export default class EventSimulator {
     }
 
     static _getKeyEventArgs (type, options) {
-        var opts = options || {};
+        var keyOptions = {
+            keyCode:  options.keyCode || 0,
+            charCode: options.charCode || 0,
+            which:    type === 'press' ? options.charCode : options.keyCode
+        };
 
-        return extend(EventSimulator._getUIEventArgs(type, options), {
-            key:           opts.key || void 0,
-            keyCode:       opts.keyCode || 0,
-            keyIdentifier: opts.keyIdentifier || void 0,
-            charCode:      opts.charCode || 0,
-            which:         type === 'press' ? opts.charCode : opts.keyCode
-        });
+        if ('keyIdentifier' in options)
+            keyOptions.keyIdentifier = options.keyIdentifier;
+
+        if ('key' in options)
+            keyOptions.key = options.key;
+
+        return extend(EventSimulator._getUIEventArgs(type, options), keyOptions);
     }
 
     static _getModifiersAsString (args) {
@@ -218,11 +222,16 @@ export default class EventSimulator {
             if (userOptions &&
                 (userOptions.keyCode !== void 0 || userOptions.charCode !== void 0)) {
                 opts = extend(opts, {
-                    key:           userOptions.key || void 0,
-                    keyCode:       userOptions.keyCode || 0,
-                    keyIdentifier: userOptions.keyIdentifier || void 0,
-                    charCode:      userOptions.charCode || 0
+                    key:      userOptions.key || void 0,
+                    keyCode:  userOptions.keyCode || 0,
+                    charCode: userOptions.charCode || 0
                 });
+
+                if ('keyIdentifier' in userOptions)
+                    opts.keyIdentifier = userOptions.keyIdentifier;
+
+                if ('key' in userOptions)
+                    opts.key = userOptions.key;
             }
 
             args = EventSimulator._getKeyEventArgs(event, opts);
@@ -335,7 +344,7 @@ export default class EventSimulator {
         var browserWithNewEventsStyle = !browserUtils.isIE || browserUtils.version > 11;
 
         if (browserWithNewEventsStyle && nativeMethods.WindowKeyboardEvent) {
-            ev = new nativeMethods.WindowKeyboardEvent(args.type, {
+            var eventArgs = {
                 bubbles:          args.canBubble,
                 cancelable:       args.cancelable,
                 cancelBubble:     false,
@@ -347,11 +356,17 @@ export default class EventSimulator {
                 shiftKey:         args.shiftKey,
                 metaKey:          args.metaKey,
                 keyCode:          args.keyCode,
-                key:              args.key,
-                keyIdentifier:    args.keyIdentifier,
                 charCode:         args.charCode,
                 which:            args.which
-            });
+            };
+
+            if ('keyIdentifier' in args)
+                eventArgs.keyIdentifier = args.keyIdentifier;
+
+            if ('key' in args)
+                eventArgs.key = args.key;
+
+            ev = new nativeMethods.WindowKeyboardEvent(args.type, eventArgs);
         }
         else if (nativeMethods.documentCreateEvent) {
             ev = nativeMethods.documentCreateEvent.call(document, 'KeyboardEvent');
@@ -374,9 +389,17 @@ export default class EventSimulator {
                 get: () => args.which
             });
 
-            Object.defineProperty(ev, 'key', {
-                get: () => args.key
-            });
+            if ('key' in args) {
+                Object.defineProperty(ev, 'key', {
+                    get: () => args.key
+                });
+            }
+
+            if ('keyIdentifier' in args) {
+                Object.defineProperty(ev, 'keyIdentifier', {
+                    get: () => args.keyIdentifier
+                });
+            }
 
             var prevented   = false;
             var returnValue = true;

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -378,26 +378,36 @@ export default class EventSimulator {
             // NOTE: the window.event.keyCode, window.event.charCode, window.event.which and
             // window.event.key properties are not assigned after KeyboardEvent is created
             Object.defineProperty(ev, 'keyCode', {
-                get: () => args.keyCode
+                configurable: true,
+                enumerable:   true,
+                get:          () => args.keyCode
             });
 
             Object.defineProperty(ev, 'charCode', {
-                get: () => args.charCode
+                configurable: true,
+                enumerable:   true,
+                get:          () => args.charCode
             });
 
             Object.defineProperty(ev, 'which', {
-                get: () => args.which
+                configurable: true,
+                enumerable:   true,
+                get:          () => args.which
             });
 
             if ('key' in args) {
                 Object.defineProperty(ev, 'key', {
-                    get: () => args.key
+                    configurable: true,
+                    enumerable:   true,
+                    get:          () => args.key
                 });
             }
 
             if ('keyIdentifier' in args) {
                 Object.defineProperty(ev, 'keyIdentifier', {
-                    get: () => args.keyIdentifier
+                    configurable: true,
+                    enumerable:   true,
+                    get:          () => args.keyIdentifier
                 });
             }
 

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -272,26 +272,48 @@ if (eventUtils.hasPointerEvents) {
     });
 }
 
+if (!browserUtils.isSafari && !browserUtils.isAndroid) {
+    asyncTest("keyboard methods should pass 'key' event option", function () {
+        var eventOptions = { keyCode: 13, key: 'Enter' };
 
-asyncTest("keyboard methods should pass 'key' and 'keyIdentifier' event options", function () {
-    var eventOptions = browserUtils.isSafari || browserUtils.isAndroid ?
-                       { keyCode: 13, keyIdentifier: 'Enter' } : { keyCode: 13, key: 'Enter' };
+        var checkEvent = function (event) {
+            strictEqual(event.key, 'Enter');
+            notOk('keyIdentifier' in event);
+        };
 
-    var checkEvent = function (event) {
-        equal(browserUtils.isSafari || browserUtils.isAndroid ? event.keyIdentifier : event.key, 'Enter');
-    };
+        domElement.addEventListener('keydown', checkEvent);
+        domElement.addEventListener('keypress', checkEvent);
+        domElement.addEventListener('keyup', checkEvent);
 
-    domElement.addEventListener('keydown', checkEvent);
-    domElement.addEventListener('keypress', checkEvent);
-    domElement.addEventListener('keyup', checkEvent);
+        eventSimulator.keydown(domElement, eventOptions);
+        eventSimulator.keypress(domElement, eventOptions);
+        eventSimulator.keyup(domElement, eventOptions);
 
-    eventSimulator.keydown(domElement, eventOptions);
-    eventSimulator.keypress(domElement, eventOptions);
-    eventSimulator.keyup(domElement, eventOptions);
+        window.setTimeout(start, 50);
+    });
+}
+else {
+    asyncTest("keyboard methods should pass 'keyIdentifier' event option", function () {
+        var eventOptions = { keyCode: 13, keyIdentifier: 'Enter' };
 
-    window.setTimeout(start, 50);
-});
+        var checkEvent = function (event) {
+            strictEqual(event.keyIdentifier, event.type === 'keypress' ? '' : 'Enter');
 
+            if (!browserUtils.isAndroid)
+                notOk('key' in event);
+        };
+
+        domElement.addEventListener('keydown', checkEvent);
+        domElement.addEventListener('keypress', checkEvent);
+        domElement.addEventListener('keyup', checkEvent);
+
+        eventSimulator.keydown(domElement, eventOptions);
+        eventSimulator.keypress(domElement, { keyCode: 13, keyIdentifier: '' });
+        eventSimulator.keyup(domElement, eventOptions);
+
+        window.setTimeout(start, 50);
+    });
+}
 
 module('regression');
 


### PR DESCRIPTION
\cc @AlexanderMoskovkin, @churkin