### PR TITLE
fix 'on calling without parameters we should return the native resultof 'fetch' function instead of window.Promise.reject' (close #1099)

### DIFF
--- a/src/client/sandbox/fetch.js
+++ b/src/client/sandbox/fetch.js
@@ -127,6 +127,9 @@ export default class FetchSandbox extends SandboxBase {
             window.Request.prototype = nativeMethods.Request.prototype;
 
             window.fetch = function (...args) {
+                if (!args.length)
+                    return nativeMethods.fetch.apply(this, args);
+
                 if (!FetchSandbox._requestIsValid(args))
                     return sandbox.window.Promise.reject(new TypeError());
 

--- a/src/client/sandbox/fetch.js
+++ b/src/client/sandbox/fetch.js
@@ -128,7 +128,7 @@ export default class FetchSandbox extends SandboxBase {
 
             window.fetch = function (...args) {
                 if (!args.length)
-                    return nativeMethods.fetch.apply(this, args);
+                    return nativeMethods.fetch.apply(this);
 
                 if (!FetchSandbox._requestIsValid(args))
                     return sandbox.window.Promise.reject(new TypeError());

--- a/test/client/fixtures/sandbox/fetch-test.js
+++ b/test/client/fixtures/sandbox/fetch-test.js
@@ -1,6 +1,8 @@
 var xhrHeaders   = hammerhead.get('../request-pipeline/xhr/headers');
 var destLocation = hammerhead.get('./utils/destination-location');
 
+var nativeMethods = hammerhead.nativeMethods;
+
 if (window.fetch) {
     asyncTest('global fetch - redirect request to proxy', function () {
         fetch('/xhr-test/100')
@@ -392,6 +394,21 @@ if (window.fetch) {
             };
 
             return Promise.all(testCases.map(createTestCasePromise));
+        });
+
+        test("on calling without parameters we should return the native result of 'fetch' function instead of window.Promise.reject (GH-1099)", function () {
+            var storedWindowPromise = window.Promise;
+
+            window.Promise = {
+                reject: function () {}
+            };
+
+            var result       = fetch();
+            var nativeResult = nativeMethods.fetch.apply(this);
+
+            strictEqual(result.constructor, nativeResult.constructor);
+
+            window.Promise = storedWindowPromise;
         });
     });
 }

--- a/test/client/fixtures/sandbox/fetch-test.js
+++ b/test/client/fixtures/sandbox/fetch-test.js
@@ -405,10 +405,9 @@ if (window.fetch) {
                     }
                 };
 
-                var result       = fetch();
-                var nativeResult = nativeMethods.fetch.apply(this);
+                var fetchPromise = fetch();
 
-                strictEqual(result.constructor, nativeResult.constructor);
+                strictEqual(fetchPromise.constructor, storedWindowPromise);
 
                 window.Promise = storedWindowPromise;
             });


### PR DESCRIPTION
@churkin @LavrovArtem 