### PR TITLE
'setSelectionRange' method fixed (closes #1025)

### DIFF
--- a/src/client/sandbox/event/selection.js
+++ b/src/client/sandbox/event/selection.js
@@ -104,7 +104,8 @@ export default class Selection {
     }
 
     static _needChangeInputType (el) {
-        return domUtils.isInputElement(el) && browserUtils.isWebKit && /^(number|email)$/.test(el.type);
+        return (browserUtils.isWebKit || browserUtils.isFirefox && browserUtils.version > 50)
+               && domUtils.isInputElement(el) && /^(number|email)$/.test(el.type);
     }
 
     setSelection (el, start, end, direction) {


### PR DESCRIPTION
\cc @churkin, @AlexanderMoskovkin
I think, there is no need for regression test here, cause it was placed in the testcafe tests, when we faced with it first time - [B254340 ](https://github.com/DevExpress/testcafe/blob/378c6c71ac0df8fd9eae8af21040b2e7f1ad0571/test/client/fixtures/automation/regression-test.js#L594). It's green, cause Sauce Labs doesn't install FF 51yet.