### PR TITLE
fix 'Should emulate native behaviour on calling 'Worker' constructor without parameters' (close #1132)

### DIFF
--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -11,6 +11,7 @@ import { isSubDomain, parseUrl, getProxyUrl, convertToProxyUrl, stringifyResourc
 import { isFirefox } from '../../utils/browser';
 import { isCrossDomainWindows, isImgElement, isBlob } from '../../utils/dom';
 import INTERNAL_ATTRS from '../../../processing/dom/internal-attributes';
+import constructorIsCalledWithoutNewKeyword from '../../utils/constructor-is-called-without-new-keyword';
 
 const nativeFunctionToString = nativeMethods.Function.toString();
 
@@ -129,8 +130,8 @@ export default class WindowSandbox extends SandboxBase {
 
         if (window.Worker) {
             window.Worker           = function (scriptURL, options) {
-                if (this instanceof window.Worker === false)
-                    throw new TypeError();
+                if (constructorIsCalledWithoutNewKeyword(this, window.Worker) )
+                    nativeMethods.Worker.apply(this, arguments);
 
                 if (arguments.length === 0)
                     return new nativeMethods.Worker();

--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -128,11 +128,17 @@ export default class WindowSandbox extends SandboxBase {
         }
 
         if (window.Worker) {
-            window.Worker           = scriptURL => {
+            window.Worker           = function (scriptURL, options) {
+                if (this instanceof window.Worker === false)
+                    throw new TypeError();
+
+                if (arguments.length === 0)
+                    return new nativeMethods.Worker();
+
                 if (typeof scriptURL === 'string')
                     scriptURL = getProxyUrl(scriptURL);
 
-                return new nativeMethods.Worker(scriptURL);
+                return arguments.length === 1 ? new nativeMethods.Worker(scriptURL) : new nativeMethods.Worker(scriptURL, options);
             };
             window.Worker.prototype = nativeMethods.Worker.prototype;
         }

--- a/src/client/utils/constructor-is-called-without-new-keyword.js
+++ b/src/client/utils/constructor-is-called-without-new-keyword.js
@@ -1,0 +1,3 @@
+export default function (callingContext, constructor) {
+    return callingContext instanceof constructor === false;
+}

--- a/test/client/fixtures/sandbox/node/classes-test.js
+++ b/test/client/fixtures/sandbox/node/classes-test.js
@@ -25,6 +25,42 @@ if (window.Worker) {
     test('window.Worker should be overridden', function () {
         notEqual(window.Worker, nativeMethods.Worker);
     });
+
+    test('throwing errors (GH-1132)', function () {
+        throws(function () {
+            window.Worker();
+        }, TypeError);
+
+        throws(function () {
+            /*eslint-disable no-new*/
+            new Worker();
+            /*eslint-enable no-new*/
+        }, TypeError);
+    });
+
+    test('checking parameters (GH-1132', function () {
+        var savedNativeWorker = nativeMethods.Worker;
+        var workerOptions     = { name: 'test' };
+
+        nativeMethods.Worker = function (scriptURL) {
+            strictEqual(arguments.length, 1);
+            strictEqual(scriptURL, urlUtils.getProxyUrl('/test'));
+        };
+        /* eslint-disable no-new */
+        new Worker('/test');
+        /* eslint-enable no-new */
+
+        nativeMethods.Worker = function (scriptURL, options) {
+            strictEqual(arguments.length, 2);
+            strictEqual(scriptURL, urlUtils.getProxyUrl('/test'));
+            strictEqual(options, workerOptions);
+        };
+        /* eslint-disable no-new */
+        new Worker('/test', workerOptions);
+        /* eslint-enable no-new */
+
+        nativeMethods.Worker = savedNativeWorker;
+    });
 }
 
 if (browserUtils.isIE9) {
@@ -42,6 +78,7 @@ if (!browserUtils.isIE || browserUtils.isIE11) {
         ok(worker instanceof Worker);
     });
 }
+
 module('EventSource');
 
 if (browserUtils.isIE) {
@@ -115,7 +152,8 @@ if (window.MutationObserver) {
     module('MutationObserver');
 
     test('should work with the operator "instanceof" (GH-690)', function () {
-        var observer = new MutationObserver(function () { });
+        var observer = new MutationObserver(function () {
+        });
 
         ok(observer instanceof MutationObserver);
     });

--- a/test/client/fixtures/sandbox/node/classes-test.js
+++ b/test/client/fixtures/sandbox/node/classes-test.js
@@ -152,8 +152,7 @@ if (window.MutationObserver) {
     module('MutationObserver');
 
     test('should work with the operator "instanceof" (GH-690)', function () {
-        var observer = new MutationObserver(function () {
-        });
+        var observer = new MutationObserver(function () { });
 
         ok(observer instanceof MutationObserver);
     });


### PR DESCRIPTION
@churkin @LavrovArtem 