### PR TITLE
drop support of 0.10, 0.12 node (tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
  include:
    - node_js: "stable"
      env: GULP_TASK="test-server"
-   - node_js: "0.10"
+   - node_js: "4"
      env: GULP_TASK="test-server"
    - node_js: "stable"
      env: GULP_TASK="test-client-travis"

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,20 +1,20 @@
-var babel        = require('babel-core');
-var gulpBabel    = require('gulp-babel');
-var del          = require('del');
-var eslint       = require('gulp-eslint');
-var fs           = require('fs');
-var gulp         = require('gulp');
-var qunitHarness = require('gulp-qunit-harness');
-var mocha        = require('gulp-mocha');
-var mustache     = require('gulp-mustache');
-var rename       = require('gulp-rename');
-var webmake      = require('gulp-webmake');
-var Promise      = require('pinkie');
-var uglify       = require('gulp-uglify');
-var gulpif       = require('gulp-if');
-var util         = require('gulp-util');
-var ll           = require('gulp-ll');
-var path         = require('path');
+const babel        = require('babel-core');
+const gulpBabel    = require('gulp-babel');
+const del          = require('del');
+const eslint       = require('gulp-eslint');
+const fs           = require('fs');
+const gulp         = require('gulp');
+const qunitHarness = require('gulp-qunit-harness');
+const mocha        = require('gulp-mocha');
+const mustache     = require('gulp-mustache');
+const rename       = require('gulp-rename');
+const webmake      = require('gulp-webmake');
+const Promise      = require('pinkie');
+const uglify       = require('gulp-uglify');
+const gulpif       = require('gulp-if');
+const util         = require('gulp-util');
+const ll           = require('gulp-ll');
+const path         = require('path');
 
 ll
     .tasks('lint')
@@ -23,7 +23,7 @@ ll
         'client-scripts-bundle'
     ]);
 
