### PR TITLE
fix vulnerabilitiy (https://nodesecurity.io/advisories/525)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "pinkie": "1.0.0",
     "read-file-relative": "^1.2.0",
     "shortid": "^2.2.4",
-    "tough-cookie": "2.3.0",
+    "tough-cookie": "2.3.3",
     "tunnel-agent": "0.6.0",
     "webauth": "^1.1.0",
     "yakaa": "1.0.1",


### PR DESCRIPTION
I cannot publish hammerhead with vulnerabilities in dependencies.
https://github.com/DevExpress/testcafe-hammerhead/blob/30786b4766ad81f900979a9e72a51cb3f4117e6f/.publishrc#L3