### PR TITLE
improve perfomance of the domUtils.isShadowUI 

### DIFF
--- a/src/client/sandbox/code-instrumentation/properties/index.js
+++ b/src/client/sandbox/code-instrumentation/properties/index.js
@@ -66,8 +66,8 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
     static _getShadowUICollectionLength (collection) {
         var shadowUIElementCount = 0;
 
-        for (var item of collection) {
-            if (domUtils.isShadowUIElement(item))
+        for (var i = 0; i < collection.length; i++) {
+            if (domUtils.isShadowUIElement(collection[i]))
                 shadowUIElementCount++;
         }
 

--- a/src/client/sandbox/code-instrumentation/properties/index.js
+++ b/src/client/sandbox/code-instrumentation/properties/index.js
@@ -1,6 +1,5 @@
 import INTERNAL_PROPS from '../../../../processing/dom/internal-properties';
 import { SAME_ORIGIN_CHECK_FAILED_STATUS_CODE } from '../../../../request-pipeline/xhr/same-origin-policy';
-import SHADOW_UI_CLASSNAME from '../../../../shadow-ui/class-name';
 import LocationAccessorsInstrumentation from '../location';
 import LocationWrapper from '../location/wrapper';
 import SandboxBase from '../../base';
@@ -65,26 +64,17 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
     }
 
     static _getShadowUICollectionLength (collection) {
-        var elementCount = 0;
+        var shadowUIElementCount = 0;
 
         for (var i = 0; i < collection.length; i++) {
-            var className = collection[i].className;
-
-            if (className) {
-                // NOTE: SVG elements' className is of the SVGAnimatedString type instead
-                // of string (GH-354).
-                if (typeof className !== 'string')
-                    className = className.baseVal || '';
-
-                if (className.indexOf(SHADOW_UI_CLASSNAME.postfix) !== -1)
-                    elementCount++;
-            }
+            if (domUtils.isShadowUIElement(collection[i]))
+                shadowUIElementCount++;
         }
 
-        if (elementCount !== 0)
+        if (shadowUIElementCount !== 0)
             ShadowUI.checkElementsPosition(collection);
 
-        return collection.length - elementCount;
+        return collection.length - shadowUIElementCount;
     }
 
     static _setTextProp (el, propName, text) {
@@ -303,6 +293,18 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
                     }
 
                     el.innerHTML = processedValue;
+
+                    if (domUtils.isBodyElement(el)) {
+                        var shadowUIRoot = this.shadowUI.select('.' + this.shadowUI.ROOT_CLASS, el)[0];
+
+                        if (shadowUIRoot) {
+                            ShadowUI.markElementAsShadow(shadowUIRoot);
+                            ShadowUI.markElementChildrenAsShadowRecursively(shadowUIRoot);
+                        }
+                    }
+
+                    else if (domUtils.isShadowUIElement(el))
+                        ShadowUI.markElementChildrenAsShadowRecursively(el);
 
                     if (isStyleEl || isScriptEl)
                         return value;

--- a/src/client/sandbox/code-instrumentation/properties/index.js
+++ b/src/client/sandbox/code-instrumentation/properties/index.js
@@ -71,7 +71,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
                 shadowUIElementCount++;
         }
 
-        if (shadowUIElementCount !== 0)
+        if (shadowUIElementCount)
             ShadowUI.checkElementsPosition(collection);
 
         return collection.length - shadowUIElementCount;
@@ -295,16 +295,13 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
                     el.innerHTML = processedValue;
 
                     if (domUtils.isBodyElement(el)) {
-                        var shadowUIRoot = this.shadowUI.select('.' + this.shadowUI.ROOT_CLASS, el)[0];
+                        var shadowUIRoot = this.shadowUI.getRoot();
 
-                        if (shadowUIRoot) {
-                            ShadowUI.markElementAsShadow(shadowUIRoot);
-                            ShadowUI.markElementChildrenAsShadowRecursively(shadowUIRoot);
-                        }
+                        ShadowUI.markElementAndChildrenAsShadow(shadowUIRoot);
                     }
 
                     else if (domUtils.isShadowUIElement(el))
-                        ShadowUI.markElementChildrenAsShadowRecursively(el);
+                        ShadowUI.markElementAndChildrenAsShadow(el);
 
                     if (isStyleEl || isScriptEl)
                         return value;

