### PR TITLE
temporary fix for testcafe tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ clone_depth: 1
 
 environment:
   GULP_TASK: "test-functional-local"
-  NODEJS_VERSION: "stable"
+  NODEJS_VERSION: "LTS"
 
 install:
 - ps: >-


### PR DESCRIPTION
@churkin @LavrovArtem 

Our mechanism of the running testcafe tests on every PR doesn't work with `npm5`.
It is the temporary solution until the origin problem will be fixed