### PR TITLE
'setSelectionRange' method fixed (closes #1025)

### DIFF
--- a/src/processing/dom/internal-properties.js
+++ b/src/processing/dom/internal-properties.js
@@ -9,5 +9,6 @@ export default {
     whichPropertyWrapper:   'hammerhead|which-property-wrapper',
     documentCharset:        'hammerhead|document-charset',
     iframeNativeMethods:    'hammerhead|iframe-native-methods',
-    hammerheadPropertyName: '%hammerhead%'
+    hammerheadPropertyName: '%hammerhead%',
+    selectionProperty:      'hammerhead|selection-property'
 };

--- a/test/client/fixtures/sandbox/selection-test.js
+++ b/test/client/fixtures/sandbox/selection-test.js
@@ -6,7 +6,9 @@ var isIE            = browserUtils.isIE;
 var isMobileBrowser = browserUtils.isIOS || browserUtils.isAndroid;
 
 var createTestInput = function () {
-    var input = $('<input type="email">').appendTo(document.body)[0];
+    document.body.innerHTML = '<input type="email">';
+
+    var input = document.querySelector('input');
 
     input.value = inputTestValue;
 
@@ -26,11 +28,11 @@ test('Set and get selection on input with "email" type', function () {
 
     var selection = selectionSandbox.getSelection(input);
 
-    equal(selection.start, testSelection.start);
-    equal(selection.end, testSelection.end);
+    strictEqual(selection.start, testSelection.start);
+    strictEqual(selection.end, testSelection.end);
 
     if (!isIE)
-        equal(selection.direction, testSelection.direction);
+        strictEqual(selection.direction, testSelection.direction);
 
     document.body.removeChild(input);
 });
@@ -39,13 +41,13 @@ test('Get selection on input with "email" type', function () {
     var input     = createTestInput();
     var selection = selectionSandbox.getSelection(input);
 
-    equal(selection.start, browserUtils.isFirefox && browserUtils.version < 51 || isIE ? 0 : inputTestValue.length);
-    equal(selection.end, browserUtils.isFirefox && browserUtils.version < 51 || isIE ? 0 : inputTestValue.length);
+    strictEqual(selection.start, browserUtils.isFirefox && browserUtils.version < 51 || isIE ? 0 : inputTestValue.length);
+    strictEqual(selection.end, browserUtils.isFirefox && browserUtils.version < 51 || isIE ? 0 : inputTestValue.length);
 
     if (isMobileBrowser || browserUtils.isSafari || browserUtils.isChrome && browserUtils.isMacPlatform)
-        equal(selection.direction, 'none');
+        strictEqual(selection.direction, 'none');
     else if (!isIE)
-        equal(selection.direction, 'forward');
+        strictEqual(selection.direction, 'forward');
 
     document.body.removeChild(input);
 });

--- a/test/client/fixtures/sandbox/selection-test.js
+++ b/test/client/fixtures/sandbox/selection-test.js
@@ -1,26 +1,51 @@
 var selectionSandbox = hammerhead.eventSandbox.selection;
 var browserUtils     = hammerhead.utils.browser;
 
-var inputTestValue = 'test@host.net';
-var isIE           = browserUtils.isIE;
+var inputTestValue  = 'test@host.net';
+var isIE            = browserUtils.isIE;
+var isMobileBrowser = browserUtils.isIOS || browserUtils.isAndroid;
 
-test('Set and get selection on input with "email" type', function () {
-    var input = document.createElement('input');
+var createTestInput = function () {
+    var input = $('<input type="email">').appendTo(document.body)[0];
 
-    input.type  = 'email';
     input.value = inputTestValue;
 
-    document.body.appendChild(input);
+    return input;
+};
 
-    input.setSelectionRange(0, inputTestValue.length, 'backward');
+test('Set and get selection on input with "email" type', function () {
+    var input = createTestInput();
+
+    var testSelection = {
+        start:     2,
+        end:       9,
+        direction: 'backward'
+    };
+
+    input.setSelectionRange(testSelection.start, testSelection.end, testSelection.direction);
 
     var selection = selectionSandbox.getSelection(input);
 
-    equal(selection.start, 0);
-    equal(selection.end, input.value.length);
+    equal(selection.start, testSelection.start);
+    equal(selection.end, testSelection.end);
 
     if (!isIE)
-        equal(selection.direction, 'backward');
+        equal(selection.direction, testSelection.direction);
+
+    document.body.removeChild(input);
+});
+
+test('Get selection on input with "email" type', function () {
+    var input     = createTestInput();
+    var selection = selectionSandbox.getSelection(input);
+
+    equal(selection.start, browserUtils.isFirefox && browserUtils.version < 51 || isIE ? 0 : inputTestValue.length);
+    equal(selection.end, browserUtils.isFirefox && browserUtils.version < 51 || isIE ? 0 : inputTestValue.length);
+
+    if (isMobileBrowser || browserUtils.isSafari || browserUtils.isChrome && browserUtils.isMacPlatform)
+        equal(selection.direction, 'none');
+    else if (!isIE)
+        equal(selection.direction, 'forward');
 
     document.body.removeChild(input);
 });

--- a/test/client/fixtures/sandbox/selection-test.js
+++ b/test/client/fixtures/sandbox/selection-test.js
@@ -1,0 +1,26 @@
+var selectionSandbox = hammerhead.eventSandbox.selection;
+var browserUtils     = hammerhead.utils.browser;
+
+var inputTestValue = 'test@host.net';
+var isIE           = browserUtils.isIE;
+
+test('Set and get selection on input with "email" type', function () {
+    var input = document.createElement('input');
+
+    input.type  = 'email';
+    input.value = inputTestValue;
+
+    document.body.appendChild(input);
+
+    input.setSelectionRange(0, inputTestValue.length, 'backward');
+
+    var selection = selectionSandbox.getSelection(input);
+
+    equal(selection.start, 0);
+    equal(selection.end, input.value.length);
+
+    if (!isIE)
+        equal(selection.direction, 'backward');
+
+    document.body.removeChild(input);
+});


### PR DESCRIPTION
\cc @churkin, @AlexanderMoskovkin
With this fix testcafe qunit tests passes in Firefox 51 locally and in Firefox beta on Sauce Labs. Currently i'm checking functional tests with this set.