--- a/src/client/sandbox/code-instrumentation/properties/index.js
+++ b/src/client/sandbox/code-instrumentation/properties/index.js
@@ -66,8 +66,8 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
     static _getShadowUICollectionLength (collection) {
         var shadowUIElementCount = 0;
 
-        for (var i = 0; i < collection.length; i++) {
-            if (domUtils.isShadowUIElement(collection[i]))
+        for (var item of collection) {
+            if (domUtils.isShadowUIElement(item))
                 shadowUIElementCount++;
         }
 

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -575,10 +575,8 @@ export default class ElementSandbox extends SandboxBase {
         if (domUtils.isScriptElement(el))
             this.emit(this.SCRIPT_ELEMENT_ADDED, { el });
 
-        if (ElementSandbox._hasShadowUIParentOrContainsShadowUIClassPostfix(el)) {
-            ShadowUI.markElementAsShadow(el);
-            ShadowUI.markElementChildrenAsShadowRecursively(el);
-        }
+        if (ElementSandbox._hasShadowUIParentOrContainsShadowUIClassPostfix(el))
+            ShadowUI.markElementAndChildrenAsShadow(el);
     }
 
     onElementRemoved (el) {

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -16,6 +16,7 @@ import getNativeQuerySelectorAll from '../../utils/get-native-query-selector-all
 import { HASH_RE } from '../../../utils/url';
 import * as windowsStorage from '../windows-storage';
 import AttributesWrapper from '../code-instrumentation/properties/attributes-wrapper';
+import ShadowUI from '../shadow-ui';
 
 const KEYWORD_TARGETS = ['_blank', '_self', '_parent', '_top'];
 
@@ -514,6 +515,10 @@ export default class ElementSandbox extends SandboxBase {
         AttributesWrapper.refreshWrappers(el);
     }
 
+    static _hasShadowUIParentOrContainsShadowUIClassPostfix (el) {
+        return el.parentNode && domUtils.isShadowUIElement(el.parentNode) || ShadowUI.containsShadowUIClassPostfix(el);
+    }
+
     _onAddFileInputInfo (el) {
         if (!domUtils.isDomElement(el))
             return;
@@ -569,6 +574,11 @@ export default class ElementSandbox extends SandboxBase {
 
         if (domUtils.isScriptElement(el))
             this.emit(this.SCRIPT_ELEMENT_ADDED, { el });
+
+        if (ElementSandbox._hasShadowUIParentOrContainsShadowUIClassPostfix(el)) {
+            ShadowUI.markElementAsShadow(el);
+            ShadowUI.markElementChildrenAsShadowRecursively(el);
+        }
     }
 
     onElementRemoved (el) {

--- a/src/client/sandbox/shadow-ui.js
+++ b/src/client/sandbox/shadow-ui.js
@@ -233,6 +233,7 @@ export default class ShadowUI extends SandboxBase {
             var refNode = head.children[i] || null;
             var newNode = nativeMethods.cloneNode.call(parser.children[i]);
 
+            ShadowUI._markElementAsShadow(newNode);
             this.nativeMethods.insertBefore.call(head, newNode, refNode);
         }
     }

--- a/src/client/sandbox/shadow-ui.js
+++ b/src/client/sandbox/shadow-ui.js
@@ -85,11 +85,13 @@ export default class ShadowUI extends SandboxBase {
             var rootOffset = getOffsetPosition(this.root);
 
             if (rootOffset.left !== 0 || rootOffset.top !== 0) {
-                var newLeft = ((parseFloat(getStyle(this.root, 'left')) || 0) - rootOffset.left).toString() + 'px';
-                var newTop  = ((parseFloat(getStyle(this.root, 'top')) || 0) - rootOffset.top).toString() + 'px';
+                var currentRootLeft = parseFloat(getStyle(this.root, 'left')) || 0;
+                var currentRootTop  = parseFloat(getStyle(this.root, 'top')) || 0;
+                var newRootLeft     = currentRootLeft - rootOffset.left + 'px';
+                var newRootTop      = currentRootTop - rootOffset.top + 'px';
 
-                setStyle(this.root, 'left', newLeft);
-                setStyle(this.root, 'top', newTop);
+                setStyle(this.root, 'left', newRootLeft);
+                setStyle(this.root, 'top', newRootTop);
             }
         }
     }

--- a/src/client/sandbox/shadow-ui.js
+++ b/src/client/sandbox/shadow-ui.js
@@ -238,9 +238,7 @@ export default class ShadowUI extends SandboxBase {
         if (!head)
             return;
 
-        for (var i = 0; i < head.children.length; i++) {
-            var headChild = head.children[i];
-
+        for (var headChild of head.children) {
             if (ShadowUI.containsShadowUIClassPostfix(headChild))
                 ShadowUI.markElementAsShadow(headChild);
         }
@@ -504,8 +502,8 @@ export default class ShadowUI extends SandboxBase {
     static markElementChildrenAsShadowRecursively (el) {
         var childElements = getNativeQuerySelectorAll(el).call(el, '*');
 
-        for (var i = 0; i < childElements.length; i++)
-            ShadowUI.markElementAsShadow(childElements[i]);
+        for (var childElement of childElements)
+            ShadowUI.markElementAsShadow(childElement);
     }
 
     static markElementAsShadow (el) {

--- a/src/client/sandbox/shadow-ui.js
+++ b/src/client/sandbox/shadow-ui.js
@@ -63,6 +63,12 @@ export default class ShadowUI extends SandboxBase {
     }
 
     _bringRootToWindowTopLeft () {
+        // NOTE: After document.write call into nested iframes with html src attribute value
+        // Firefox has document.defaultView equal null
+        // In this case we can not calculate the 'left' and 'top' style properties
+        if (!this.document.defaultView)
+            return;
+
         var rootHasParentWithNonStaticPosition = false;
         var parent                             = this.root.parentNode;
 

--- a/src/client/sandbox/shadow-ui.js
+++ b/src/client/sandbox/shadow-ui.js
@@ -238,7 +238,9 @@ export default class ShadowUI extends SandboxBase {
         if (!head)
             return;
 
-        for (var headChild of head.children) {
+        for (var i = 0; i < head.children.length; i++) {
+            var headChild = head.children[i];
+
             if (ShadowUI.containsShadowUIClassPostfix(headChild))
                 ShadowUI.markElementAsShadow(headChild);
         }
@@ -502,8 +504,8 @@ export default class ShadowUI extends SandboxBase {
     static markElementChildrenAsShadowRecursively (el) {
         var childElements = getNativeQuerySelectorAll(el).call(el, '*');
 
-        for (var childElement of childElements)
-            ShadowUI.markElementAsShadow(childElement);
+        for (var i = 0; i < childElements.length; i++)
+            ShadowUI.markElementAsShadow(childElements[i]);
     }
 
     static markElementAsShadow (el) {

--- a/src/client/sandbox/shadow-ui.js
+++ b/src/client/sandbox/shadow-ui.js
@@ -242,7 +242,7 @@ export default class ShadowUI extends SandboxBase {
             var headChild = head.children[i];
 
             if (ShadowUI.containsShadowUIClassPostfix(headChild))
-                ShadowUI.markElementAsShadow(headChild);
+                ShadowUI._markElementAsShadow(headChild);
         }
     }
 
@@ -254,7 +254,7 @@ export default class ShadowUI extends SandboxBase {
                 nativeMethods.setAttribute.call(this.root, 'id', ShadowUI.patchId(this.ROOT_ID));
                 nativeMethods.setAttribute.call(this.root, 'contenteditable', 'false');
                 this.addClass(this.root, this.ROOT_CLASS);
-                ShadowUI.markElementAsShadow(this.root);
+                ShadowUI._markElementAsShadow(this.root);
                 nativeMethods.appendChild.call(this.document.body, this.root);
 
                 for (var event of EVENTS)
@@ -501,15 +501,17 @@ export default class ShadowUI extends SandboxBase {
         return nativeMethods.insertBefore.call(rootParent, el, rootParent.lastChild);
     }
 
-    static markElementChildrenAsShadowRecursively (el) {
+    static _markElementAsShadow (el) {
+        el[INTERNAL_PROPS.shadowUIElement] = true;
+    }
+
+    static markElementAndChildrenAsShadow (el) {
+        ShadowUI._markElementAsShadow(el);
+
         var childElements = getNativeQuerySelectorAll(el).call(el, '*');
 
         for (var i = 0; i < childElements.length; i++)
-            ShadowUI.markElementAsShadow(childElements[i]);
-    }
-
-    static markElementAsShadow (el) {
-        el[INTERNAL_PROPS.shadowUIElement] = true;
+            ShadowUI._markElementAsShadow(childElements[i]);
     }
 
     static containsShadowUIClassPostfix (element) {

--- a/src/client/utils/dom.js
+++ b/src/client/utils/dom.js
@@ -536,18 +536,7 @@ export function isElementFocusable (el) {
 }
 
 export function isShadowUIElement (element) {
-    while (element) {
-        if (element.tagName === 'BODY' || element.tagName === 'HEAD')
-            return false;
-
-        // NOTE: Check the className type to avoid issues with a SVG element’s className property.
-        if (typeof element.className === 'string' && element.className.indexOf(SHADOW_UI_CLASSNAME.postfix) > -1)
-            return true;
-
-        element = element.parentNode;
-    }
-
-    return false;
+    return !!element[INTERNAL_PROPS.shadowUIElement];
 }
 
 export function isWindow (instance) {

--- a/src/client/utils/style.js
+++ b/src/client/utils/style.js
@@ -33,10 +33,10 @@ export function isStyleSheet (instance) {
     return domUtils.instanceToString(instance) === '[object CSSStyleSheet]';
 }
 
-export function get (el, property, doc) {
+export function get (el, property, doc, win) {
     el = el.documentElement || el;
 
-    var computedStyle = getComputedStyle(el, doc);
+    var computedStyle = getComputedStyle(el, doc, win);
 
     return computedStyle && computedStyle[property];
 }
@@ -55,10 +55,16 @@ export function getBordersWidth (el) {
     };
 }
 
-export function getComputedStyle (el, doc) {
+export function getComputedStyle (el, doc, win) {
+    // NOTE: In Firefox, after calling the 'document.write' function for nested iframes with html src value
+    // document.defaultView equals 'null'. But 'window.document' equals 'document'.
+    // This is why, we are forced to calculate the targetWindow instead of use document.defaultView.
     doc = doc || document;
+    win = win || window;
 
-    return doc.defaultView.getComputedStyle(el, null);
+    var targetWin = doc.defaultView || win;
+
+    return targetWin.getComputedStyle(el, null);
 }
 
 export function getElementMargin (el) {

--- a/src/processing/dom/internal-properties.js
+++ b/src/processing/dom/internal-properties.js
@@ -10,5 +10,6 @@ export default {
     documentCharset:      'hammerhead|document-charset',
     iframeNativeMethods:  'hammerhead|iframe-native-methods',
     hammerhead:           '%hammerhead%',
-    selection:            'hammerhead|selection'
+    selection:            'hammerhead|selection',
+    shadowUIElement:      'hammerhead|shadow-ui-element'
 };

--- a/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
@@ -1,5 +1,4 @@
 var INTERNAL_PROPS                       = hammerhead.get('../processing/dom/internal-properties');
-var SHADOW_UI_CLASSNAME                  = hammerhead.get('../shadow-ui/class-name');
 var urlUtils                             = hammerhead.get('./utils/url');
 var processScript                        = hammerhead.get('../processing/script').processScript;
 var removeProcessingHeader               = hammerhead.get('../processing/script/header').remove;
@@ -252,7 +251,7 @@ test('document.scripts', function () {
     var scriptsCollectionLength = eval(processScript('document.scripts')).length;
     var scriptEl                = document.createElement('script');
 
-    scriptEl.className = SHADOW_UI_CLASSNAME.script;
+    shadowUI.addClass(scriptEl, 'script');
     document.body.appendChild(scriptEl);
 
     strictEqual(scriptsCollectionLength, eval(processScript('document.scripts')).length);
@@ -264,7 +263,7 @@ test('document.styleSheets (GH-1000)', function () {
     var styleSheetsCollectionLength = eval(processScript('document.styleSheets')).length;
     var shadowStyleSheet            = document.createElement('style');
 
-    shadowStyleSheet.className = SHADOW_UI_CLASSNAME.uiStylesheet;
+    shadowUI.addClass(shadowStyleSheet, 'ui-stylesheet');
     document.body.appendChild(shadowStyleSheet);
 
     strictEqual(styleSheetsCollectionLength, eval(processScript('document.styleSheets')).length);
@@ -273,7 +272,9 @@ test('document.styleSheets (GH-1000)', function () {
 
     document.body.appendChild(styleSheet);
 
-    strictEqual(styleSheet, eval(processScript('document.styleSheets')).item(0).ownerNode);
+    var proxiedStyleSheetsCollection = getProperty(document, 'styleSheets');
+
+    strictEqual(styleSheet, proxiedStyleSheetsCollection.item(0).ownerNode);
 
     shadowStyleSheet.parentNode.removeChild(shadowStyleSheet);
     styleSheet.parentNode.removeChild(styleSheet);

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -341,8 +341,9 @@ test('document.write for page html (T190753)', function () {
 
 if (browserUtils.isFirefox || browserUtils.isIE11) {
     asyncTest('override window methods after document.write call (T239109)', function () {
-        var $iframe = $('<iframe id="test_wrapper">');
+        var iframe = document.createElement('iframe');
 
+        iframe.id = 'test_wrapper';
         window.top.onIframeInited = function (window) {
             var iframeIframeSandbox = window['%hammerhead%'].sandbox.iframe;
 
@@ -350,7 +351,7 @@ if (browserUtils.isFirefox || browserUtils.isIE11) {
             iframeIframeSandbox.off(iframeIframeSandbox.RUN_TASK_SCRIPT, iframeIframeSandbox.iframeReadyToInitHandler);
         };
 
-        $iframe[0].setAttribute('src', 'javascript:\'' +
+        iframe.setAttribute('src', 'javascript:\'' +
                                        '   <html><body><script>' +
                                        '       window.top.onIframeInited(window);' +
                                        '       var quote = String.fromCharCode(34);' +
@@ -359,15 +360,16 @@ if (browserUtils.isFirefox || browserUtils.isIE11) {
                                        '   </sc' + 'ript></body></html>' +
                                        '\'');
 
-        $iframe.appendTo('body');
+        document.body.appendChild(iframe);
 
         var id = setInterval(function () {
-            var testIframe = $iframe[0].contentDocument.getElementById('test_iframe');
+            var testIframe = iframe.contentDocument.getElementById('test_iframe');
 
             if (testIframe && testIframe.contentDocument.body.children[0].tagName.toLowerCase() === 'div') {
                 clearInterval(id);
                 ok(true);
-                $iframe.remove();
+                iframe.parentNode.removeChild(iframe);
+
                 start();
             }
         }, 10);
@@ -553,6 +555,8 @@ test('an iframe should not contain self-removing scripts after document.close (G
     iframeDocument.close();
 
     strictEqual(nativeMethods.querySelectorAll.call(document, '.' + SHADOW_UI_CLASSNAME.selfRemovingScript).length, 0);
+
+    iframe.parentNode.removeChild(iframe);
 });
 
 test('querySelector should return an element if a selector contains the href attribute with hash as a value (GH-922)', function () {

--- a/test/client/fixtures/sandbox/shadow-ui-test.js
+++ b/test/client/fixtures/sandbox/shadow-ui-test.js
@@ -106,6 +106,14 @@ asyncTest('get root after body recreation', function () {
     document.body.appendChild(iframe);
 });
 
+test('set innerHTML for root', function () {
+    var root = shadowUI.getRoot();
+
+    eval(processScript('root.innerHTML = "<div>\"'));
+
+    ok(domUtils.isShadowUIElement(root.childNodes[0]));
+});
+
 module('childNodes');
 
 test('body.childNodes', function () {
@@ -779,10 +787,3 @@ if (document.implementation && document.implementation.createHTMLDocument) {
     });
 }
 
-test('ShadowUI elements created via changing innerHTML should be recognized', function () {
-    var root = shadowUI.getRoot();
-
-    eval(processScript('root.innerHTML = "<div>\"'));
-
-    ok(domUtils.isShadowUIElement(root.childNodes[0]));
-});

--- a/test/client/fixtures/sandbox/shadow-ui-test.js
+++ b/test/client/fixtures/sandbox/shadow-ui-test.js
@@ -614,7 +614,7 @@ asyncTest('stylesheets are restored after the document is cleaned', function () 
         for (var index = 0, length = iframeUIStylesheets.length; index < length; index++) {
             var iframeUIStylesheet = iframeUIStylesheets[index];
 
-            domUtils.isShadowUIElement(iframeUIStylesheet);
+            ok(domUtils.isShadowUIElement(iframeUIStylesheet));
             result += iframeUIStylesheet.id;
         }
 

--- a/test/client/fixtures/sandbox/shadow-ui-test.js
+++ b/test/client/fixtures/sandbox/shadow-ui-test.js
@@ -8,13 +8,17 @@ var domUtils      = hammerhead.utils.dom;
 var positionUtils = hammerhead.utils.position;
 var nativeMethods = hammerhead.nativeMethods;
 
+var TEST_DIV_SELECTOR   = '#testDiv';
+var TEST_CLASS_NAME     = 'test-class';
+var TEST_CLASS_SELECTOR = '.test-class';
+
 QUnit.testStart(function () {
-    if (!$('#testDiv').length)
+    if (!$(TEST_DIV_SELECTOR).length)
         $('<div id="testDiv">').appendTo('body');
 
-    $('#testDiv').empty();
+    $(TEST_DIV_SELECTOR).empty();
     $(shadowUI.getRoot()).empty();
-    $('.test-class').remove();
+    $(TEST_CLASS_SELECTOR).remove();
     iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
     iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
 });
@@ -30,7 +34,7 @@ test('add UI class and get UI element with selector', function () {
     document.body.appendChild(uiElem);
 
     shadowUI.addClass(uiElem, 'ui-elem-class');
-    $('#testDiv').append(uiElem);
+    $(TEST_DIV_SELECTOR).append(uiElem);
     uiElem = shadowUI.select('div.ui-elem-class')[0];
 
     strictEqual(uiElem.id, 'uiElem');
@@ -40,11 +44,11 @@ test('add UI class and get UI element with selector', function () {
 
 if (window.MutationObserver) {
     asyncTest('shadow MutationObserver', function () {
-        var uiEl = document.createElement('div');
-        var el   = nativeMethods.createElement.call(document, 'div');
+        var uiEl         = document.createElement('div');
+        var el           = document.createElement('div');
+        var shadowUIRoot = shadowUI.getRoot();
 
         shadowUI.addClass(uiEl, 'ui-elem-class');
-        nativeMethods.insertBefore.call(document.body, uiEl, document.body.children[0]);
 
         var observer = new window.MutationObserver(function (mutations) {
             strictEqual(mutations.length, 1);
@@ -52,13 +56,14 @@ if (window.MutationObserver) {
             observer.disconnect();
             uiEl.parentNode.removeChild(uiEl);
             el.parentNode.removeChild(el);
+
             start();
         });
 
         observer.observe(document.body, { childList: true });
 
-        nativeMethods.appendChild.call(document.body, uiEl);
-        nativeMethods.appendChild.call(document.body, el);
+        shadowUIRoot.appendChild(uiEl);
+        document.body.appendChild(el);
     });
 }
 
@@ -144,18 +149,20 @@ test('head.children', function () {
     var found = false;
     var link1 = document.createElement('link');
 
-    link1.rel       = 'stylesheet';
-    link1.href      = '/test.css';
-    link1.type      = 'text/css';
-    link1.className = SHADOW_UI_CLASSNAME.uiStylesheet;
+    link1.rel  = 'stylesheet';
+    link1.href = '/test.css';
+    link1.type = 'text/css';
+
+    shadowUI.addClass(link1, 'ui-stylesheet');
     document.head.insertBefore(link1, document.head.firstChild);
 
     var link2 = document.createElement('link');
 
-    link2.rel       = 'stylesheet';
-    link2.href      = '/test.css';
-    link2.type      = 'text/css';
-    link2.className = SHADOW_UI_CLASSNAME.uiStylesheet;
+    link2.rel  = 'stylesheet';
+    link2.href = '/test.css';
+    link2.type = 'text/css';
+
+    shadowUI.addClass(link2, 'ui-stylesheet');
     document.head.insertBefore(link2, document.head.firstChild);
 
     var children       = document.head.children;
@@ -183,18 +190,20 @@ test('head.childNodes', function () {
     var found = false;
     var link1 = document.createElement('link');
 
-    link1.rel       = 'stylesheet';
-    link1.href      = '/test.css';
-    link1.type      = 'text/css';
-    link1.className = SHADOW_UI_CLASSNAME.uiStylesheet;
+    link1.rel  = 'stylesheet';
+    link1.href = '/test.css';
+    link1.type = 'text/css';
+
+    shadowUI.addClass(link1, 'ui-stylesheet');
     document.head.insertBefore(link1, document.head.firstChild);
 
     var link2 = document.createElement('link');
 
-    link2.rel       = 'stylesheet';
-    link2.href      = '/test.css';
-    link2.type      = 'text/css';
-    link2.className = SHADOW_UI_CLASSNAME.uiStylesheet;
+    link2.rel  = 'stylesheet';
+    link2.href = '/test.css';
+    link2.type = 'text/css';
+
+    shadowUI.addClass(link2, 'ui-stylesheet');
     document.head.insertBefore(link2, document.head.firstChild);
 
     var childNodes       = document.head.childNodes;
@@ -270,16 +279,16 @@ test('body.getElementsByClassName', function () {
     var uiElem = document.createElement('div');
 
     uiElem.id        = 'uiChild';
-    uiElem.className = 'test-class';
+    uiElem.className = TEST_CLASS_NAME;
     root.appendChild(uiElem);
 
     var pageElem = document.createElement('div');
 
     pageElem.id        = 'pageElem';
-    pageElem.className = 'test-class';
+    pageElem.className = TEST_CLASS_NAME;
     document.body.appendChild(pageElem);
 
-    var elems = document.body.getElementsByClassName('test-class');
+    var elems = document.body.getElementsByClassName(TEST_CLASS_NAME);
 
     strictEqual(elems.length, 1);
     strictEqual(elems[0].id, 'pageElem');
@@ -290,13 +299,13 @@ test('body.getElementsByTagName', function () {
     var uiElem = document.createElement('textarea');
 
     uiElem.id        = 'uiChild';
-    uiElem.className = 'test-class';
+    uiElem.className = TEST_CLASS_NAME;
     root.appendChild(uiElem);
 
     var pageElem = document.createElement('textarea');
 
     pageElem.id        = 'pageElem';
-    pageElem.className = 'test-class';
+    pageElem.className = TEST_CLASS_NAME;
     document.body.appendChild(pageElem);
 
     var elems = document.body.getElementsByTagName('TEXTAREA');
@@ -309,10 +318,11 @@ test('head.getElementsByTagName', function () {
     var found = false;
     var link  = document.createElement('link');
 
-    link.rel       = 'stylesheet';
-    link.href      = '/test.css';
-    link.type      = 'text/css';
-    link.className = SHADOW_UI_CLASSNAME.uiStylesheet;
+    link.rel  = 'stylesheet';
+    link.href = '/test.css';
+    link.type = 'text/css';
+
+    shadowUI.addClass(link, 'ui-stylesheet');
     document.head.appendChild(link);
 
     var children = document.head.getElementsByTagName('link');
@@ -331,13 +341,13 @@ test('body.querySelector', function () {
     var uiElem = document.createElement('div');
 
     uiElem.id        = 'uiChild';
-    uiElem.className = 'test-class cli';
+    uiElem.className = TEST_CLASS_NAME + ' cli';
     root.appendChild(uiElem);
 
     var pageElem = document.createElement('div');
 
     pageElem.id        = 'pageElem';
-    pageElem.className = 'test-class cli2';
+    pageElem.className = TEST_CLASS_NAME + ' cli2';
     document.body.appendChild(pageElem);
 
     uiElem   = document.body.querySelector('.cl1');
@@ -352,16 +362,16 @@ test('body.querySelectorAll', function () {
     var uiElem = document.createElement('div');
 
     uiElem.id        = 'uiChild';
-    uiElem.className = 'test-class cli';
+    uiElem.className = TEST_CLASS_NAME + ' cli';
     root.appendChild(uiElem);
 
     var pageElem = document.createElement('div');
 
     pageElem.id        = 'pageElem';
-    pageElem.className = 'test-class cli2';
+    pageElem.className = TEST_CLASS_NAME + ' cli2';
     document.body.appendChild(pageElem);
 
-    var elems = document.body.querySelectorAll('.test-class');
+    var elems = document.body.querySelectorAll(TEST_CLASS_SELECTOR);
 
     strictEqual(elems.length, 1);
     strictEqual(elems[0].id, 'pageElem');
@@ -370,7 +380,7 @@ test('body.querySelectorAll', function () {
 module('document methods');
 
 test('elementFromPoint', function () {
-    var testDiv   = document.querySelector('#testDiv');
+    var testDiv   = document.querySelector(TEST_DIV_SELECTOR);
     var simpleDiv = document.createElement('div');
     var shadowDiv = document.createElement('div');
 
@@ -391,7 +401,7 @@ test('elementFromPoint', function () {
 
 if (document.caretPositionFromPoint) {
     test('caretPositionFromPoint', function () {
-        var testDiv   = document.querySelector('#testDiv');
+        var testDiv   = document.querySelector(TEST_DIV_SELECTOR);
         var simpleDiv = document.createElement('div');
         var shadowDiv = document.createElement('div');
 
@@ -417,7 +427,7 @@ if (document.caretPositionFromPoint) {
 
 if (document.caretRangeFromPoint) {
     test('caretRangeFromPoint', function () {
-        var testDiv   = document.querySelector('#testDiv');
+        var testDiv   = document.querySelector(TEST_DIV_SELECTOR);
         var simpleDiv = document.createElement('div');
         var shadowDiv = document.createElement('div');
 
@@ -445,29 +455,41 @@ if (document.caretRangeFromPoint) {
 }
 
 test('getElementById', function () {
-    var $testDiv = $('#testDiv');
-    var $uiRoot  = $('<div>').appendTo($testDiv);
+    var testDiv  = document.querySelector(TEST_DIV_SELECTOR);
+    var uiRoot   = shadowUI.getRoot();
+    var uiChild  = document.createElement('div');
+    var pageElem = document.createElement('div');
 
-    $('<div>').attr('id', 'uiChild').appendTo($uiRoot);
-    $('<div>').attr('id', 'pageElem').appendTo($testDiv);
+    uiChild.id         = 'uiChild';
+    uiChild.className  = TEST_CLASS_NAME;
+    pageElem.id        = 'pageElem';
+    pageElem.className = TEST_CLASS_NAME;
 
-    shadowUI.addClass($uiRoot[0], 'root');
+    uiRoot.appendChild(uiChild);
+    testDiv.appendChild(pageElem);
 
-    var uiElem   = document.getElementById('uiChild');
-    var pageElem = document.getElementById('pageElem');
+    uiChild  = document.getElementById('uiChild');
+    pageElem = document.getElementById('pageElem');
 
-    ok(!uiElem);
+    ok(!uiChild);
     strictEqual(pageElem.id, 'pageElem');
 });
 
 test('getElementsByName', function () {
-    var $testDiv = $('#testDiv');
-    var $uiRoot  = $('<div>').appendTo($testDiv);
+    var testDiv  = document.querySelector(TEST_DIV_SELECTOR);
+    var uiRoot   = shadowUI.getRoot();
+    var uiChild  = document.createElement('a');
+    var pageElem = document.createElement('a');
 
-    $('<input>').attr('id', 'uiChild').attr('name', 'test-name').appendTo($uiRoot);
-    $('<input>').attr('id', 'pageElem').attr('name', 'test-name').appendTo($testDiv);
+    uiChild.id         = 'uiChild';
+    uiChild.className  = TEST_CLASS_NAME;
+    uiChild.name       = 'test-name';
+    pageElem.id        = 'pageElem';
+    pageElem.className = TEST_CLASS_NAME;
+    pageElem.name      = 'test-name';
 
-    shadowUI.addClass($uiRoot[0], 'root');
+    uiRoot.appendChild(uiChild);
+    testDiv.appendChild(pageElem);
 
     var elems = document.getElementsByName('test-name');
 
@@ -476,62 +498,81 @@ test('getElementsByName', function () {
 });
 
 test('getElementsByTagName', function () {
-    var $testDiv = $('#testDiv');
-    var $uiRoot  = $('<div>').appendTo($testDiv);
+    var testDiv  = document.querySelector(TEST_DIV_SELECTOR);
+    var uiRoot   = shadowUI.getRoot();
+    var uiChild  = document.createElement('div');
+    var pageElem = document.createElement('div');
 
-    $('<div>').attr('id', 'uiChild').appendTo($uiRoot);
-    $('<div>').attr('id', 'pageElem').appendTo($testDiv);
+    uiChild.id         = 'uiChild';
+    uiChild.className  = TEST_CLASS_NAME;
+    pageElem.id        = 'pageElem';
+    pageElem.className = TEST_CLASS_NAME;
 
-    shadowUI.addClass($uiRoot[0], 'root');
+    uiRoot.appendChild(uiChild);
+    testDiv.appendChild(pageElem);
 
     var elems = document.getElementsByTagName('DIV');
 
-    $.each(elems, function () {
-        notEqual(this.id, 'uiChild');
-    });
+    for (var i = 0; i < elems.length; i++)
+        notEqual(elems[i].id, 'uiChild');
 });
 
 test('getElementsByClassName', function () {
-    var $testDiv = $('#testDiv');
-    var $uiRoot  = $('<div>').appendTo($testDiv);
+    var testDiv  = document.querySelector(TEST_DIV_SELECTOR);
+    var uiRoot   = shadowUI.getRoot();
+    var uiChild  = document.createElement('div');
+    var pageElem = document.createElement('div');
 
-    $('<div>').attr('id', 'uiChild').addClass('test-class').appendTo($uiRoot);
-    $('<div>').attr('id', 'pageElem').addClass('test-class').appendTo($testDiv);
+    uiChild.id         = 'uiChild';
+    uiChild.className  = TEST_CLASS_NAME;
+    pageElem.id        = 'pageElem';
+    pageElem.className = TEST_CLASS_NAME;
 
-    shadowUI.addClass($uiRoot[0], 'root');
+    uiRoot.appendChild(uiChild);
+    testDiv.appendChild(pageElem);
 
-    var elems = document.getElementsByClassName('test-class');
+    var elems = document.getElementsByClassName(TEST_CLASS_NAME);
 
     strictEqual(elems.length, 1);
     strictEqual(elems[0].id, 'pageElem');
 });
 
 test('querySelector', function () {
-    var $testDiv = $('#testDiv');
-    var $uiRoot  = $('<div>').appendTo($testDiv);
+    var testDiv  = document.querySelector(TEST_DIV_SELECTOR);
+    var uiRoot   = shadowUI.getRoot();
+    var uiChild  = document.createElement('div');
+    var pageElem = document.createElement('div');
 
-    $('<div>').attr('id', 'uiChild').addClass('ui-class').appendTo($uiRoot);
-    $('<div>').attr('id', 'pageElem').addClass('page-class').appendTo($testDiv);
+    uiChild.id         = 'uiChild';
+    uiChild.className  = TEST_CLASS_NAME + ' ui-child-class';
+    pageElem.id        = 'pageElem';
+    pageElem.className = TEST_CLASS_NAME + ' page-element-class';
 
-    shadowUI.addClass($uiRoot[0], 'root');
+    uiRoot.appendChild(uiChild);
+    testDiv.appendChild(pageElem);
 
-    var uiElem   = document.querySelector('.ui-class');
-    var pageElem = document.querySelector('.page-class');
+    uiChild  = document.querySelector('.ui-child-class');
+    pageElem = document.querySelector('.page-element-class');
 
-    ok(!uiElem);
+    ok(!uiChild);
     strictEqual(pageElem.id, 'pageElem');
 });
 
 test('querySelectorAll', function () {
-    var $testDiv = $('#testDiv');
-    var $uiRoot  = $('<div>').appendTo($testDiv);
+    var testDiv  = document.querySelector(TEST_DIV_SELECTOR);
+    var uiRoot   = shadowUI.getRoot();
+    var uiChild  = document.createElement('div');
+    var pageElem = document.createElement('div');
 
-    $('<div>').attr('id', 'uiChild').addClass('test-class').appendTo($uiRoot);
-    $('<div>').attr('id', 'pageElem').addClass('test-class').appendTo($testDiv);
+    uiChild.id         = 'uiChild';
+    uiChild.className  = TEST_CLASS_NAME;
+    pageElem.id        = 'pageElem';
+    pageElem.className = TEST_CLASS_NAME;
 
-    shadowUI.addClass($uiRoot[0], 'root');
+    uiRoot.appendChild(uiChild);
+    testDiv.appendChild(pageElem);
 
-    var elems = document.querySelectorAll('.test-class');
+    var elems = document.querySelectorAll(TEST_CLASS_SELECTOR);
 
     strictEqual(elems.length, 1);
     strictEqual(elems[0].id, 'pageElem');
@@ -562,8 +603,12 @@ asyncTest('stylesheets are restored after the document is cleaned', function () 
         );
         var result              = '';
 
-        for (var index = 0, length = iframeUIStylesheets.length; index < length; index++)
-            result += iframeUIStylesheets[index].id;
+        for (var index = 0, length = iframeUIStylesheets.length; index < length; index++) {
+            var iframeUIStylesheet = iframeUIStylesheets[index];
+
+            domUtils.isShadowUIElement(iframeUIStylesheet);
+            result += iframeUIStylesheet.id;
+        }
 
         ok(iframe.contentDocument.body.innerHTML.indexOf('Cleaned!') > -1);
         strictEqual(length, 3);
@@ -647,14 +692,14 @@ asyncTest("do nothing if ShadowUIStylesheet doesn't exist", function () {
 module('regression');
 
 test('SVG elements\' className is of the SVGAnimatedString type instead of string (GH-354)', function () {
-    document.body.innerHTML = '<svg></svg>' + document.body.innerHTML;
+    setProperty(document.body, 'innerHTML', '<svg></svg>' + document.body.innerHTML);
 
-    var svg = document.body.childNodes[0];
+    var svg                         = document.body.childNodes[0];
+    var processedBodyChildrenLength = getProperty(document.body.children, 'length');
 
-    ok(typeof svg.className !== 'string');
-    strictEqual(eval(processScript('document.body.children.length')), document.body.children.length - 1);
+    strictEqual(processedBodyChildrenLength, document.body.children.length - 1);
 
-    document.body.removeChild(svg);
+    svg.parentNode.removeChild(svg);
 });
 
 asyncTest('after clean up iframe.body.innerHtml ShadowUI\'s root must exist (T225944)', function () {
@@ -733,3 +778,11 @@ if (document.implementation && document.implementation.createHTMLDocument) {
         strictEqual(htmlDoc.getElementsByTagName('body')[0], nativeMethods.getElementsByTagName.call(htmlDoc, 'body')[0]);
     });
 }
+
+test('ShadowUI elements created via changing innerHTML should be recognized', function () {
+    var root = shadowUI.getRoot();
+
+    eval(processScript('root.innerHTML = "<div>\"'));
+
+    ok(domUtils.isShadowUIElement(root.childNodes[0]));
+});


### PR DESCRIPTION
@churkin, @AlexanderMoskovkin

Part number 2: improve perfomance of the domUtils.isShadowUI 

ShadowUI element is marked with the internal property `INTERNAL_PROPS.shadowUIElement` and `element.className` that contains `-hammerhead-shadow-ui` suffux.

ClassName uses for applying css styles and `INTERNAL_PROPS.shadowUIElement` uses for speed up the `IsShadowUIElement` check.