### PR TITLE
Save the native "value" property setter of HTMLInputElement.prototype (close #1185)

### DIFF
--- a/src/client/sandbox/native-methods.js
+++ b/src/client/sandbox/native-methods.js
@@ -177,6 +177,16 @@ class NativeMethods {
         if (win.DOMParser)
             this.DOMParserParseFromString = win.DOMParser.prototype.parseFromString;
 
+        // Setters
+        var inputValueDescriptor    = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'value');
+        var textAreaValueDescriptor = win.Object.getOwnPropertyDescriptor(win.HTMLTextAreaElement.prototype, 'value');
+
+        if (inputValueDescriptor && typeof inputValueDescriptor.set === 'function')
+            this.inputValueSetter = inputValueDescriptor.set;
+
+        if (textAreaValueDescriptor && typeof textAreaValueDescriptor.set === 'function')
+            this.textAreaValueSetter = textAreaValueDescriptor.set;
+
         this.refreshClasses(win);
     }
 

--- a/test/client/fixtures/sandbox/native-methods-test.js
+++ b/test/client/fixtures/sandbox/native-methods-test.js
@@ -7,3 +7,33 @@ if (nativeMethods.performanceNow) {
         ok(!isNaN(parseFloat(now)));
     });
 }
+
+if (nativeMethods.inputValueSetter) {
+    test('correct value property setters are saved for the input and textarea elements', function () {
+        var input                 = document.createElement('input');
+        var inputValueGetter      = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').get;
+        var textArea              = document.createElement('textarea');
+        var textAreaValueGetter   = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').get;
+        var testNativeValueSetter = function (el, setter, getter) {
+            Object.defineProperty(el, 'value', {
+                get: function () {
+                    return getter.call(el);
+                },
+                set: function (value) {
+                    return value;
+                }
+            });
+
+            el.value = '123';
+
+            strictEqual(el.value, '');
+
+            setter.call(el, '123');
+
+            strictEqual(el.value, '123');
+        };
+
+        testNativeValueSetter(input, nativeMethods.inputValueSetter, inputValueGetter);
+        testNativeValueSetter(textArea, nativeMethods.textAreaValueSetter, textAreaValueGetter);
+    });
+}


### PR DESCRIPTION
/cc @AlexanderMoskovkin @miherlosev 