### PR TITLE
Rename internal props

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -212,7 +212,7 @@ var hammerhead = new Hammerhead();
 
 // NOTE: The 'load' event is raised after calling document.close for a same-domain iframe
 // So, we need to define the '%hammerhead%' variable as 'configurable' so that it can be redefined.
-Object.defineProperty(window, INTERNAL_PROPS.hammerheadPropertyName, {
+Object.defineProperty(window, INTERNAL_PROPS.hammerhead, {
     value:        hammerhead,
     configurable: true
 });

--- a/src/client/sandbox/base.js
+++ b/src/client/sandbox/base.js
@@ -19,7 +19,7 @@ export default class SandboxBase extends EventEmitter {
             this.document.body;
             /*eslint-enable no-unused-expressions */
 
-            if (this.window[INTERNAL_PROPS.hammerheadPropertyName]) {
+            if (this.window[INTERNAL_PROPS.hammerhead]) {
                 var frameElement = getFrameElement(this.window);
 
                 return frameElement && !isElementInDocument(frameElement, findDocument(frameElement));

--- a/src/client/sandbox/cookie.js
+++ b/src/client/sandbox/cookie.js
@@ -12,7 +12,7 @@ import BYTES_PER_COOKIE_LIMIT from '../../session/cookie-limit';
 export default class CookieSandbox extends SandboxBase {
     _getSettings () {
         var windowSettings = this.window !== this.window.top && !isCrossDomainWindows(this.window, this.window.top) ?
-                             this.window.top[INTERNAL_PROPS.hammerheadPropertyName].get('./settings') : settings;
+                             this.window.top[INTERNAL_PROPS.hammerhead].get('./settings') : settings;
 
         return windowSettings.get();
     }

--- a/src/client/sandbox/event/selection.js
+++ b/src/client/sandbox/event/selection.js
@@ -48,7 +48,7 @@ export default class Selection {
                 }
 
                 if (useInternalSelection) {
-                    el[INTERNAL_PROPS.selectionProperty] = {
+                    el[INTERNAL_PROPS.selection] = {
                         selectionStart:     el.selectionStart,
                         selectionEnd:       el.selectionEnd,
                         selectionDirection: el.selectionDirection
@@ -160,7 +160,7 @@ export default class Selection {
             el.type = 'text';
         }
 
-        var internalSelection = el[INTERNAL_PROPS.selectionProperty];
+        var internalSelection = el[INTERNAL_PROPS.selection];
 
         selection = {
             start:     internalSelection ? internalSelection.selectionStart : el.selectionStart,

--- a/src/client/sandbox/node/document/writer.js
+++ b/src/client/sandbox/node/document/writer.js
@@ -26,12 +26,12 @@ const IS_NOT_CLOSED_PROPERTY = 'hammerhead|is-not-closed-element';
 const ON_WINDOW_RECREATION_SCRIPT_TEMPLATE = `
     <script class="${ SHADOW_UI_CLASSNAME.selfRemovingScript }" type="text/javascript">
         (function () {
-            var hammerhead = window["${ INTERNAL_PROPS.hammerheadPropertyName }"];
+            var hammerhead = window["${ INTERNAL_PROPS.hammerhead }"];
             var sandbox = hammerhead && hammerhead.sandbox;
             var script = document.currentScript || document.scripts[document.scripts.length - 1];
             if (!sandbox) {
                 try {
-                    sandbox = window.parent["${ INTERNAL_PROPS.hammerheadPropertyName }"].get('./sandbox/backup').get(window);
+                    sandbox = window.parent["${ INTERNAL_PROPS.hammerhead }"].get('./sandbox/backup').get(window);
                 } catch(e) {}
             }
             if (sandbox) {

--- a/src/client/sandbox/storages/index.js
+++ b/src/client/sandbox/storages/index.js
@@ -36,7 +36,7 @@ export default class StorageSandbox extends SandboxBase {
         var host                  = destLocation.getParsed().host;
         var storageKey            = StorageSandbox._getStorageKey(sessionId, host);
         var topSameDomainWindow   = getTopSameDomainWindow(this.window);
-        var topSameDomainStorages = topSameDomainWindow[INTERNAL_PROPS.hammerheadPropertyName].sandbox.storageSandbox.storages;
+        var topSameDomainStorages = topSameDomainWindow[INTERNAL_PROPS.hammerhead].sandbox.storageSandbox.storages;
 
         // NOTE: Use the already created wrappers.
         if (topSameDomainStorages[storageKey]) {

--- a/src/client/utils/html.js
+++ b/src/client/utils/html.js
@@ -35,7 +35,7 @@ export const INIT_SCRIPT_FOR_IFRAME_TEMPLATE = `
         (function () {
             var parentHammerhead = null;
             try {
-                parentHammerhead = window.parent["${ INTERNAL_PROPS.hammerheadPropertyName }"];
+                parentHammerhead = window.parent["${ INTERNAL_PROPS.hammerhead }"];
             } catch(e) {}
             if (parentHammerhead) parentHammerhead.sandbox.onIframeDocumentRecreated(window.frameElement);
             var script = document.currentScript || document.scripts[document.scripts.length - 1];

--- a/src/processing/dom/internal-properties.js
+++ b/src/processing/dom/internal-properties.js
@@ -10,5 +10,5 @@ export default {
     documentCharset:      'hammerhead|document-charset',
     iframeNativeMethods:  'hammerhead|iframe-native-methods',
     hammerhead:           '%hammerhead%',
-    selection:            'hammerhead|selection-property'
+    selection:            'hammerhead|selection'
 };

--- a/src/processing/dom/internal-properties.js
+++ b/src/processing/dom/internal-properties.js
@@ -4,11 +4,11 @@
 // -------------------------------------------------------------
 
 export default {
-    processDomMethodName:   'hammerhead|process-dom-method',
-    processedContext:       'hammerhead|processed-context',
-    whichPropertyWrapper:   'hammerhead|which-property-wrapper',
-    documentCharset:        'hammerhead|document-charset',
-    iframeNativeMethods:    'hammerhead|iframe-native-methods',
-    hammerheadPropertyName: '%hammerhead%',
-    selectionProperty:      'hammerhead|selection-property'
+    processDomMethodName: 'hammerhead|process-dom-method',
+    processedContext:     'hammerhead|processed-context',
+    whichPropertyWrapper: 'hammerhead|which-property-wrapper',
+    documentCharset:      'hammerhead|document-charset',
+    iframeNativeMethods:  'hammerhead|iframe-native-methods',
+    hammerhead:           '%hammerhead%',
+    selection:            'hammerhead|selection-property'
 };

--- a/src/processing/resources/page.js
+++ b/src/processing/resources/page.js
@@ -11,8 +11,8 @@ import INTERNAL_PROPS from '../../processing/dom/internal-properties';
 const BODY_CREATED_EVENT_SCRIPT = dedent(`
     <script type="text/javascript" class="${ SHADOW_UI_CLASSNAME.selfRemovingScript }">
         (function () {
-            if (window["${ INTERNAL_PROPS.hammerheadPropertyName }"])
-                window["${ INTERNAL_PROPS.hammerheadPropertyName }"].sandbox.node.raiseBodyCreatedEvent();
+            if (window["${ INTERNAL_PROPS.hammerhead }"])
+                window["${ INTERNAL_PROPS.hammerhead }"].sandbox.node.raiseBodyCreatedEvent();
 
             var script = document.currentScript || document.scripts[document.scripts.length - 1];
             script.parentNode.removeChild(script);


### PR DESCRIPTION
@churkin @LavrovArtem 

PR https://github.com/DevExpress/testcafe-hammerhead/pull/1112 PR has a perfomance problem.
It is big PR that contains a several logic parts.
To simplify https://github.com/DevExpress/testcafe-hammerhead/pull/1112 PR I will cut clear parts and pulls their separately.

Part number 1:
Rename internal properties. See motivation - https://github.com/ryanmcdermott/clean-code-javascript#dont-add-unneeded-context
```js
INTERNAL_PROPS.hammerheadPropertyName ->INTERNAL_PROPS.hammerhead
INTERNAL_PROPS.selectionProperty      ->INTERNAL_PROPS.selection
```
