### PR TITLE
fix events names (close #678)

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -36,7 +36,7 @@ class Hammerhead {
             this.sandbox.node.element);
 
         this.EVENTS = {
-            beforeFormSubmit:        this.sandbox.node.element.BEFORE_FORM_SUBMIT,
+            beforeFormSubmit:        this.sandbox.node.element.BEFORE_FORM_SUBMIT_EVENT,
             beforeBeforeUnload:      this.sandbox.event.unload.BEFORE_BEFORE_UNLOAD_EVENT,
             beforeUnload:            this.sandbox.event.unload.BEFORE_UNLOAD_EVENT,
             unload:                  this.sandbox.event.unload.UNLOAD_EVENT,
@@ -45,13 +45,13 @@ class Hammerhead {
             uncaughtJsError:         this.sandbox.node.win.UNCAUGHT_JS_ERROR_EVENT,
             startFileUploading:      this.sandbox.upload.START_FILE_UPLOADING_EVENT,
             endFileUploading:        this.sandbox.upload.END_FILE_UPLOADING_EVENT,
-            evalIframeScript:        this.sandbox.iframe.EVAL_EXTERNAL_SCRIPT,
+            evalIframeScript:        this.sandbox.iframe.EVAL_EXTERNAL_SCRIPT_EVENT,
             xhrCompleted:            this.sandbox.xhr.XHR_COMPLETED_EVENT,
             xhrError:                this.sandbox.xhr.XHR_ERROR_EVENT,
-            xhrSend:                 this.sandbox.xhr.XHR_SEND_EVENT,
-            fetchSend:               this.sandbox.fetch.FETCH_REQUEST_SEND_EVENT,
+            xhrSend:                 this.sandbox.xhr.XHR_SENT_EVENT,
+            fetchSend:               this.sandbox.fetch.FETCH_REQUEST_SENT_EVENT,
             pageNavigationTriggered: this.pageNavigationWatch.PAGE_NAVIGATION_TRIGGERED_EVENT,
-            scriptElementAdded:      this.sandbox.node.element.SCRIPT_ELEMENT_ADDED
+            scriptElementAdded:      this.sandbox.node.element.SCRIPT_ELEMENT_ADDED_EVENT
         };
 
         this.PROCESSING_COMMENTS = {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -48,8 +48,8 @@ class Hammerhead {
             evalIframeScript:        this.sandbox.iframe.EVAL_EXTERNAL_SCRIPT_EVENT,
             xhrCompleted:            this.sandbox.xhr.XHR_COMPLETED_EVENT,
             xhrError:                this.sandbox.xhr.XHR_ERROR_EVENT,
-            xhrSend:                 this.sandbox.xhr.XHR_SENT_EVENT,
-            fetchSend:               this.sandbox.fetch.FETCH_REQUEST_SENT_EVENT,
+            beforeXhrSend:           this.sandbox.xhr.BEFORE_XHR_SEND_EVENT,
+            fetchSent:               this.sandbox.fetch.FETCH_REQUEST_SENT_EVENT,
             pageNavigationTriggered: this.pageNavigationWatch.PAGE_NAVIGATION_TRIGGERED_EVENT,
             scriptElementAdded:      this.sandbox.node.element.SCRIPT_ELEMENT_ADDED_EVENT
         };
@@ -139,14 +139,14 @@ class Hammerhead {
 
             case this.EVENTS.xhrCompleted:
             case this.EVENTS.xhrError:
-            case this.EVENTS.xhrSend:
+            case this.EVENTS.beforeXhrSend:
                 return this.sandbox.xhr;
 
             case this.EVENTS.beforeFormSubmit:
             case this.EVENTS.scriptElementAdded:
                 return this.sandbox.node.element;
 
-            case this.EVENTS.fetchSend:
+            case this.EVENTS.fetchSent:
                 return this.sandbox.fetch;
 
             default:

--- a/src/client/page-navigation-watch.js
+++ b/src/client/page-navigation-watch.js
@@ -28,7 +28,7 @@ export default class PageNavigationWatch extends EventEmiter {
         };
 
         // NOTE: fires when form.submit() is called
-        elementSandbox.on(elementSandbox.BEFORE_FORM_SUBMIT, e => onFormSubmit(e.form));
+        elementSandbox.on(elementSandbox.BEFORE_FORM_SUBMIT_EVENT, e => onFormSubmit(e.form));
 
         // NOTE: fires when the form is submitted by clicking the submit button
         eventSandbox.listeners.initElementListening(window, ['submit']);

--- a/src/client/sandbox/fetch.js
+++ b/src/client/sandbox/fetch.js
@@ -12,7 +12,7 @@ export default class FetchSandbox extends SandboxBase {
     constructor () {
         super();
 
-        this.FETCH_REQUEST_SEND_EVENT = 'hammerhead|event|fetch-request-send-event';
+        this.FETCH_REQUEST_SENT_EVENT = 'hammerhead|event|fetch-request-sent-event';
     }
 
     static _addSpecialHeadersToRequestInit (init) {
@@ -145,7 +145,7 @@ export default class FetchSandbox extends SandboxBase {
                 var fetchPromise = nativeMethods.fetch.apply(this, args);
 
                 FetchSandbox._processFetchPromise(fetchPromise);
-                sandbox.emit(sandbox.FETCH_REQUEST_SEND_EVENT, fetchPromise);
+                sandbox.emit(sandbox.FETCH_REQUEST_SENT_EVENT, fetchPromise);
 
                 return fetchPromise;
             };

--- a/src/client/sandbox/iframe.js
+++ b/src/client/sandbox/iframe.js
@@ -13,14 +13,14 @@ export default class IframeSandbox extends SandboxBase {
     constructor (nodeMutation, cookieSandbox) {
         super();
 
-        this.RUN_TASK_SCRIPT               = 'hammerhead|event|run-task-script';
-        this.EVAL_HAMMERHEAD_SCRIPT        = 'hammerhead|event|eval-hammerhead-script';
-        this.EVAL_EXTERNAL_SCRIPT          = 'hammerhead|event|eval-external-script';
+        this.RUN_TASK_SCRIPT_EVENT         = 'hammerhead|event|run-task-script';
+        this.EVAL_HAMMERHEAD_SCRIPT_EVENT  = 'hammerhead|event|eval-hammerhead-script';
+        this.EVAL_EXTERNAL_SCRIPT_EVENT    = 'hammerhead|event|eval-external-script';
         this.IFRAME_DOCUMENT_CREATED_EVENT = 'hammerhead|event|iframe-document-created';
 
         this.cookieSandbox = cookieSandbox;
 
-        this.on(this.RUN_TASK_SCRIPT, this.iframeReadyToInitHandler);
+        this.on(this.RUN_TASK_SCRIPT_EVENT, this.iframeReadyToInitHandler);
         nodeMutation.on(nodeMutation.IFRAME_ADDED_TO_DOM_EVENT, e => this.processIframe(e.iframe));
 
         this.iframeNativeMethodsBackup = null;
@@ -84,14 +84,14 @@ export default class IframeSandbox extends SandboxBase {
                 Object.defineProperty(iframe.contentWindow, IFRAME_WINDOW_INITED, { value: true });
 
                 // NOTE: Raise this internal event to eval the Hammerhead code script.
-                this.emit(this.EVAL_HAMMERHEAD_SCRIPT, { iframe });
+                this.emit(this.EVAL_HAMMERHEAD_SCRIPT_EVENT, { iframe });
 
                 // NOTE: Raise this event to eval external code script.
-                this.emit(this.EVAL_EXTERNAL_SCRIPT, { iframe });
+                this.emit(this.EVAL_EXTERNAL_SCRIPT_EVENT, { iframe });
 
                 // NOTE: Raise this event to eval the "task" script and to call the Hammerhead initialization method
                 // and external script initialization code.
-                this.emit(this.RUN_TASK_SCRIPT, { iframe });
+                this.emit(this.RUN_TASK_SCRIPT_EVENT, { iframe });
 
                 iframe.contentWindow[INTERNAL_PROPS.processDomMethodName]();
             }

--- a/src/client/sandbox/index.js
+++ b/src/client/sandbox/index.js
@@ -181,7 +181,7 @@ export default class Sandbox extends SandboxBase {
         urlResolver.init(this.document);
 
         // NOTE: Eval Hammerhead code script.
-        this.iframe.on(this.iframe.EVAL_HAMMERHEAD_SCRIPT, e => initHammerheadClient(e.iframe.contentWindow, true));
+        this.iframe.on(this.iframe.EVAL_HAMMERHEAD_SCRIPT_EVENT, e => initHammerheadClient(e.iframe.contentWindow, true));
 
         // NOTE: We need to reattach a sandbox to the recreated iframe document.
         this.node.mutation.on(this.node.mutation.DOCUMENT_CLEANED_EVENT, e => this.reattach(e.window, e.document));

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -34,8 +34,8 @@ export default class ElementSandbox extends SandboxBase {
 
         this.overridedMethods = null;
 
-        this.BEFORE_FORM_SUBMIT   = 'hammerhead|event|before-form-submit';
-        this.SCRIPT_ELEMENT_ADDED = 'hammerhead|event|script-added';
+        this.BEFORE_FORM_SUBMIT_EVENT   = 'hammerhead|event|before-form-submit';
+        this.SCRIPT_ELEMENT_ADDED_EVENT = 'hammerhead|event|script-added';
     }
 
     static _isKeywordTarget (value) {
@@ -332,7 +332,7 @@ export default class ElementSandbox extends SandboxBase {
 
             formSubmit () {
                 sandbox._ensureTargetContainsExistingBrowsingContext(this);
-                sandbox.emit(sandbox.BEFORE_FORM_SUBMIT, { form: this });
+                sandbox.emit(sandbox.BEFORE_FORM_SUBMIT_EVENT, { form: this });
 
                 return nativeMethods.formSubmit.apply(this, arguments);
             },
@@ -573,7 +573,7 @@ export default class ElementSandbox extends SandboxBase {
         }
 
         if (domUtils.isScriptElement(el))
-            this.emit(this.SCRIPT_ELEMENT_ADDED, { el });
+            this.emit(this.SCRIPT_ELEMENT_ADDED_EVENT, { el });
 
         if (ElementSandbox._hasShadowUIParentOrContainsShadowUIClassPostfix(el))
             ShadowUI.markElementAndChildrenAsShadow(el);

--- a/src/client/sandbox/shadow-ui.js
+++ b/src/client/sandbox/shadow-ui.js
@@ -321,7 +321,7 @@ export default class ShadowUI extends SandboxBase {
         this._overrideElementMethods(window);
         this._markScriptsAndStylesAsShadowInHead(window.document.head);
 
-        this.iframeSandbox.on(this.iframeSandbox.RUN_TASK_SCRIPT, e => {
+        this.iframeSandbox.on(this.iframeSandbox.RUN_TASK_SCRIPT_EVENT, e => {
             var iframeHead = e.iframe.contentDocument.head;
 
             this._restoreUIStyleSheets(iframeHead, this._getUIStyleSheetsHtml());

--- a/src/client/sandbox/xhr.js
+++ b/src/client/sandbox/xhr.js
@@ -13,9 +13,9 @@ export default class XhrSandbox extends SandboxBase {
     constructor (cookieSandbox) {
         super();
 
-        this.XHR_COMPLETED_EVENT = 'hammerhead|event|xhr-completed';
-        this.XHR_ERROR_EVENT     = 'hammerhead|event|xhr-error';
-        this.XHR_SENT_EVENT      = 'hammerhead|event|xhr-sent';
+        this.XHR_COMPLETED_EVENT   = 'hammerhead|event|xhr-completed';
+        this.XHR_ERROR_EVENT       = 'hammerhead|event|xhr-error';
+        this.BEFORE_XHR_SEND_EVENT = 'hammerhead|event|before-xhr-send';
 
         this.cookieSandbox = cookieSandbox;
 
@@ -95,7 +95,7 @@ export default class XhrSandbox extends SandboxBase {
         xmlHttpRequestProto.send = function () {
             var xhr = this;
 
-            xhrSandbox.emit(xhrSandbox.XHR_SENT_EVENT, { xhr });
+            xhrSandbox.emit(xhrSandbox.BEFORE_XHR_SEND_EVENT, { xhr });
 
             var orscHandler = () => {
                 if (this.readyState === 4)

--- a/src/client/sandbox/xhr.js
+++ b/src/client/sandbox/xhr.js
@@ -15,7 +15,7 @@ export default class XhrSandbox extends SandboxBase {
 
         this.XHR_COMPLETED_EVENT = 'hammerhead|event|xhr-completed';
         this.XHR_ERROR_EVENT     = 'hammerhead|event|xhr-error';
-        this.XHR_SEND_EVENT      = 'hammerhead|event|xhr-send';
+        this.XHR_SENT_EVENT      = 'hammerhead|event|xhr-sent';
 
         this.cookieSandbox = cookieSandbox;
 
@@ -95,7 +95,7 @@ export default class XhrSandbox extends SandboxBase {
         xmlHttpRequestProto.send = function () {
             var xhr = this;
 
-            xhrSandbox.emit(xhrSandbox.XHR_SEND_EVENT, { xhr });
+            xhrSandbox.emit(xhrSandbox.XHR_SENT_EVENT, { xhr });
 
             var orscHandler = () => {
                 if (this.readyState === 4)

--- a/test/client/data/event-sandbox/embedded-iframes.html
+++ b/test/client/data/event-sandbox/embedded-iframes.html
@@ -20,8 +20,8 @@
         }
     };
 
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 
     messageSandbox.on(messageSandbox.SERVICE_MSG_RECEIVED_EVENT, function (e) {
         if (e.message.embeddedIframesTestPassed)

--- a/test/client/data/event-sandbox/send-message-when-top-window-is-cross-domain.html
+++ b/test/client/data/event-sandbox/send-message-when-top-window-is-cross-domain.html
@@ -17,8 +17,8 @@
             e.iframe.contentWindow[INTERNAL_PROPS.processDomMethodName] = function () { }
         };
 
-        iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-        iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+        iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+        iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 
         var INSTRUCTION    = hammerhead.get('../processing/script/instruction');
         var setProperty    = window[INSTRUCTION.setProperty];

--- a/test/client/data/node-sandbox/iframe-override-elems-after-write.html
+++ b/test/client/data/node-sandbox/iframe-override-elems-after-write.html
@@ -22,7 +22,7 @@
     var INTERNAL_PROPS = hammerhead.get('../processing/dom/internal-properties');
     var postMessage = hammerhead.sandbox.event.message.postMessage;
 
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, window.top.initIframeTestHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, window.top.initIframeTestHandler);
 
     document.write('<a>Link</a><iframe id="test"></iframe>');
 

--- a/test/client/fixtures/api-test.js
+++ b/test/client/fixtures/api-test.js
@@ -1,12 +1,12 @@
 var iframeSandbox = hammerhead.sandbox.iframe;
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 module('regression');

--- a/test/client/fixtures/sandbox/backup-test.js
+++ b/test/client/fixtures/sandbox/backup-test.js
@@ -4,12 +4,12 @@ var iframeSandbox = hammerhead.sandbox.iframe;
 var browserUtils  = hammerhead.utils.browser;
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 if (browserUtils.isIE) {

--- a/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
@@ -16,12 +16,12 @@ var shadowUI      = hammerhead.sandbox.shadowUI;
 var iframeSandbox = hammerhead.sandbox.iframe;
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 if (!browserUtils.isIE || browserUtils.version > 9) {

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -11,12 +11,12 @@ var browserUtils  = hammerhead.utils.browser;
 
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 asyncTest('iframe with empty src', function () {

--- a/test/client/fixtures/sandbox/code-instrumentation/setters-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/setters-test.js
@@ -13,12 +13,12 @@ var elementEditingWatcher = hammerhead.sandbox.event.elementEditingWatcher;
 var eventSimulator        = hammerhead.sandbox.event.eventSimulator;
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 test('unsupported protocol', function () {

--- a/test/client/fixtures/sandbox/code-instrumentation/type-verification-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/type-verification-test.js
@@ -4,12 +4,12 @@ var accessors     = hammerhead.sandbox.codeInstrumentation.elementPropertyAccess
 var iframeSandbox = hammerhead.sandbox.iframe;
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 test('is anchor instance', function () {

--- a/test/client/fixtures/sandbox/event/active-window-tracker-test.js
+++ b/test/client/fixtures/sandbox/event/active-window-tracker-test.js
@@ -11,12 +11,12 @@ function createIframe () {
 }
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 
     document.body.focus();
 });

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -6,12 +6,12 @@ var focusBlur      = hammerhead.sandbox.event.focusBlur;
 var eventSimulator = hammerhead.sandbox.event.eventSimulator;
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 if (!browserUtils.isIE9) {

--- a/test/client/fixtures/sandbox/event/focus-blur-change-test.js
+++ b/test/client/fixtures/sandbox/event/focus-blur-change-test.js
@@ -248,14 +248,14 @@ QUnit.testStart(function (e) {
     if (modulesForSmallTestTimeout.indexOf(e.module) !== -1)
         QUnit.config.testTimeout = smallTestTimeout;
 
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
     QUnit.config.testTimeout = defaultTestTimeout;
 
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 module('focus');

--- a/test/client/fixtures/sandbox/event/internal-listeners-test.js
+++ b/test/client/fixtures/sandbox/event/internal-listeners-test.js
@@ -84,8 +84,8 @@ QUnit.testStart(function () {
     $uiElement = $('<div>').appendTo($container);
     uiElement  = $uiElement[0];
 
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
@@ -93,7 +93,7 @@ QUnit.testDone(function () {
     $input.remove();
     $uiElement.remove();
 
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 test('initElementListening', function () {

--- a/test/client/fixtures/sandbox/event/message-test.js
+++ b/test/client/fixtures/sandbox/event/message-test.js
@@ -7,12 +7,12 @@ var iframeSandbox  = hammerhead.sandbox.iframe;
 var messageSandbox = hammerhead.sandbox.event.message;
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 asyncTest('onmessage event (handler has "object" type) (GH-133)', function () {

--- a/test/client/fixtures/sandbox/iframe-flag-test.js
+++ b/test/client/fixtures/sandbox/iframe-flag-test.js
@@ -8,12 +8,12 @@ QUnit.testStart(function () {
     // NOTE: The 'window.open' method used in QUnit.
     window.open       = nativeMethods.windowOpen;
     window.setTimeout = nativeMethods.setTimeout;
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 function hasIframeFlag (url) {
@@ -136,8 +136,8 @@ asyncTest('assign a url attribute to elements with the "target" attribute in emb
             var iframeHammerhead    = iframe.contentWindow['%hammerhead%'];
             var iframeIframeSandbox = iframeHammerhead.sandbox.iframe;
 
-            iframeIframeSandbox.on(iframeIframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-            iframeIframeSandbox.off(iframeIframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+            iframeIframeSandbox.on(iframeIframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+            iframeIframeSandbox.off(iframeIframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 
             embeddedIframe = iframeDocument.createElement('iframe');
 

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -10,12 +10,12 @@ QUnit.testStart(function () {
     // NOTE: The 'window.open' method used in QUnit.
     window.open       = nativeMethods.windowOpen;
     window.setTimeout = nativeMethods.setTimeout;
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 test('event should not raise before iframe is appended to DOM', function () {
@@ -25,12 +25,12 @@ test('event should not raise before iframe is appended to DOM', function () {
         eventRaised = true;
     };
 
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, handler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, handler);
 
     document.createElement('iframe');
 
     ok(!eventRaised);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, handler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, handler);
 });
 
 test('event should not raise if a cross-domain iframe is appended', function () {
@@ -40,12 +40,12 @@ test('event should not raise if a cross-domain iframe is appended', function () 
         eventRaised = true;
     };
 
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, handler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, handler);
 
     var $iframe = $('<iframe id="test7" src="http://cross.domain.com">').appendTo('body');
 
     ok(!eventRaised);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, handler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, handler);
     $iframe.remove();
 });
 
@@ -100,14 +100,14 @@ asyncTest('ready to init event must not raise for added iframe(B239643)', functi
                 iframeLoadingEventRaised = true;
             };
 
-            iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, handler);
+            iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, handler);
 
             /* eslint-disable no-unused-vars */
             var dummy = container.innerHTML;
 
             /* eslint-enable no-unused-vars */
             ok(!iframeLoadingEventRaised);
-            iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, handler);
+            iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, handler);
             container.parentNode.removeChild(container);
             start();
         });
@@ -204,9 +204,9 @@ asyncTest('an error occurs when proxing two nested iframes (a top iframe has src
             xhr.send();
         };
 
-        iframeIframeSandbox.off(iframeIframeSandbox.RUN_TASK_SCRIPT, iframeIframeSandbox.iframeReadyToInitHandler);
-        iframeIframeSandbox.on(iframeIframeSandbox.RUN_TASK_SCRIPT, checkXhrEventListeners);
-        iframeIframeSandbox.on(iframeIframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+        iframeIframeSandbox.off(iframeIframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeIframeSandbox.iframeReadyToInitHandler);
+        iframeIframeSandbox.on(iframeIframeSandbox.RUN_TASK_SCRIPT_EVENT, checkXhrEventListeners);
+        iframeIframeSandbox.on(iframeIframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 
         nestedIframe.id = 'test_nestedIframe_klshgfn111';
         nestedIframe.setAttribute('src', 'about:blank');

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -16,12 +16,12 @@ QUnit.testStart(function () {
     // NOTE: The 'window.open' method used in QUnit.
     window.open       = nativeMethods.windowOpen;
     window.setTimeout = nativeMethods.setTimeout;
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 // NOTE: IE11 has a strange bug that does not allow this test to pass

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -9,12 +9,12 @@ QUnit.testStart(function () {
     // NOTE: The 'window.open' method used in QUnit.
     window.open       = nativeMethods.windowOpen;
     window.setTimeout = nativeMethods.setTimeout;
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 test('document.write for iframe.src with javascript protocol', function () {
@@ -347,8 +347,8 @@ if (browserUtils.isFirefox || browserUtils.isIE11) {
         window.top.onIframeInited = function (window) {
             var iframeIframeSandbox = window['%hammerhead%'].sandbox.iframe;
 
-            iframeIframeSandbox.on(iframeIframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-            iframeIframeSandbox.off(iframeIframeSandbox.RUN_TASK_SCRIPT, iframeIframeSandbox.iframeReadyToInitHandler);
+            iframeIframeSandbox.on(iframeIframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+            iframeIframeSandbox.off(iframeIframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeIframeSandbox.iframeReadyToInitHandler);
         };
 
         iframe.setAttribute('src', 'javascript:\'' +

--- a/test/client/fixtures/sandbox/node/document-write-test.js
+++ b/test/client/fixtures/sandbox/node/document-write-test.js
@@ -4,8 +4,8 @@ var nativeMethods = hammerhead.nativeMethods;
 var iframeSandbox = hammerhead.sandbox.iframe;
 var nodeSandbox   = hammerhead.sandbox.node;
 
-iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 
 var iframeForWrite       = document.createElement('iframe');
 var iframeForNativeWrite = nativeMethods.createElement.call(document, 'iframe');

--- a/test/client/fixtures/sandbox/node/dom-processor-test.js
+++ b/test/client/fixtures/sandbox/node/dom-processor-test.js
@@ -14,12 +14,12 @@ var iframeSandbox = hammerhead.sandbox.iframe;
 QUnit.testStart(function () {
     // NOTE: The 'window.open' method used in QUnit.
     window.open = nativeMethods.windowOpen;
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 test('iframe', function () {

--- a/test/client/fixtures/sandbox/node/dom-test.js
+++ b/test/client/fixtures/sandbox/node/dom-test.js
@@ -11,12 +11,12 @@ QUnit.testStart(function () {
     // NOTE: The 'window.open' method used in QUnit.
     window.open       = nativeMethods.windowOpen;
     window.setTimeout = nativeMethods.setTimeout;
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 asyncTest('prevent "error" event during image reloading', function () {

--- a/test/client/fixtures/sandbox/node/methods-test.js
+++ b/test/client/fixtures/sandbox/node/methods-test.js
@@ -10,12 +10,12 @@ QUnit.testStart(function () {
     // NOTE: The 'window.open' method used in QUnit.
     window.open       = nativeMethods.windowOpen;
     window.setTimeout = nativeMethods.setTimeout;
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 var nativeMethodCalled;

--- a/test/client/fixtures/sandbox/shadow-ui-test.js
+++ b/test/client/fixtures/sandbox/shadow-ui-test.js
@@ -19,12 +19,12 @@ QUnit.testStart(function () {
     $(TEST_DIV_SELECTOR).empty();
     $(shadowUI.getRoot()).empty();
     $(TEST_CLASS_SELECTOR).remove();
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 test('add UI class and get UI element with selector', function () {

--- a/test/client/fixtures/sandbox/storages-test.js
+++ b/test/client/fixtures/sandbox/storages-test.js
@@ -15,12 +15,12 @@ QUnit.testStart(function () {
     storageSandbox.localStorage.clear();
     storageSandbox.sessionStorage.clear();
 
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 function waitStorageUpdated () {

--- a/test/client/fixtures/sandbox/windows-storage-test.js
+++ b/test/client/fixtures/sandbox/windows-storage-test.js
@@ -2,12 +2,12 @@ var iframeSandbox = hammerhead.sandbox.iframe;
 var windowStorage = hammerhead.sandbox.windowStorage;
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 test('iframe', function () {

--- a/test/client/fixtures/sandbox/xhr-test.js
+++ b/test/client/fixtures/sandbox/xhr-test.js
@@ -9,12 +9,12 @@ var browserUtils  = hammerhead.utils.browser;
 var nativeMethods = hammerhead.nativeMethods;
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 test('redirect requests to proxy', function () {

--- a/test/client/fixtures/target-attr-test.js
+++ b/test/client/fixtures/target-attr-test.js
@@ -7,12 +7,12 @@ var eventSimulator = hammerhead.sandbox.event.eventSimulator;
 
 QUnit.testStart(function () {
     window.name = 'window_name';
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 function createTestedLink () {

--- a/test/client/fixtures/utils/dom-test.js
+++ b/test/client/fixtures/utils/dom-test.js
@@ -6,12 +6,12 @@ var iframeSandbox = hammerhead.sandbox.iframe;
 var nativeMethods = hammerhead.nativeMethods;
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 function toArray (arg) {

--- a/test/client/fixtures/utils/html-test.js
+++ b/test/client/fixtures/utils/html-test.js
@@ -10,12 +10,12 @@ var iframeSandbox = hammerhead.sandbox.iframe;
 var shadowUI      = hammerhead.sandbox.shadowUI;
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 module('clean up html');

--- a/test/client/fixtures/utils/string-trim-test.js
+++ b/test/client/fixtures/utils/string-trim-test.js
@@ -1,12 +1,12 @@
 var iframeSandbox = hammerhead.sandbox.iframe;
 
 QUnit.testStart(function () {
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 module('regression');

--- a/test/client/fixtures/utils/url-test.js
+++ b/test/client/fixtures/utils/url-test.js
@@ -15,12 +15,12 @@ QUnit.testStart(function () {
     // NOTE: The 'window.open' method used in QUnit.
     window.open       = nativeMethods.windowOpen;
     window.setTimeout = nativeMethods.setTimeout;
-    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, iframeSandbox.iframeReadyToInitHandler);
+    iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, iframeSandbox.iframeReadyToInitHandler);
 });
 
 QUnit.testDone(function () {
-    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT, initIframeTestHandler);
+    iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, initIframeTestHandler);
 });
 
 function getProxyUrl (url, resourceType) {


### PR DESCRIPTION
@churkin @LavrovArtem 

Rename:
`XHR_SEND_EVENT` -> `XHR_SENT_EVENT`
`FETCH_REQUEST_SEND_EVENT` -> `FETCH_REQUEST_SENT_EVENT`

Now, all event ends with `_EVENT` postfix.