-var CLIENT_TESTS_SETTINGS = {
+const CLIENT_TESTS_SETTINGS = {
     basePath:        './test/client/fixtures',
     port:            2000,
     crossDomainPort: 2001,
@@ -35,7 +35,7 @@ var CLIENT_TESTS_SETTINGS = {
     configApp: require('./test/client/config-qunit-server-app')
 };
 
-var CLIENT_TESTS_BROWSERS = [
+const CLIENT_TESTS_BROWSERS = [
     {
         platform:    'Windows 10',
         browserName: 'MicrosoftEdge'
@@ -96,7 +96,7 @@ var CLIENT_TESTS_BROWSERS = [
     }
 ];
 
-var SAUCELABS_SETTINGS = {
+const SAUCELABS_SETTINGS = {
     username:  process.env.SAUCE_USERNAME,
     accessKey: process.env.SAUCE_ACCESS_KEY,
     build:     process.env.TRAVIS_JOB_ID || '',
@@ -107,23 +107,23 @@ var SAUCELABS_SETTINGS = {
 };
 
 function hang () {
-    return new Promise(function () {
+    return new Promise(() => {
         // NOTE: Hang forever.
     });
 }
 
 // Build
-gulp.task('clean', function (cb) {
+gulp.task('clean', cb => {
     del(['./lib'], cb);
 });
 
-gulp.task('templates', ['clean'], function () {
+gulp.task('templates', ['clean'], () => {
     return gulp
         .src('./src/client/task.js.mustache', { silent: false })
         .pipe(gulp.dest('./lib/client'));
 });
 
-gulp.task('client-scripts', ['client-scripts-bundle'], function () {
+gulp.task('client-scripts', ['client-scripts-bundle'], () => {
     return gulp.src('./src/client/index.js.wrapper.mustache')
         .pipe(mustache({ source: fs.readFileSync('./lib/client/hammerhead.js').toString() }))
         .pipe(rename('hammerhead.js'))
@@ -131,12 +131,12 @@ gulp.task('client-scripts', ['client-scripts-bundle'], function () {
         .pipe(gulp.dest('./lib/client'));
 });
 
-gulp.task('client-scripts-bundle', ['clean'], function () {
+gulp.task('client-scripts-bundle', ['clean'], () => {
     return gulp.src('./src/client/index.js')
         .pipe(webmake({
             sourceMap: false,
-            transform: function (filename, code) {
-                var transformed = babel.transform(code, {
+            transform: (filename, code) => {
+                const transformed = babel.transform(code, {
                     sourceMap: false,
                     filename:  filename,
                     ast:       false,
@@ -156,13 +156,13 @@ gulp.task('client-scripts-bundle', ['clean'], function () {
         .pipe(gulp.dest('./lib/client'));
 });
 
-gulp.task('server-scripts', ['clean'], function () {
+gulp.task('server-scripts', ['clean'], () => {
     return gulp.src(['./src/**/*.js', '!./src/client/**/*.js'])
         .pipe(gulpBabel())
         .pipe(gulp.dest('lib/'));
 });
 
-gulp.task('lint', function () {
+gulp.task('lint', () => {
     return gulp
         .src([
             './src/**/*.js',
@@ -179,7 +179,7 @@ gulp.task('build', ['client-scripts', 'server-scripts', 'templates', 'lint']);
 
 
 // Test
-gulp.task('test-server', ['build'], function () {
+gulp.task('test-server', ['build'], () => {
     return gulp.src('./test/server/*-test.js', { read: false })
         .pipe(mocha({
             ui:        'bdd',
@@ -190,7 +190,7 @@ gulp.task('test-server', ['build'], function () {
         }));
 });
 
-gulp.task('test-client', ['build'], function () {
+gulp.task('test-client', ['build'], () => {
     gulp.watch('./src/**', ['build']);
 
     return gulp
@@ -198,13 +198,13 @@ gulp.task('test-client', ['build'], function () {
         .pipe(qunitHarness(CLIENT_TESTS_SETTINGS));
 });
 
-gulp.task('test-client-travis', ['build'], function () {
+gulp.task('test-client-travis', ['build'], () => {
     return gulp
         .src('./test/client/fixtures/**/*-test.js')
         .pipe(qunitHarness(CLIENT_TESTS_SETTINGS, SAUCELABS_SETTINGS));
 });
 
-gulp.task('playground', ['set-dev-mode', 'build'], function () {
+gulp.task('playground', ['set-dev-mode', 'build'], () => {
     require('./test/playground/server.js').start();
 
     return hang();

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,9 +1,9 @@
 {
    "compact": false,
-   "presets": [
-     "es2015-hammerhead",
-     "babel-preset-stage-2"
-   ],
+  "presets": [
+    "es2015-hammerhead",
+    "babel-preset-stage-2"
+  ],
    "plugins": [
      "transform-runtime",
      "add-module-exports"

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,9 +1,9 @@
 {
    "compact": false,
-  "presets": [
-    "es2015-hammerhead",
-    "babel-preset-stage-2"
-  ],
+   "presets": [
+     "es2015-hammerhead",
+     "babel-preset-stage-2"
+   ],
    "plugins": [
      "transform-runtime",
      "add-module-exports"

--- a/test/playground/server.js
+++ b/test/playground/server.js
@@ -17,13 +17,9 @@ function createSession () {
 
     session._getIframePayloadScript = () => '';
     session._getPayloadScript       = () => '';
-    session.getAuthCredentials      = () => {
-        return {};
-    };
-    session.handleFileDownload      = () => {
-    };
-    session.handlePageError         = () => {
-    };
+    session.getAuthCredentials      = () => ({});
+    session.handleFileDownload      = () => void 0;
+    session.handlePageError         = () => void 0;
 
     return session;
 }

--- a/test/playground/server.js
+++ b/test/playground/server.js
@@ -1,44 +1,37 @@
-var express = require('express');
-var http    = require('http');
-var Path    = require('path');
-var process = require('child_process');
+'use strict';
 
-var Proxy   = require('../../lib/proxy');
-var Session = require('../../lib/session');
+const express = require('express');
+const http    = require('http');
+const Path    = require('path');
+const process = require('child_process');
 
-//Const
-var PROXY_PORT_1 = 1401;
-var PROXY_PORT_2 = 1402;
-var SERVER_PORT  = 1400;
+const Proxy   = require('../../lib/proxy');
+const Session = require('../../lib/session');
+
+const PROXY_PORT_1 = 1401;
+const PROXY_PORT_2 = 1402;
+const SERVER_PORT  = 1400;
 
 function createSession () {
-    var session = new Session('test/playground/upload-storage');
+    const session = new Session('test/playground/upload-storage');
 
-    session._getIframePayloadScript = function () {
-        return '';
-    };
-
-    session._getPayloadScript = function () {
-        return '';
-    };
-
-    session.getAuthCredentials = function () {
+    session._getIframePayloadScript = () => '';
+    session._getPayloadScript       = () => '';
+    session.getAuthCredentials      = () => {
         return {};
     };
-
-    session.handleFileDownload = function () {
+    session.handleFileDownload      = () => {
     };
-
-    session.handlePageError = function () {
+    session.handlePageError         = () => {
     };
 
     return session;
 }
 
-exports.start = function () {
-    var app       = express();
-    var proxy     = new Proxy('localhost', PROXY_PORT_1, PROXY_PORT_2);
-    var appServer = http.createServer(app);
+exports.start = () => {
+    const app       = express();
+    const proxy     = new Proxy('localhost', PROXY_PORT_1, PROXY_PORT_2);
+    const appServer = http.createServer(app);
 
     app
         .use(express.bodyParser())
@@ -46,12 +39,12 @@ exports.start = function () {
         .set('view options', { layout: false })
         .set('views', Path.join(__dirname, './views'));
 
-    app.get('*', function (req, res) {
+    app.get('*', (req, res) => {
         res.render('index');
     });
 
-    app.post('*', function (req, res) {
-        var url = req.param('url');
+    app.post('*', (req, res) => {
+        let url = req.param('url');
 
         if (!url) {
             res.status(403);
@@ -59,7 +52,7 @@ exports.start = function () {
         }
         else {
             if (url.indexOf('file://') !== 0 && url.indexOf('http://') !== 0 && url.indexOf('https://') !== 0) {
-                var matches = url.match(/^([A-Za-z]:)?(\/|\\)/);
+                const matches = url.match(/^([A-Za-z]:)?(\/|\\)/);
 
                 if (matches && matches[0].length === 1)
                     url = 'file://' + url;

--- a/test/server/.eslintrc
+++ b/test/server/.eslintrc
@@ -1,7 +1,8 @@
 {
   "rules": {
     "max-nested-callbacks": 0,
-    "no-unused-expressions": 0
+    "no-unused-expressions": 0,
+    "no-var": 2
   },
   "env": {
     "mocha": true

--- a/test/server/auth-test.js
+++ b/test/server/auth-test.js
@@ -17,7 +17,7 @@ describe('Authentication', () => {
         session = new Session();
 
         session.getAuthCredentials = () => null;
-        session.handleFileDownload = () => {};
+        session.handleFileDownload = () => void 0;
 
         proxy = new Proxy('127.0.0.1', 1836, 1837);
     });

--- a/test/server/auth-test.js
+++ b/test/server/auth-test.js
@@ -1,56 +1,49 @@
-var expect       = require('chai').expect;
-var express      = require('express');
-var ntlm         = require('express-ntlm');
-var auth         = require('basic-auth');
-var request      = require('request');
-var Proxy        = require('../../lib/proxy');
-var Session      = require('../../lib/session');
-var requestAgent = require('../../lib/request-pipeline/destination-request/agent');
+'use strict';
 
-describe('Authentication', function () {
-    var proxy   = null;
-    var session = null;
+const expect       = require('chai').expect;
+const express      = require('express');
+const ntlm         = require('express-ntlm');
+const auth         = require('basic-auth');
+const request      = require('request');
+const Proxy        = require('../../lib/proxy');
+const Session      = require('../../lib/session');
+const requestAgent = require('../../lib/request-pipeline/destination-request/agent');
 
-    beforeEach(function () {
+describe('Authentication', () => {
+    let proxy   = null;
+    let session = null;
+
+    beforeEach(() => {
         session = new Session();
 
-        session.getAuthCredentials = function () {
-            return null;
-        };
-
-        session.handleFileDownload = function () {
-        };
+        session.getAuthCredentials = () => null;
+        session.handleFileDownload = () => {};
 
         proxy = new Proxy('127.0.0.1', 1836, 1837);
     });
 
-    afterEach(function () {
+    afterEach(() => {
         proxy.close();
         requestAgent.resetKeepAliveConnections();
     });
 
-    describe('NTLM Authentication', function () {
-        var ntlmServer = null;
+    describe('NTLM Authentication', () => {
+        let ntlmServer = null;
 
-        before(function () {
-            var app = express();
+        before(() => {
+            const app = express();
 
             app.use(ntlm());
 
-            app.all('*', function (req, res) {
-                res.end(JSON.stringify(req.ntlm));
-            });
+            app.all('*', (req, res) => res.end(JSON.stringify(req.ntlm)));
 
             ntlmServer = app.listen(1506);
         });
 
-        after(function () {
-            ntlmServer.close();
-        });
+        after(() => ntlmServer.close());
 
-
-        it('Should authorize with correct credentials', function (done) {
-            session.getAuthCredentials = function () {
+        it('Should authorize with correct credentials', done => {
+            session.getAuthCredentials = () => {
                 return {
                     username:    'username',
                     password:    'password',
@@ -59,8 +52,8 @@ describe('Authentication', function () {
                 };
             };
 
-            request(proxy.openSession('http://127.0.0.1:1506/', session), function (err, res, body) {
-                var parsedBody = JSON.parse(body);
+            request(proxy.openSession('http://127.0.0.1:1506/', session), (err, res, body) => {
+                const parsedBody = JSON.parse(body);
 
                 expect(res.statusCode).eql(200);
                 expect(parsedBody.UserName).equal('username');
@@ -72,14 +65,14 @@ describe('Authentication', function () {
         });
     });
 
-    describe('Basic Authentication', function () {
-        var basicServer = null;
+    describe('Basic Authentication', () => {
+        let basicServer = null;
 
-        before(function () {
-            var app = express();
+        before(() => {
+            const app = express();
 
-            app.all('*', function (req, res) {
-                var credentials = auth(req);
+            app.all('*', (req, res) => {
+                const credentials = auth(req);
 
                 if (!credentials || credentials.name !== 'username' || credentials.pass !== 'password') {
                     res.statusCode = 401;
@@ -95,19 +88,17 @@ describe('Authentication', function () {
             basicServer = app.listen(1507);
         });
 
-        after(function () {
-            basicServer.close();
-        });
+        after(() => basicServer.close());
 
-        it('Should authorize with correct credentials', function (done) {
-            session.getAuthCredentials = function () {
+        it('Should authorize with correct credentials', done => {
+            session.getAuthCredentials = () => {
                 return {
                     username: 'username',
                     password: 'password'
                 };
             };
 
-            request(proxy.openSession('http://127.0.0.1:1507/', session), function (err, res, body) {
+            request(proxy.openSession('http://127.0.0.1:1507/', session), (err, res, body) => {
                 expect(body).equal('Access granted');
                 expect(res.statusCode).equal(200);
 
@@ -115,15 +106,15 @@ describe('Authentication', function () {
             });
         });
 
-        it('Should not authorize with incorrect credentials', function (done) {
-            session.getAuthCredentials = function () {
+        it('Should not authorize with incorrect credentials', done => {
+            session.getAuthCredentials = () => {
                 return {
                     username: 'username',
                     password: 'invalidPassword'
                 };
             };
 
-            request(proxy.openSession('http://127.0.0.1:1507/', session), function (err, res, body) {
+            request(proxy.openSession('http://127.0.0.1:1507/', session), (err, res, body) => {
                 expect(body).equal('Access denied');
                 expect(res.statusCode).equal(401);
                 // NOTE: prevent showing the native credentials window.

--- a/test/server/content-type-test.js
+++ b/test/server/content-type-test.js
@@ -1,8 +1,10 @@
-var contentTypeUtils = require('../../lib/utils/content-type');
-var expect           = require('chai').expect;
+'use strict';
 
-it('Should detect scripts', function () {
-    var checkScript = function (contentType, accept) {
+const contentTypeUtils = require('../../lib/utils/content-type');
+const expect           = require('chai').expect;
+
+it('Should detect scripts', () => {
+    const checkScript = (contentType, accept) => {
         expect(contentTypeUtils.isScriptResource(contentType, accept)).to.be.true;
     };
 
@@ -41,16 +43,16 @@ it('Should detect scripts', function () {
     checkScript('text/plain', 'text/x-javascript');
 });
 
-it('Should detect css', function () {
+it('Should detect css', () => {
     expect(contentTypeUtils.isCSSResource('TEXT/CSS', '*/*')).to.be.true;
     expect(contentTypeUtils.isCSSResource('', 'TEXT/CSS')).to.be.true;
 });
 
-it('Should detect manifest', function () {
+it('Should detect manifest', () => {
     expect(contentTypeUtils.isManifest('text/CACHE-manifest')).to.be.true;
 });
 
-it('Should detect page', function () {
+it('Should detect page', () => {
     expect(contentTypeUtils.isPage('TEXT/HTML')).to.be.true;
     expect(contentTypeUtils.isPage('application/xhtml+xml')).to.be.true;
     expect(contentTypeUtils.isPage('application/xml')).to.be.true;

--- a/test/server/encoding-test.js
+++ b/test/server/encoding-test.js
@@ -1,25 +1,25 @@
-var expect        = require('chai').expect;
-var Promise       = require('pinkie');
-var encodeContent = require('../../lib/processing/encoding').encodeContent;
-var decodeContent = require('../../lib/processing/encoding').decodeContent;
-var Charset       = require('../../lib/processing/encoding/charset');
+'use strict';
 
-describe('Content encoding', function () {
-    var src = new Buffer('Answer to the Ultimate Question of Life, the Universe, and Everything.');
+const expect        = require('chai').expect;
+const Promise       = require('pinkie');
+const encodeContent = require('../../lib/processing/encoding').encodeContent;
+const decodeContent = require('../../lib/processing/encoding').decodeContent;
+const Charset       = require('../../lib/processing/encoding/charset');
 
-    it('Should encode and decode content', function () {
-        this.timeout(4000);
+describe('Content encoding', () => {
+    const src = new Buffer('Answer to the Ultimate Question of Life, the Universe, and Everything.');
 
+    it('Should encode and decode content', () => {
         function testConfiguration (encoding, charsetStr) {
-            var charset = new Charset();
+            const charset = new Charset();
 
             charset.set(charsetStr, 2);
 
             return encodeContent(src, encoding, charset)
-                .then(function (encoded) {
+                .then(encoded => {
                     return decodeContent(encoded, encoding, charset);
                 })
-                .then(function (decoded) {
+                .then(decoded => {
                     expect(decoded).eql(src.toString());
                 });
         }
@@ -32,11 +32,11 @@ describe('Content encoding', function () {
             testConfiguration(null, 'iso-8859-1'),
             testConfiguration('br', 'utf8')
         ]);
-    });
+    }).timeout(5000);
 
-    it('Should handle decoding errors', function () {
+    it('Should handle decoding errors', () => {
         return decodeContent(src, 'deflate', 'utf-8')
-            .catch(function (err) {
+            .catch(err => {
                 expect(err).to.be.an('object');
             });
     });

--- a/test/server/external-proxy-test.js
+++ b/test/server/external-proxy-test.js
@@ -41,8 +41,7 @@ describe('External proxy', () => {
         session = new Session();
 
         session.getAuthCredentials = () => null;
-        session.handleFileDownload = () => {
-        };
+        session.handleFileDownload = () => void 0;
 
         proxy = new Proxy('127.0.0.1', 1836, 1837);
 

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -329,8 +329,7 @@ describe('Proxy', () => {
         session = new Session();
 
         session.getAuthCredentials = () => null;
-        session.handleFileDownload = () => {
-        };
+        session.handleFileDownload = () => void 0;
 
         proxy = new Proxy('127.0.0.1', 1836, 1837);
     });

--- a/test/server/router-test.js
+++ b/test/server/router-test.js
@@ -1,36 +1,38 @@
-var expect = require('chai').expect;
-var Router = require('../../lib/proxy/router');
-var md5    = require('crypto-md5');
+'use strict';
 
-describe('Router', function () {
+const expect = require('chai').expect;
+const Router = require('../../lib/proxy/router');
+const md5    = require('crypto-md5');
+
+describe('Router', () => {
     function noop () {
     }
 
-    it('Should route requests', function () {
-        var router          = new Router();
-        var calledHandlerId = null;
-        var routeParams     = null;
+    it('Should route requests', () => {
+        const router        = new Router();
+        let calledHandlerId = null;
+        let routeParams     = null;
 
         router._processStaticContent = noop;
 
-        router.GET('/yo/42/test/', function () {
+        router.GET('/yo/42/test/', () => {
             calledHandlerId = 'get';
         });
 
-        router.POST('/yo/42/test/', function () {
+        router.POST('/yo/42/test/', () => {
             calledHandlerId = 'post';
         });
 
-        router.GET('/42/hammerhead', function () {
+        router.GET('/42/hammerhead', () => {
             calledHandlerId = 'no-trailing-slash';
         });
 
-        router.GET('/yo/{param1}/{param2}', function (req, res, serverInfo, params) {
+        router.GET('/yo/{param1}/{param2}', (req, res, serverInfo, params) => {
             calledHandlerId = 'get-with-params';
             routeParams     = params;
         });
 
-        router.POST('/yo/{param1}/{param2}', function (req, res, serverInfo, params) {
+        router.POST('/yo/{param1}/{param2}', (req, res, serverInfo, params) => {
             calledHandlerId = 'post-with-params';
             routeParams     = params;
         });
@@ -74,13 +76,13 @@ describe('Router', function () {
         shouldNotRoute('/some/unknown/url', 'GET', 'no-trailing-slash');
     });
 
-    it('Should provide headers and content for static resources if ETag not match', function () {
-        var router = new Router();
+    it('Should provide headers and content for static resources if ETag not match', () => {
+        const router = new Router();
 
         router._processStaticContent = noop;
 
         function testRoute (url, handler) {
-            var reqMock = {
+            const reqMock = {
                 url:     url,
                 method:  'GET',
                 headers: {
@@ -88,7 +90,7 @@ describe('Router', function () {
                 }
             };
 
-            var resMock = {
+            const resMock = {
                 headers:    {},
                 content:    null,
                 statusCode: null,
@@ -109,12 +111,12 @@ describe('Router', function () {
             expect(resMock.headers['cache-control']).eql('max-age=30, must-revalidate');
         }
 
-        var jsHandler = {
+        const jsHandler = {
             contentType: 'application/x-javascript',
             content:     'js'
         };
 
-        var cssHandler = {
+        const cssHandler = {
             contentType: 'text/css',
             content:     'css'
         };
@@ -126,12 +128,12 @@ describe('Router', function () {
         testRoute('/some/static/css', cssHandler);
     });
 
-    it('Should respond 304 for static resources if ETag match', function () {
-        var router = new Router();
+    it('Should respond 304 for static resources if ETag match', () => {
+        const router = new Router();
 
         router._processStaticContent = noop;
 
-        var reqMock = {
+        const reqMock = {
             url:     '/some/static/js',
             method:  'GET',
             headers: {
@@ -139,7 +141,7 @@ describe('Router', function () {
             }
         };
 
-        var resMock = {
+        const resMock = {
             headers:    {},
             content:    null,
             statusCode: null,

--- a/test/server/script-processor-test.js
+++ b/test/server/script-processor-test.js
@@ -1,13 +1,15 @@
-var expect                          = require('chai').expect;
-var multiline                       = require('multiline');
-var processScript                   = require('../../lib/processing/script').processScript;
-var isScriptProcessed               = require('../../lib/processing/script').isScriptProcessed;
-var HEADER                          = require('../../lib/processing/script/header').HEADER;
-var SCRIPT_PROCESSING_START_COMMENT = require('../../lib/processing/script/header').SCRIPT_PROCESSING_START_COMMENT;
-var INSTRUMENTED_PROPERTIES         = require('../../lib/processing/script/instrumented').PROPERTIES;
+'use strict';
+
+const expect                          = require('chai').expect;
+const multiline                       = require('multiline');
+const processScript                   = require('../../lib/processing/script').processScript;
+const isScriptProcessed               = require('../../lib/processing/script').isScriptProcessed;
+const HEADER                          = require('../../lib/processing/script/header').HEADER;
+const SCRIPT_PROCESSING_START_COMMENT = require('../../lib/processing/script/header').SCRIPT_PROCESSING_START_COMMENT;
+const INSTRUMENTED_PROPERTIES         = require('../../lib/processing/script/instrumented').PROPERTIES;
 
 
-var ACORN_UNICODE_PATCH_WARNING = multiline(function () {/*
+const ACORN_UNICODE_PATCH_WARNING = multiline(function () {/*
  ATTENTION! If this test fails, this may happen because you have updated acorn.
  We have patched acorn to enable it to work with unicode identifiers.
 
@@ -32,7 +34,7 @@ var ACORN_UNICODE_PATCH_WARNING = multiline(function () {/*
 */
 });
 
-var ACORN_STRICT_MODE_PATCH_WARNING = multiline(function () {/*
+const ACORN_STRICT_MODE_PATCH_WARNING = multiline(function () {/*
  ATTENTION! If this test fails, this may happen because you have updated acorn.
  We have patched acorn to enable it to work with ES6 syntax in strict mode.
 
@@ -54,7 +56,7 @@ var ACORN_STRICT_MODE_PATCH_WARNING = multiline(function () {/*
 */
 });
 
-var ESOTOPE_RAW_LITERAL_PATCH_WARNING = multiline(function () {/*
+const ESOTOPE_RAW_LITERAL_PATCH_WARNING = multiline(function () {/*
  ATTENTION! If this test fails, this may happen because you have updated esotope.
  We have patched esotope to enable it to work with raw literals without additional parsing.
 
@@ -85,13 +87,13 @@ function normalizeCode (code) {
 function testProcessing (testCases) {
     testCases = Array.isArray(testCases) ? testCases : [testCases];
 
-    testCases.forEach(function (testCase) {
-        var processed = processScript(testCase.src, false);
-        var actual    = normalizeCode(processed);
-        var expected  = normalizeCode(testCase.expected);
-        var msg       = 'Source: ' + testCase.src + '\n' +
-                        'Result: ' + processed + '\n' +
-                        'Expected: ' + testCase.expected + '\n';
+    testCases.forEach(testCase => {
+        const processed = processScript(testCase.src, false);
+        const actual    = normalizeCode(processed);
+        const expected  = normalizeCode(testCase.expected);
+        let msg         = 'Source: ' + testCase.src + '\n' +
+                          'Result: ' + processed + '\n' +
+                          'Expected: ' + testCase.expected + '\n';
 
         if (testCase.msg)
             msg += '\n\n' + testCase.msg;
@@ -101,8 +103,8 @@ function testProcessing (testCases) {
 }
 
 function testPropertyProcessing (templates) {
-    INSTRUMENTED_PROPERTIES.forEach(function (propName) {
-        var testCases = templates.map(function (template) {
+    INSTRUMENTED_PROPERTIES.forEach(propName => {
+        const testCases = templates.map(template => {
             return {
                 src:      template.src.replace(/\{0\}/g, propName),
                 expected: template.expected.replace(/\{0\}/g, propName)
@@ -114,18 +116,18 @@ function testPropertyProcessing (templates) {
 }
 
 function assertHasHeader (expected, testCases) {
-    testCases.forEach(function (src) {
-        var processed = processScript(src, true);
-        var hasHeader = processed.indexOf(HEADER) > -1;
-        var msg       = 'Source: ' + src + '\n';
+    testCases.forEach(src => {
+        const processed = processScript(src, true);
+        const hasHeader = processed.indexOf(HEADER) > -1;
+        const msg       = 'Source: ' + src + '\n';
 
         expect(hasHeader).eql(expected, msg);
     });
 }
 
-describe('Script processor', function () {
-    describe('Processing header', function () {
-        it('Should add processing header', function () {
+describe('Script processor', () => {
+    describe('Processing header', () => {
+        it('Should add processing header', () => {
             assertHasHeader(true, [
                 'var a = 42;',
                 '[]; var a = 42; []',
@@ -133,41 +135,41 @@ describe('Script processor', function () {
             ]);
         });
 
-        it('Should not add processing header for the data script', function () {
+        it('Should not add processing header for the data script', () => {
             assertHasHeader(false, [
                 '[1, 2, 3]',
                 '{ a: 42 }'
             ]);
         });
 
-        it('Should not add processing header twice', function () {
-            var src        = 'var a = 42;';
-            var processed1 = processScript(src, true);
-            var processed2 = processScript(processed1, true);
+        it('Should not add processing header twice', () => {
+            const src        = 'var a = 42;';
+            const processed1 = processScript(src, true);
+            const processed2 = processScript(processed1, true);
 
             expect(normalizeCode(processed1)).eql(normalizeCode(processed2));
         });
     });
 
-    it('Should determine if script was processed', function () {
-        var src       = '//comment\n var temp = 0; \n var host = location.host; \n temp = 1; \n // comment';
-        var processed = processScript(src, false);
+    it('Should determine if script was processed', () => {
+        const src       = '//comment\n var temp = 0; \n var host = location.host; \n temp = 1; \n // comment';
+        const processed = processScript(src, false);
 
         expect(isScriptProcessed(src)).to.be.false;
         expect(isScriptProcessed(processed)).to.be.true;
     });
 
-    it('Should add the strict mode directive before the script header', function () {
-        var src       = '/*comment*/\n' +
-                        '"use strict";\n' +
-                        'location.host = "host";';
-        var processed = processScript(src, true);
+    it('Should add the strict mode directive before the script header', () => {
+        const src       = '/*comment*/\n' +
+                          '"use strict";\n' +
+                          'location.host = "host";';
+        const processed = processScript(src, true);
 
         expect(isScriptProcessed(processed)).to.be.true;
         expect(processed.indexOf(SCRIPT_PROCESSING_START_COMMENT + '"use strict";')).eql(0);
     });
 
-    it('Should process location getters and setters', function () {
+    it('Should process location getters and setters', () => {
         testProcessing([
             { src: 'var location = value', expected: 'var location = value' },
             {
@@ -299,20 +301,20 @@ describe('Script processor', function () {
         ]);
     });
 
-    it('Should expand concat operator', function () {
+    it('Should expand concat operator', () => {
         testProcessing([
             { src: 'prop += 1', expected: 'prop = prop + 1' },
             { src: 'prop += 2 + prop + 1', expected: 'prop = prop + (2 + prop + 1)' }
         ]);
     });
 
-    it('Should add a space before the replacement string', function () {
-        var processed = processScript('if(true){;}else"0"[s]', false);
+    it('Should add a space before the replacement string', () => {
+        const processed = processScript('if(true){;}else"0"[s]', false);
 
         expect(processed).eql('if(true){;}else __get$("0",s)');
     });
 
-    it('Should process a "new" expression if its body contains processed nodes', function () {
+    it('Should process a "new" expression if its body contains processed nodes', () => {
         testPropertyProcessing([
             { src: 'new a.{0}.b()', expected: 'new (__get$(a,"{0}")).b()' },
             {
@@ -332,7 +334,7 @@ describe('Script processor', function () {
         ]);
     });
 
-    it('Should process properties', function () {
+    it('Should process properties', () => {
         testPropertyProcessing([
             { src: 'switch(s){case a.{0}:b.{0}}', expected: 'switch(s){case __get$(a,"{0}"): __get$(b,"{0}")}' },
             { src: 'function {0}(){}', expected: 'function {0}(){}' },
@@ -384,7 +386,7 @@ describe('Script processor', function () {
         ]);
     });
 
-    it('Should process computed properties', function () {
+    it('Should process computed properties', () => {
         testPropertyProcessing([
             { src: 'var temp = "location"; obj[t]', expected: 'var temp = "location";__get$(obj, t)' },
             {
@@ -413,14 +415,14 @@ describe('Script processor', function () {
         ]);
     });
 
-    it('Should process object expressions', function () {
+    it('Should process object expressions', () => {
         testProcessing({
             src:      '{ location: value, value: location, src: src }',
             expected: '{ location: value, value: __get$Loc(location), src: src }'
         });
     });
 
-    it('Should keep raw literals', function () {
+    it('Should keep raw literals', () => {
         testProcessing({
             src:      'obj["\\u003c/script>"]=location',
             expected: 'obj["\\u003c/script>"]=__get$Loc(location)',
@@ -428,7 +430,7 @@ describe('Script processor', function () {
         });
     });
 
-    it('Should process eval()', function () {
+    it('Should process eval()', () => {
         testProcessing([
             { src: 'eval(script)', expected: 'eval(__proc$Script(script))' },
             { src: 'eval("script")', expected: 'eval(__proc$Script("script"))' },
@@ -518,7 +520,7 @@ describe('Script processor', function () {
         ]);
     });
 
-    it('Should process postMessage', function () {
+    it('Should process postMessage', () => {
         testProcessing([
             { src: 'window.postMessage("", "")', expected: '__call$(window, "postMessage", ["", ""])' },
             { src: 'window["postMessage"]("", "")', expected: '__call$(window, "postMessage", ["", ""])' },
@@ -626,7 +628,7 @@ describe('Script processor', function () {
         ]);
     });
 
-    it('Should process storages', function () {
+    it('Should process storages', () => {
         testProcessing([
             {
                 src:      'function localStorage(){}; function sessionStorage() {};',
@@ -683,7 +685,7 @@ describe('Script processor', function () {
         ]);
     });
 
-    it('Should process for..in iteration', function () {
+    it('Should process for..in iteration', () => {
         testProcessing([
             { src: 'for(obj.prop in src){}', expected: 'for(var __set$temp in src){obj.prop = __set$temp;}' },
             { src: 'for(obj["prop"] in src){}', expected: 'for(var __set$temp in src){obj["prop"] = __set$temp;}' },
@@ -696,7 +698,7 @@ describe('Script processor', function () {
         ]);
     });
 
-    it('Should keep unicode identifiers', function () {
+    it('Should keep unicode identifiers', () => {
         testProcessing({
             src:      '({\\u00c0:"value"})[value]',
             expected: '__get$({\\u00c0:"value"}, value)',
@@ -704,7 +706,7 @@ describe('Script processor', function () {
         });
     });
 
-    it('Should allow ES6 syntax in strict mode', function () {
+    it('Should allow ES6 syntax in strict mode', () => {
         testProcessing([
             {
                 src:      '"use strict";var let=0;obj.src;',
@@ -719,7 +721,7 @@ describe('Script processor', function () {
         ]);
     });
 
-    it('Should ignore HTML comments', function () {
+    it('Should ignore HTML comments', () => {
         testProcessing([
             { src: 'a[i];\n<!-- comment -->', expected: '__get$(a, i);' },
             { src: '<!-- comment -->\n a[i];', expected: '__get$(a, i);' },
@@ -734,22 +736,22 @@ describe('Script processor', function () {
         ]);
     });
 
-    describe('Regression', function () {
-        it('Should leave comments unchanged (T170848)', function () {
+    describe('Regression', () => {
+        it('Should leave comments unchanged (T170848)', () => {
             testProcessing({
                 src:      'function test(){ \n /* \n line1 \n line2 \n line3 \n */ } a.src=function(){};',
                 expected: 'function test(){ \n /* \n line1 \n line2 \n line3 \n */ } __set$(a,"src",function(){});'
             });
         });
 
-        it('Should process content in block statement (T209250)', function () {
+        it('Should process content in block statement (T209250)', () => {
             testProcessing({
                 src:      '{ (function() { a.src = "success"; })(); }',
                 expected: '{ (function() { __set$(a, "src", "success"); })(); }'
             });
         });
 
-        it('Should keep script content inside HTML comments (T226589)', function () {
+        it('Should keep script content inside HTML comments (T226589)', () => {
             testProcessing({
                 src: 'document.writeln("<!--test123-->");\n' +
                      '<!--Begin -->\n' +
@@ -780,7 +782,7 @@ describe('Script processor', function () {
             });
         });
 
-        it('Should handle malformed HTML comments (T239244)', function () {
+        it('Should handle malformed HTML comments (T239244)', () => {
             testProcessing({
                 src: '<!-- rai_mm_tools -->\n' +
                      '<!--\n' +
@@ -796,7 +798,7 @@ describe('Script processor', function () {
             });
         });
 
-        it('Should handle malformed closing HTML comments (health monitor)', function () {
+        it('Should handle malformed closing HTML comments (health monitor)', () => {
             testProcessing([
                 {
                     src: '<!--\n' +
@@ -815,7 +817,7 @@ describe('Script processor', function () {
             ]);
         });
 
-        it('Should keep line after open HTML comments (health monitor)', function () {
+        it('Should keep line after open HTML comments (health monitor)', () => {
             testProcessing({
                 src: '<!--\n' +
                      'var rdm0 = "";\n' +
@@ -830,8 +832,8 @@ describe('Script processor', function () {
             });
         });
 
-        it('Should not throw parser exceptions', function () {
-            var testParser = function (scriptStr) {
+        it('Should not throw parser exceptions', () => {
+            const testParser = function (scriptStr) {
                 scriptStr += '\nx.src';
 
                 expect(processScript(scriptStr, false).indexOf('x.src') === -1).equal(true);
@@ -841,7 +843,7 @@ describe('Script processor', function () {
             testParser('function s(){do var x = 9; while(false)return}'); // GH-567
         });
 
-        it('Should process the content in the conditional function declaration', function () {
+        it('Should process the content in the conditional function declaration', () => {
             testProcessing({
                 src:      'function foo() { if(true) function bar() { obj.src; } }',
                 expected: 'function foo() { if(true) function bar() { __get$(obj, "src"); } }'

--- a/test/server/upload-test.js
+++ b/test/server/upload-test.js
@@ -1,18 +1,20 @@
-var fs            = require('fs');
-var express       = require('express');
-var request       = require('request');
-var expect        = require('chai').expect;
-var tmp           = require('tmp');
-var mime          = require('mime');
-var path          = require('path');
-var upload        = require('../../lib/upload');
-var FormData      = require('../../lib/upload/form-data');
-var UploadStorage = require('../../lib/upload/storage');
+'use strict';
 
-var BOUNDARY     = 'separator';
-var CONTENT_TYPE = 'multipart/form-data; boundary=' + BOUNDARY;
+const fs            = require('fs');
+const express       = require('express');
+const request       = require('request');
+const expect        = require('chai').expect;
+const tmp           = require('tmp');
+const mime          = require('mime');
+const path          = require('path');
+const upload        = require('../../lib/upload');
+const FormData      = require('../../lib/upload/form-data');
+const UploadStorage = require('../../lib/upload/storage');
 
-var dataFiles = [
+const BOUNDARY     = 'separator';
+const CONTENT_TYPE = 'multipart/form-data; boundary=' + BOUNDARY;
+
+const dataFiles = [
     'empty',
     'empty-with-separator',
     'empty-with-separator-and-newline',
@@ -26,8 +28,8 @@ var dataFiles = [
     'empty-headers'
 ];
 
-var data = dataFiles.reduce(function (dataFile, filename) {
-    var content = fs.readFileSync('test/server/data/form-data/' + filename + '.formdata');
+const data = dataFiles.reduce((dataFile, filename) => {
+    const content = fs.readFileSync('test/server/data/form-data/' + filename + '.formdata');
 
     // NOTE: Force \r\n new lines.
     dataFile[filename] = newLineReplacer(content);
@@ -40,7 +42,7 @@ function newLineReplacer (content) {
 }
 
 function initFormData (name) {
-    var formData = new FormData();
+    const formData = new FormData();
 
     formData.parseContentTypeHeader(CONTENT_TYPE);
     formData.parseBody(data[name]);
@@ -48,27 +50,27 @@ function initFormData (name) {
     return formData;
 }
 
-describe('Upload', function () {
-    describe('Form data parsing', function () {
-        it('Should parse empty form data', function () {
-            var cases = [
+describe('Upload', () => {
+    describe('Form data parsing', () => {
+        it('Should parse empty form data', () => {
+            const cases = [
                 'empty',
                 'empty-with-separator',
                 'empty-with-separator-and-newline'
             ];
 
-            cases.forEach(function (item) {
-                var formData = initFormData(item);
+            cases.forEach(item => {
+                const formData = initFormData(item);
 
                 expect(formData.entries).to.be.empty;
                 expect(formData.preamble).to.be.empty;
             });
         });
 
-        it('Should parse filename', function () {
-            var formData = initFormData('filename-name');
-            var entry    = formData.entries[0];
-            var body     = Buffer.concat(entry.body).toString();
+        it('Should parse filename', () => {
+            const formData = initFormData('filename-name');
+            const entry    = formData.entries[0];
+            const body     = Buffer.concat(entry.body).toString();
 
             expect(entry.name).eql('upload');
             expect(entry.fileName).eql('plain.txt');
@@ -76,12 +78,12 @@ describe('Upload', function () {
             expect(body).eql('I am a plain text file\r\n');
         });
 
-        it('Should parse filename with special characters', function () {
-            var formData = initFormData('special-chars-in-file-name');
-            var entry0   = formData.entries[0];
-            var body0    = Buffer.concat(entry0.body).toString();
-            var entry1   = formData.entries[1];
-            var body1    = Buffer.concat(entry1.body).toString();
+        it('Should parse filename with special characters', () => {
+            const formData = initFormData('special-chars-in-file-name');
+            const entry0   = formData.entries[0];
+            const body0    = Buffer.concat(entry0.body).toString();
+            const entry1   = formData.entries[1];
+            const body1    = Buffer.concat(entry1.body).toString();
 
 
             expect(entry0.name).eql('title');
@@ -93,10 +95,10 @@ describe('Upload', function () {
             expect(body1).eql('I am a text file with a funky name!\r\n');
         });
 
-        it('Should parse empty filename', function () {
-            var formData = initFormData('filename-no-name');
-            var entry    = formData.entries[0];
-            var body     = Buffer.concat(entry.body).toString();
+        it('Should parse empty filename', () => {
+            const formData = initFormData('filename-no-name');
+            const entry    = formData.entries[0];
+            const body     = Buffer.concat(entry.body).toString();
 
             expect(entry.name).eql('upload');
             expect(entry.fileName).to.be.empty;
@@ -104,10 +106,10 @@ describe('Upload', function () {
             expect(body).eql('I am a plain text file\r\n');
         });
 
-        it('Should parse preamble', function () {
-            var formData = initFormData('preamble-string');
-            var entry    = formData.entries[0];
-            var body     = Buffer.concat(entry.body).toString();
+        it('Should parse preamble', () => {
+            const formData = initFormData('preamble-string');
+            const entry    = formData.entries[0];
+            const body     = Buffer.concat(entry.body).toString();
 
             expect(formData.preamble).to.have.length(1);
             expect(formData.preamble[0].toString()).eql('This is a preamble which should be ignored');
@@ -117,10 +119,10 @@ describe('Upload', function () {
             expect(body).eql('I am a plain text file\r\n');
         });
 
-        it('Should parse new line preamble', function () {
-            var formData = initFormData('preamble-newline');
-            var entry    = formData.entries[0];
-            var body     = Buffer.concat(entry.body).toString();
+        it('Should parse new line preamble', () => {
+            const formData = initFormData('preamble-newline');
+            const entry    = formData.entries[0];
+            const body     = Buffer.concat(entry.body).toString();
 
             expect(formData.preamble).to.have.length(1);
             expect(formData.preamble[0].toString()).to.be.empty;
@@ -130,10 +132,10 @@ describe('Upload', function () {
             expect(body).eql('I am a plain text file\r\n');
         });
 
-        it('Should parse epilogue', function () {
-            var formData = initFormData('epilogue-string');
-            var entry    = formData.entries[0];
-            var body     = Buffer.concat(entry.body).toString();
+        it('Should parse epilogue', () => {
+            const formData = initFormData('epilogue-string');
+            const entry    = formData.entries[0];
+            const body     = Buffer.concat(entry.body).toString();
 
             expect(formData.epilogue).to.have.length(1);
             expect(formData.epilogue[0].toString()).eql('This is a epilogue which should be ignored');
@@ -143,10 +145,10 @@ describe('Upload', function () {
             expect(body).eql('I am a plain text file\r\n');
         });
 
-        it('Should parse if separator misses trailing hyphens', function () {
-            var formData = initFormData('missing-hyphens');
-            var entry    = formData.entries[0];
-            var body     = Buffer.concat(entry.body).toString();
+        it('Should parse if separator misses trailing hyphens', () => {
+            const formData = initFormData('missing-hyphens');
+            const entry    = formData.entries[0];
+            const body     = Buffer.concat(entry.body).toString();
 
             expect(entry.name).eql('upload');
             expect(entry.fileName).eql('plain.txt');
@@ -154,10 +156,10 @@ describe('Upload', function () {
             expect(body).eql('I am a plain text file\r\n');
         });
 
-        it('Should parse empty headers', function () {
-            var formData = initFormData('empty-headers');
-            var entry    = formData.entries[0];
-            var body     = Buffer.concat(entry.body).toString();
+        it('Should parse empty headers', () => {
+            const formData = initFormData('empty-headers');
+            const entry    = formData.entries[0];
+            const body     = Buffer.concat(entry.body).toString();
 
             expect(entry.name).to.be.not.ok;
             expect(entry.fileName).to.be.not.ok;
@@ -168,32 +170,32 @@ describe('Upload', function () {
 
     });
 
-    describe('Form data formatting', function () {
-        it('Should format malformed data', function () {
-            var cases = [
+    describe('Form data formatting', () => {
+        it('Should format malformed data', () => {
+            const cases = [
                 { src: 'empty', expected: '--' + BOUNDARY + '--\r\n' },
                 { src: 'empty-with-separator', expected: '--' + BOUNDARY + '--\r\n' },
                 { src: 'empty-with-separator-and-newline', expected: '--' + BOUNDARY + '--\r\n' },
                 { src: 'missing-hyphens', expected: data['missing-hyphens'].toString() + '--\r\n' }
             ];
 
-            cases.forEach(function (testCase) {
-                var formData = initFormData(testCase.src);
+            cases.forEach(testCase => {
+                const formData = initFormData(testCase.src);
 
                 expect(formData.toBuffer().toString()).eql(testCase.expected);
             });
         });
 
-        it('Should format data with missing headers', function () {
-            var formData = initFormData('empty-headers');
-            var actual   = formData.toBuffer().toString().replace(/ /g, '');
-            var expected = data['empty-headers'].toString().replace(/ /g, '');
+        it('Should format data with missing headers', () => {
+            const formData = initFormData('empty-headers');
+            const actual   = formData.toBuffer().toString().replace(/ /g, '');
+            const expected = data['empty-headers'].toString().replace(/ /g, '');
 
             expect(actual).eql(expected);
         });
 
-        it('Should format form data', function () {
-            var cases = [
+        it('Should format form data', () => {
+            const cases = [
                 'filename-name',
                 'filename-no-name',
                 'preamble-newline',
@@ -202,33 +204,31 @@ describe('Upload', function () {
                 'special-chars-in-file-name'
             ];
 
-            cases.forEach(function (dataName) {
-                var formData = initFormData(dataName);
-                var actual   = formData.toBuffer().toString();
-                var expected = data[dataName].toString();
+            cases.forEach(dataName => {
+                const formData = initFormData(dataName);
+                const actual   = formData.toBuffer().toString();
+                const expected = data[dataName].toString();
 
                 expect(actual).eql(expected);
             });
         });
     });
 
-    describe('IE9 FileReader shim', function () {
-        var server = null;
+    describe('IE9 FileReader shim', () => {
+        let server = null;
 
-        before(function () {
-            var app = express();
+        before(() => {
+            const app = express();
 
             app.post('/ie9-file-reader-shim', upload.ie9FileReaderShim);
 
             server = app.listen(2000);
         });
 
-        after(function () {
-            server.close();
-        });
+        after(() => server.close());
 
-        it('Should provide file information', function (done) {
-            var options = {
+        it('Should provide file information', done => {
+            const options = {
                 method:  'POST',
                 url:     'http://localhost:2000/ie9-file-reader-shim?filename=plain.txt&input-name=upload',
                 body:    data['epilogue-string'],
@@ -237,9 +237,9 @@ describe('Upload', function () {
                 }
             };
 
-            request(options, function (err, res, body) {
-                var file         = JSON.parse(body);
-                var expectedBody = 'I am a plain text file\r\n';
+            request(options, (err, res, body) => {
+                const file         = JSON.parse(body);
+                const expectedBody = 'I am a plain text file\r\n';
 
                 expect(res.headers['content-type']).to.be.undefined;
                 expect(new Buffer(file.data, 'base64').toString()).eql(expectedBody);
@@ -252,17 +252,15 @@ describe('Upload', function () {
         });
     });
 
-    describe('Upload storage', function () {
-        var SRC_PATH  = 'test/server/data/upload/';
-        var tmpDirObj = null;
+    describe('Upload storage', () => {
+        const SRC_PATH = 'test/server/data/upload/';
+        let tmpDirObj  = null;
 
-        beforeEach(function () {
+        beforeEach(() => {
             tmpDirObj = tmp.dirSync();
         });
 
-        afterEach(function () {
-            tmpDirObj.removeCallback();
-        });
+        afterEach(() => tmpDirObj.removeCallback());
 
         function getStoredFilePath (fileName) {
             return path.resolve(path.join(tmpDirObj.name, fileName));
@@ -292,21 +290,21 @@ describe('Upload', function () {
             expect(fileInfo.info.lastModifiedDate).eql(fs.statSync(filePath).mtime);
         }
 
-        it('Should store and get file', function () {
-            var storage = new UploadStorage(tmpDirObj.name);
+        it('Should store and get file', () => {
+            const storage = new UploadStorage(tmpDirObj.name);
 
-            var srcFilePath    = getSrcFilePath('file-to-upload.txt');
-            var storedFilePath = getStoredFilePath('file-to-upload.txt');
+            const srcFilePath    = getSrcFilePath('file-to-upload.txt');
+            const storedFilePath = getStoredFilePath('file-to-upload.txt');
 
             return storage
                 .store(['file-to-upload.txt'], [fs.readFileSync(srcFilePath)])
-                .then(function (result) {
+                .then(result => {
                     expect(result).to.be.null;
                     assertFileExistence(storedFilePath);
                     assertFileContentsIdentical(storedFilePath, srcFilePath);
 
                     return storage.get(['file-to-upload.txt']);
-                }).then(function (result) {
+                }).then(result => {
                     expect(result.length).eql(1);
                     assetCorrectFileInfo(result[0], 'file-to-upload.txt', storedFilePath);
 
@@ -314,37 +312,37 @@ describe('Upload', function () {
                 });
         });
 
-        it('Should return an error if storing or getting is impossible', function () {
-            var storage        = new UploadStorage('this/path/will/not/exist/ever/');
-            var storedFilePath = path.resolve(path.join('this/path/will/not/exist/ever/', 'file-to-upload.txt'));
-            var filePath       = getSrcFilePath('file-to-upload.txt');
+        it('Should return an error if storing or getting is impossible', () => {
+            const storage        = new UploadStorage('this/path/will/not/exist/ever/');
+            const storedFilePath = path.resolve(path.join('this/path/will/not/exist/ever/', 'file-to-upload.txt'));
+            const filePath       = getSrcFilePath('file-to-upload.txt');
 
             return storage
                 .store(['file-to-upload.txt'], [filePath])
-                .then(function (result) {
+                .then(result => {
                     expect(result.length).eql(1);
                     assertCorrectErr(result[0], storedFilePath);
 
                     return storage.get(['file-to-upload.txt']);
                 })
-                .then(function (result) {
+                .then(result => {
                     expect(result.length).eql(1);
                     assertCorrectErr(result[0], storedFilePath);
                 });
         });
 
-        it('Should store and get multiple files', function () {
-            var storage = new UploadStorage(tmpDirObj.name);
+        it('Should store and get multiple files', () => {
+            const storage = new UploadStorage(tmpDirObj.name);
 
-            var file1Path        = getSrcFilePath('expected.formdata');
-            var file2Path        = getSrcFilePath('src.formdata');
-            var fakeFilePath     = getStoredFilePath('fake-file.txt');
-            var file1StoragePath = getStoredFilePath('expected.formdata');
-            var file2StoragePath = getStoredFilePath('src.formdata');
+            const file1Path        = getSrcFilePath('expected.formdata');
+            const file2Path        = getSrcFilePath('src.formdata');
+            const fakeFilePath     = getStoredFilePath('fake-file.txt');
+            const file1StoragePath = getStoredFilePath('expected.formdata');
+            const file2StoragePath = getStoredFilePath('src.formdata');
 
             return storage
                 .store(['expected.formdata', 'src.formdata'], [fs.readFileSync(file1Path), fs.readFileSync(file2Path)])
-                .then(function (result) {
+                .then(result => {
                     expect(result).to.be.null;
                     assertFileExistence(file1StoragePath);
                     assertFileExistence(file2StoragePath);
@@ -353,7 +351,7 @@ describe('Upload', function () {
 
                     return storage.get(['expected.formdata', 'src.formdata', 'fake-file.txt']);
                 })
-                .then(function (result) {
+                .then(result => {
                     expect(result.length).eql(3);
                     assetCorrectFileInfo(result[0], 'expected.formdata', file1StoragePath);
                     assetCorrectFileInfo(result[1], 'src.formdata', file2StoragePath);
@@ -365,18 +363,18 @@ describe('Upload', function () {
         });
     });
 
-    it('Should inject uploads', function () {
-        var src      = newLineReplacer(fs.readFileSync('test/server/data/upload/src.formdata'));
-        var expected = newLineReplacer(fs.readFileSync('test/server/data/upload/expected.formdata'));
-        var actual   = upload.inject(CONTENT_TYPE, src);
+    it('Should inject uploads', () => {
+        const src      = newLineReplacer(fs.readFileSync('test/server/data/upload/src.formdata'));
+        const expected = newLineReplacer(fs.readFileSync('test/server/data/upload/expected.formdata'));
+        const actual   = upload.inject(CONTENT_TYPE, src);
 
         expect(actual.toString()).eql(expected.toString());
     });
 
-    it('Should remove only the information about hidden input (GH-395)', function () {
-        var src      = newLineReplacer(fs.readFileSync('test/server/data/upload/empty-file-info-src.formdata'));
-        var expected = newLineReplacer(fs.readFileSync('test/server/data/upload/empty-file-info-expected.formdata'));
-        var actual   = upload.inject(CONTENT_TYPE, src);
+    it('Should remove only the information about hidden input (GH-395)', () => {
+        const src      = newLineReplacer(fs.readFileSync('test/server/data/upload/empty-file-info-src.formdata'));
+        const expected = newLineReplacer(fs.readFileSync('test/server/data/upload/empty-file-info-expected.formdata'));
+        const actual   = upload.inject(CONTENT_TYPE, src);
 
         expect(actual.toString()).eql(expected.toString());
     });

--- a/test/server/windows-domain-test.js
+++ b/test/server/windows-domain-test.js
@@ -1,14 +1,16 @@
-var OS            = require('os-family');
-var expect        = require('chai').expect;
-var windowsDomain = require('../../lib/request-pipeline/destination-request/windows-domain');
+'use strict';
 
-describe('Windows domain', function () {
+const OS            = require('os-family');
+const expect        = require('chai').expect;
+const windowsDomain = require('../../lib/request-pipeline/destination-request/windows-domain');
+
+describe('Windows domain', () => {
     if (OS.win) {
-        it('Should assign windows domain and workstation to credentials', function () {
-            var credentials = {};
+        it('Should assign windows domain and workstation to credentials', () => {
+            const credentials = {};
 
             return windowsDomain.assign(credentials)
-                .then(function () {
+                .then(() => {
                     expect(credentials.domain).to.be.a('string');
                     expect(credentials.workstation).to.be.a('string');
                 });


### PR DESCRIPTION
@LavrovArtem 
Changes:
- [travis] move up `test-server`  task to the node 4.x
- rewrite server tests, playground and `gulpfile.js` using es6 syntax