### PR TITLE
fix 'Code instrumentation for 'document.activeElement' should work properly if it equals null' (close #1226)

### DIFF
--- a/src/client/sandbox/code-instrumentation/properties/index.js
+++ b/src/client/sandbox/code-instrumentation/properties/index.js
@@ -147,7 +147,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
                 condition: domUtils.isDocument,
 
                 get: el => {
-                    if (domUtils.isShadowUIElement(el.activeElement))
+                    if (el.activeElement && domUtils.isShadowUIElement(el.activeElement))
                         return this.shadowUI.getLastActiveElement() || el.body;
 
                     return el.activeElement;

--- a/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
@@ -573,3 +573,29 @@ test('we should not process element\'s properties if they do not exist (GH-1164)
         strictEqual(getProperty(svg, property), svgHasProperty ? style : void 0, property);
     });
 });
+
+test('document.activeElement when it equals null (GH-1226)', function () {
+    expect(1);
+
+    var div      = document.createElement('div');
+    var innerDiv = document.createElement('div');
+
+    div.id            = 'div';
+    innerDiv.id       = 'innerDiv';
+    innerDiv.tabIndex = 0;
+    div.appendChild(innerDiv);
+    document.body.appendChild(div);
+    innerDiv.focus();
+    setProperty(div, 'innerHTML', '<span>Replaced</span>');
+
+    try {
+        var instrumentedValue = getProperty(document, 'activeElement');
+
+        strictEqual(instrumentedValue, document.activeElement);
+    }
+    catch (err) {
+        ok(false);
+    }
+
+    div.parentNode.removeChild(div);
+});


### PR DESCRIPTION
@churkin @LavrovArtem 
It is bug related with ReportServer tests.