### PR TITLE
Use 'for...of' loop for array

### DIFF
--- a/src/client/sandbox/code-instrumentation/location/wrapper.js
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.js
@@ -101,8 +101,8 @@ export default class LocationWrapper extends EventEmitter {
             }));
         };
 
-        for (var i = 0, len = urlProps.length; i < len; i++)
-            overrideProperty(urlProps[i]);
+        for (var urlProp of urlProps)
+            overrideProperty(urlProp);
 
         this.assign = url => {
             var proxiedHref = getProxiedHref(url);

--- a/src/client/sandbox/event/listeners.js
+++ b/src/client/sandbox/event/listeners.js
@@ -75,8 +75,8 @@ export default class Listeners extends EventEmitter {
     }
 
     static _isDifferentHandler (outerHandlers, listener, useCapture) {
-        for (var i = 0, len = outerHandlers.length; i < len; i++) {
-            if (outerHandlers[i].fn === listener && outerHandlers[i].useCapture === useCapture)
+        for (var outerHandler of outerHandlers) {
+            if (outerHandler.fn === listener && outerHandler.useCapture === useCapture)
                 return false;
         }
 
@@ -119,8 +119,8 @@ export default class Listeners extends EventEmitter {
                 stopPropagation(e);
             };
 
-            for (var i = 0; i < internalHandlers.length; i++) {
-                internalHandlers[i].call(el, e, elWindow[EVENT_SANDBOX_DISPATCH_EVENT_FLAG], preventEvent, cancelHandlers, stopEventPropagation);
+            for (var internalHandler of internalHandlers) {
+                internalHandler.call(el, e, elWindow[EVENT_SANDBOX_DISPATCH_EVENT_FLAG], preventEvent, cancelHandlers, stopEventPropagation);
 
                 if (eventPrevented || stopPropagationCalled)
                     break;
@@ -234,8 +234,8 @@ export default class Listeners extends EventEmitter {
 
         this.listeningCtx.addListeningElement(el, events);
 
-        for (var i = 0; i < events.length; i++)
-            nativeAddEventListener.call(el, events[i], this._createEventHandler(), true);
+        for (var event of events)
+            nativeAddEventListener.call(el, event, this._createEventHandler(), true);
 
         var overridedMethods = this._createElementOverridedMethods(el);
 
@@ -259,8 +259,8 @@ export default class Listeners extends EventEmitter {
         if (elementCtx) {
             var eventNames = Object.keys(elementCtx);
 
-            for (var i = 0, len = eventNames.length; i < len; i++)
-                nativeAddEventListener.call(el, eventNames[i], this._createEventHandler(), true);
+            for (var eventName of eventNames)
+                nativeAddEventListener.call(el, eventName, this._createEventHandler(), true);
         }
     }
 
@@ -290,8 +290,8 @@ export default class Listeners extends EventEmitter {
         if (!this.listeningCtx.isElementListening(el))
             this.initElementListening(el, events);
 
-        for (var i = 0; i < events.length; i++) {
-            var eventListeningInfo = this.listeningCtx.getEventCtx(el, events[i]);
+        for (var event of events) {
+            var eventListeningInfo = this.listeningCtx.getEventCtx(el, event);
 
             eventListeningInfo.outerHandlersWrapper = wrapper;
         }

--- a/src/client/sandbox/shadow-ui.js
+++ b/src/client/sandbox/shadow-ui.js
@@ -245,8 +245,8 @@ export default class ShadowUI extends SandboxBase {
                 this.addClass(this.root, this.ROOT_CLASS);
                 nativeMethods.appendChild.call(this.document.body, this.root);
 
-                for (var i = 0; i < EVENTS.length; i++)
-                    this.root.addEventListener(EVENTS[i], stopPropagation);
+                for (var event of EVENTS)
+                    this.root.addEventListener(event, stopPropagation);
 
                 this._bringRootToWindowTopLeft();
                 nativeMethods.documentAddEventListener.call(this.document, 'DOMContentLoaded', () => {

--- a/src/client/sandbox/storages/wrapper.js
+++ b/src/client/sandbox/storages/wrapper.js
@@ -65,9 +65,9 @@ export default function StorageWrapper (window, nativeStorage, nativeStorageKey)
         var addedProperties = getAddedProperties();
         var state           = [[], []];
 
-        for (var i = 0; i < addedProperties.length; i++) {
-            state[KEY].push(addedProperties[i]);
-            state[VALUE].push(this[addedProperties[i]]);
+        for (var addedProperty of addedProperties) {
+            state[KEY].push(addedProperty);
+            state[VALUE].push(this[addedProperty]);
         }
 
         return state;
@@ -157,8 +157,8 @@ export default function StorageWrapper (window, nativeStorage, nativeStorageKey)
         var addedProperties = getAddedProperties();
         var changed         = false;
 
-        for (var i = 0; i < addedProperties.length; i++) {
-            delete this[addedProperties[i]];
+        for (var addedProperty of addedProperties) {
+            delete this[addedProperty];
             changed = true;
         }
 

--- a/src/client/sandbox/upload/info-manager.js
+++ b/src/client/sandbox/upload/info-manager.js
@@ -90,8 +90,8 @@ export default class UploadInfoManager {
             else if (Browser.isIE9 || Browser.isIE10) {
                 var filePaths = [];
 
-                for (var i = 0; i < fileNames.length; i++)
-                    filePaths.push(FAKE_PATH_STRING + fileNames[i].split('/').pop());
+                for (var fileName of fileNames)
+                    filePaths.push(FAKE_PATH_STRING + fileName.split('/').pop());
 
                 value = filePaths.join(', ');
             }
@@ -167,9 +167,9 @@ export default class UploadInfoManager {
     }
 
     getUploadInfo (input) {
-        for (var i = 0; i < this.uploadInfo.length; i++) {
-            if (this.uploadInfo[i].input === input)
-                return this.uploadInfo[i];
+        for (var uploadInfoItem of this.uploadInfo) {
+            if (uploadInfoItem.input === input)
+                return uploadInfoItem;
         }
 
         return null;

--- a/src/client/transport.js
+++ b/src/client/transport.js
@@ -220,8 +220,8 @@ class Transport extends EventEmitter {
 
             window.localStorage.removeItem(settings.get().sessionId);
 
-            for (var i = 0, len = storedMessages.length; i < len; i++)
-                tasks.push(this.queuedAsyncServiceMsg(storedMessages[i]));
+            for (var storedMessage of storedMessages)
+                tasks.push(this.queuedAsyncServiceMsg(storedMessage));
 
             return Promise.all(tasks);
         }

--- a/src/client/utils/dom.js
+++ b/src/client/utils/dom.js
@@ -66,9 +66,9 @@ function addClassFallback (el, className) {
         var classNames = className.split(/\s+/);
         var setClass   = ' ' + el.className + ' ';
 
-        for (var i = 0; i < classNames.length; i++) {
-            if (setClass.indexOf(' ' + classNames[i] + ' ') === -1)
-                setClass += classNames[i] + ' ';
+        for (var currentClassName of classNames) {
+            if (setClass.indexOf(' ' + currentClassName + ' ') === -1)
+                setClass += currentClassName + ' ';
         }
 
         el.className = trim(setClass);
@@ -712,8 +712,8 @@ export function addClass (el, className) {
     if (el && el.classList) {
         var classNames = className.split(/\s+/);
 
-        for (var i = 0, len = classNames.length; i < len; i++)
-            el.classList.add(classNames[i]);
+        for (var currentClassName of classNames)
+            el.classList.add(currentClassName);
     }
     else
         addClassFallback(el, className);
@@ -727,8 +727,8 @@ export function removeClass (el, className) {
     if (el.classList) {
         var classNames = className.split(/\s+/);
 
-        for (var i = 0, len = classNames.length; i < len; i++)
-            el.classList.remove(classNames[i]);
+        for (var currentClassName of classNames)
+            el.classList.remove(currentClassName);
     }
     else
         removeClassFallback(el, className);

--- a/src/client/utils/event-emitter.js
+++ b/src/client/utils/event-emitter.js
@@ -35,9 +35,9 @@ export default class EventEmitter {
         if (listeners) {
             var filtered = [];
 
-            for (var i = 0, len = listeners.length; i < len; i++) {
-                if (listeners[i] !== listener)
-                    filtered.push(listeners[i]);
+            for (var currentListener of listeners) {
+                if (currentListener !== listener)
+                    filtered.push(currentListener);
             }
 
             this.eventsListeners[evt] = filtered;


### PR DESCRIPTION
@churkin @LavrovArtem 

We can not use `for ...of` loop for non array classes.

We use `loose=true` option value for [`babel-plugin-transform-es2015-for-of`](https://www.npmjs.com/package/babel-plugin-transform-es2015-for-of) plugin.
With this option babel generates simplified output that causes an error in browsers not supported `Symbol` implementation (for example, `IE`).