### PR TITLE
hide 'item', 'namedItem', 'length' from property enumeration

### DIFF
--- a/src/client/sandbox/node/live-node-list/wrapper.js
+++ b/src/client/sandbox/node/live-node-list/wrapper.js
@@ -5,8 +5,6 @@ const arrayFilter = Array.prototype.filter;
 export default class LiveNodeListWrapper {
     constructor (nodeList, domContentLoadedEventRaised, tagName) {
         Object.defineProperty(this, 'item', {
-            enumerable: true,
-
             value: index => {
                 this._refreshNodeList();
 
@@ -14,12 +12,17 @@ export default class LiveNodeListWrapper {
             }
         });
         Object.defineProperty(this, 'length', {
-            enumerable: true,
-
             get: () => {
                 this._refreshNodeList();
 
                 return this._filteredNodeList.length;
+            }
+        });
+        Object.defineProperty(this, 'namedItem', {
+            value: (...args) => {
+                const findNamedItem = this._nodeList.namedItem.apply(this._nodeList, args);
+
+                return findNamedItem && isShadowUIElement(findNamedItem) ? null : findNamedItem;
             }
         });
         Object.defineProperty(this, '_nodeList', { value: nodeList });
@@ -30,19 +33,6 @@ export default class LiveNodeListWrapper {
             value:    domContentLoadedEventRaised
         });
         Object.defineProperty(this, '_tagName', { value: tagName.toLowerCase() });
-
-        if (this.namedItem) {
-            Object.defineProperty(this, 'namedItem', {
-                enumerable: true,
-
-                value: (...args) => {
-                    const findNamedItem = this._nodeList.namedItem.apply(this._nodeList, args);
-
-                    return findNamedItem && isShadowUIElement(findNamedItem) ? null : findNamedItem;
-                }
-            });
-        }
-
         Object.defineProperty(this, '_refreshNodeListInternal', {
             value: () => {
                 this._filteredNodeList = arrayFilter.call(this._nodeList, element => !isShadowUIElement(element));

--- a/src/client/sandbox/node/live-node-list/wrapper.js
+++ b/src/client/sandbox/node/live-node-list/wrapper.js
@@ -18,13 +18,17 @@ export default class LiveNodeListWrapper {
                 return this._filteredNodeList.length;
             }
         });
-        Object.defineProperty(this, 'namedItem', {
-            value: (...args) => {
-                const findNamedItem = this._nodeList.namedItem.apply(this._nodeList, args);
 
-                return findNamedItem && isShadowUIElement(findNamedItem) ? null : findNamedItem;
-            }
-        });
+        if (this.namedItem) {
+            Object.defineProperty(this, 'namedItem', {
+                value: (...args) => {
+                    const findNamedItem = this._nodeList.namedItem.apply(this._nodeList, args);
+
+                    return findNamedItem && isShadowUIElement(findNamedItem) ? null : findNamedItem;
+                }
+            });
+        }
+
         Object.defineProperty(this, '_nodeList', { value: nodeList });
         Object.defineProperty(this, '_filteredNodeList', { writable: true });
         Object.defineProperty(this, '_isDirty', { writable: true, value: true });

--- a/test/client/fixtures/sandbox/node/live-node-list-factory-test.js
+++ b/test/client/fixtures/sandbox/node/live-node-list-factory-test.js
@@ -72,7 +72,8 @@ module('getElementsByTagName', function () {
         root.appendChild(form3);
 
         var elements           = document.body.getElementsByTagName('form');
-        var nativeNodeListType = nativeMethods.getElementsByTagName.call(document, 'form').constructor;
+        var nativeNodeList     = nativeMethods.getElementsByTagName.call(document, 'form');
+        var nativeNodeListType = nativeNodeList.constructor;
 
         ok(elements instanceof nativeNodeListType);
         strictEqual(elements.length, 1);
@@ -84,8 +85,11 @@ module('getElementsByTagName', function () {
         strictEqual(elements[1], form2);
         strictEqual(elements.item(0), form1);
         strictEqual(elements.item(1), form2);
-        strictEqual(elements.namedItem(form1.id), form1);
-        strictEqual(elements.namedItem(form3.id), null);
+
+        if (nativeNodeList.namedItem) {
+            strictEqual(elements.namedItem(form1.id), form1);
+            strictEqual(elements.namedItem(form3.id), null);
+        }
     });
 
     module('performance', function () {

--- a/test/client/fixtures/sandbox/node/live-node-list-factory-test.js
+++ b/test/client/fixtures/sandbox/node/live-node-list-factory-test.js
@@ -72,8 +72,7 @@ module('getElementsByTagName', function () {
         root.appendChild(form3);
 
         var elements           = document.body.getElementsByTagName('form');
-        var nativeNodeList     = nativeMethods.getElementsByTagName.call(document, 'form');
-        var nativeNodeListType = nativeNodeList.constructor;
+        var nativeNodeListType = nativeMethods.getElementsByTagName.call(document, 'form').constructor;
 
         ok(elements instanceof nativeNodeListType);
         strictEqual(elements.length, 1);
@@ -86,7 +85,7 @@ module('getElementsByTagName', function () {
         strictEqual(elements.item(0), form1);
         strictEqual(elements.item(1), form2);
 
-        if (nativeNodeList.namedItem) {
+        if (elements.namedItem) {
             strictEqual(elements.namedItem(form1.id), form1);
             strictEqual(elements.namedItem(form3.id), null);
         }

--- a/test/client/fixtures/sandbox/node/live-node-list-factory-test.js
+++ b/test/client/fixtures/sandbox/node/live-node-list-factory-test.js
@@ -84,11 +84,8 @@ module('getElementsByTagName', function () {
         strictEqual(elements[1], form2);
         strictEqual(elements.item(0), form1);
         strictEqual(elements.item(1), form2);
-
-        if (elements.namedItem) {
-            strictEqual(elements.namedItem(form1.id), form1);
-            strictEqual(elements.namedItem(form3.id), null);
-        }
+        strictEqual(elements.namedItem(form1.id), form1);
+        strictEqual(elements.namedItem(form3.id), null);
     });
 
     module('performance', function () {

--- a/test/client/fixtures/sandbox/shadow-ui-test.js
+++ b/test/client/fixtures/sandbox/shadow-ui-test.js
@@ -821,4 +821,11 @@ test('processed nodeList should have non-enumerable "item" and "namedItem" prope
 
     strictEqual(collectionKeys.indexOf('item'), -1, 'item');
     strictEqual(collectionKeys.indexOf('namedItem'), -1, 'namedItem');
+
+    collection     = document.getElementsByTagName('div');
+    collectionKeys = Object.keys(collection);
+
+    strictEqual(collectionKeys.indexOf('item'), -1, 'item');
+    strictEqual(collectionKeys.indexOf('namedItem'), -1, 'namedItem');
+    strictEqual(collectionKeys.indexOf('length'), -1, 'length');
 });


### PR DESCRIPTION
@churkin @LavrovArtem 

We filter shadow ui elements using `Array` (`getElementsByClassName`, `querySelector`, `querySelectorAll`) and `LiveNodeListWrapper` (`getElementsByTagName`).
For array-based filtering we are hiding `item' and `namedItem` methods from enumeration.
See https://github.com/DevExpress/testcafe-hammerhead/commit/a3f16bcb201503ac5e053222d5dc6d3c2794ee99

We need do same for `LiveNodeListWrapper`-based filtering.