### PR TITLE
fix memory leaks (part 1)

### DIFF
--- a/src/client/sandbox/code-instrumentation/properties/anchor.js
+++ b/src/client/sandbox/code-instrumentation/properties/anchor.js
@@ -1,8 +1,8 @@
 import { parseProxyUrl } from '../../../utils/url';
 import nativeMethods from '../../native-methods';
 
-const anchor      = nativeMethods.createElement.call(document, 'a');
-const emptyAnchor = nativeMethods.createElement.call(document, 'a');
+let anchor      = nativeMethods.createElement.call(document, 'a');
+let emptyAnchor = nativeMethods.createElement.call(document, 'a');
 
 export function getAnchorProperty (el, prop) {
     if (el.href) {
@@ -28,4 +28,9 @@ export function setAnchorProperty (el, prop, value) {
     }
 
     return '';
+}
+
+export function dispose () {
+    anchor      = null;
+    emptyAnchor = null;
 }

--- a/src/client/sandbox/index.js
+++ b/src/client/sandbox/index.js
@@ -20,6 +20,8 @@ import StorageSandbox from './storages';
 import ElectronSandbox from './electron';
 import ConsoleSandbox from './console';
 import { isIE, isWebKit, isElectron } from '../utils/browser';
+import { dispose as htmlUtilDispose } from '../utils/html';
+import { dispose as anchorCodeInstumentationDispose } from './code-instrumentation/properties/anchor';
 import { create as createSandboxBackup, get as getSandboxBackup } from './backup';
 import urlResolver from '../utils/url-resolver';
 import * as windowStorage from './windows-storage';
@@ -51,6 +53,7 @@ export default class Sandbox extends SandboxBase {
         this.codeInstrumentation = new CodeInstrumentation(nodeMutation, this.event, this.cookie, this.upload, this.shadowUI, this.storageSandbox);
         this.node                = new NodeSandbox(nodeMutation, this.iframe, this.event, this.upload, this.shadowUI);
         this.console             = new ConsoleSandbox(messageSandbox);
+        this.unload              = unloadSandbox;
 
         if (isElectron)
             this.electron = new ElectronSandbox();
@@ -203,5 +206,16 @@ export default class Sandbox extends SandboxBase {
 
         if (this.electron)
             this.electron.attach(window);
+
+        this.unload.on(this.unload.UNLOAD_EVENT, () => this.dispose());
+    }
+
+    dispose () {
+        this.event.hover.lastHoveredElement     = null;
+        this.event.focusBlur.lastFocusedElement = null;
+
+        htmlUtilDispose();
+        anchorCodeInstumentationDispose();
+        urlResolver.dispose(this.document);
     }
 }

--- a/src/client/sandbox/index.js
+++ b/src/client/sandbox/index.js
@@ -217,5 +217,6 @@ export default class Sandbox extends SandboxBase {
         htmlUtilDispose();
         anchorCodeInstumentationDispose();
         urlResolver.dispose(this.document);
+        this.storageSandbox.dispose();
     }
 }

--- a/src/client/sandbox/storages/index.js
+++ b/src/client/sandbox/storages/index.js
@@ -134,9 +134,10 @@ export default class StorageSandbox extends SandboxBase {
     dispose () {
         const topSameDomainWindow = getTopSameDomainWindow(this.window);
 
-        if (this.window === topSameDomainWindow) {
-            // this.localStorage.dispose();
-            // this.sessionStorage.dispose();
+        // NOTE: For removed iframe without src in IE11 window.top equals iframe's window
+        if (this.window === topSameDomainWindow && !topSameDomainWindow.frameElement) {
+            this.localStorage.dispose();
+            this.sessionStorage.dispose();
         }
         else {
             delete this.localStorage;

--- a/src/client/sandbox/storages/index.js
+++ b/src/client/sandbox/storages/index.js
@@ -135,8 +135,12 @@ export default class StorageSandbox extends SandboxBase {
         const topSameDomainWindow = getTopSameDomainWindow(this.window);
 
         if (this.window === topSameDomainWindow) {
-            this.localStorage.dispose();
-            this.sessionStorage.dispose();
+            // this.localStorage.dispose();
+            // this.sessionStorage.dispose();
+        }
+        else {
+            delete this.localStorage;
+            delete this.sessionStorage;
         }
     }
 }

--- a/src/client/sandbox/storages/index.js
+++ b/src/client/sandbox/storages/index.js
@@ -116,8 +116,8 @@ export default class StorageSandbox extends SandboxBase {
 
         this._createStorageWrappers();
 
-        this.localStorage.on(this.localStorage.STORAGE_CHANGED_EVENT, e => this._simulateStorageEventIfNecessary(e, this.localStorage));
-        this.sessionStorage.on(this.sessionStorage.STORAGE_CHANGED_EVENT, e => this._simulateStorageEventIfNecessary(e, this.sessionStorage));
+        this.onLocalStorageChangeListener = this.localStorage.on(this.localStorage.STORAGE_CHANGED_EVENT, e => this._simulateStorageEventIfNecessary(e, this.localStorage));
+        this.onSessionStorageListener     = this.sessionStorage.on(this.sessionStorage.STORAGE_CHANGED_EVENT, e => this._simulateStorageEventIfNecessary(e, this.sessionStorage));
 
         this.listeners.initElementListening(window, ['storage']);
         this.listeners.addInternalEventListener(window, ['storage'], (e, dispatched, preventEvent) => {
@@ -129,16 +129,15 @@ export default class StorageSandbox extends SandboxBase {
     }
 
     dispose () {
+        this.localStorage.off(this.localStorage.STORAGE_CHANGED_EVENT, this.onLocalStorageChangeListener);
+        this.sessionStorage.off(this.sessionStorage.STORAGE_CHANGED_EVENT, this.onSessionStorageListener);
+
         const topSameDomainWindow = getTopSameDomainWindow(this.window);
 
         // NOTE: For removed iframe without src in IE11 window.top equals iframe's window
         if (this.window === topSameDomainWindow && !topSameDomainWindow.frameElement) {
             this.localStorage.dispose();
             this.sessionStorage.dispose();
-        }
-        else {
-            delete this.localStorage;
-            delete this.sessionStorage;
         }
     }
 }

--- a/src/client/sandbox/storages/index.js
+++ b/src/client/sandbox/storages/index.js
@@ -130,4 +130,13 @@ export default class StorageSandbox extends SandboxBase {
 
         this._overrideStorageEvent();
     }
+
+    dispose () {
+        const topSameDomainWindow = getTopSameDomainWindow(this.window);
+
+        if (this.window === topSameDomainWindow) {
+            this.localStorage.dispose();
+            this.sessionStorage.dispose();
+        }
+    }
 }

--- a/src/client/sandbox/storages/index.js
+++ b/src/client/sandbox/storages/index.js
@@ -112,7 +112,7 @@ export default class StorageSandbox extends SandboxBase {
         this._createStorageWrappers();
 
         const storageChanged = (key, oldValue, newValue, url, storage) => {
-            if (storage.getContext() !== this.window)
+            if (storage && storage.getContext() !== this.window)
                 this._simulateStorageEvent(key, oldValue, newValue, url, storage);
         };
 

--- a/src/client/sandbox/storages/index.js
+++ b/src/client/sandbox/storages/index.js
@@ -21,15 +21,13 @@ export default class StorageSandbox extends SandboxBase {
         this.isLocked       = false;
     }
 
-    _simulateStorageEvent (eventData) {
-        if (!this.isDeactivated())
-            this.eventSimulator.storage(this.window, eventData);
-    }
-
     _simulateStorageEventIfNecessary (event, storageArea) {
+        if (this.isDeactivated())
+            return;
+
         if (storageArea && storageArea.getContext() !== this.window) {
             event.storageArea = storageArea;
-            this._simulateStorageEvent(event);
+            this.eventSimulator.storage(this.window, event);
         }
     }
 

--- a/src/client/sandbox/storages/wrapper.js
+++ b/src/client/sandbox/storages/wrapper.js
@@ -23,6 +23,7 @@ export default class StorageWrapper {
     constructor (window, nativeStorage, nativeStorageKey) {
         this.eventEmitter      = new EventEmitter();
         this.on                = (ev, handler) => this.eventEmitter.on(ev, handler);
+        this.off               = (ev, handler) => this.eventEmitter.off(ev, handler);
         this.emit              = (ev, e) => this.eventEmitter.emit(ev, e);
         this.nativeStorage     = nativeStorage;
         this.nativeStorageKey  = nativeStorageKey;

--- a/src/client/sandbox/storages/wrapper.js
+++ b/src/client/sandbox/storages/wrapper.js
@@ -30,6 +30,7 @@ export default function StorageWrapper (window, nativeStorage, nativeStorageKey)
     this.initialProperties = [];
     this.wrapperMethods    = [];
     this.context           = window;
+    this.intervalId        = null;
 
     this.STORAGE_CHANGED_EVENT = 'hammerhead|event|storage-changed';
     this.EMPTY_OLD_VALUE_ARG   = isIE ? '' : null;
@@ -122,7 +123,7 @@ export default function StorageWrapper (window, nativeStorage, nativeStorageKey)
         loadStorage();
         this.lastState = this.getCurrentState();
 
-        window.setInterval(() => checkStorageChanged(), 10);
+        this.intervalId = nativeMethods.setInterval.call(this.window, () => checkStorageChanged(), 10);
     };
 
     this.setContext = context => {

--- a/src/client/sandbox/storages/wrapper.js
+++ b/src/client/sandbox/storages/wrapper.js
@@ -159,6 +159,10 @@ export default class StorageWrapper {
             this.lastState = this.getCurrentState();
         };
 
+        this.dispose = () => {
+            nativeMethods.clearInterval.call(this.window, this.intervalId);
+        };
+
         const castToString = value => {
             // NOTE: The browser automatically translates the key and the value to a string. To repeat this behavior,
             // we use native storage:

--- a/src/client/sandbox/storages/wrapper.js
+++ b/src/client/sandbox/storages/wrapper.js
@@ -19,220 +19,223 @@ function getWrapperMethods () {
     return methods;
 }
 
-export default function StorageWrapper (window, nativeStorage, nativeStorageKey) {
-    this.eventEmitter      = new EventEmitter();
-    this.on                = (ev, handler) => this.eventEmitter.on(ev, handler);
-    this.emit              = (ev, e) => this.eventEmitter.emit(ev, e);
-    this.nativeStorage     = nativeStorage;
-    this.nativeStorageKey  = nativeStorageKey;
-    this.lastState         = null;
-    this.window            = window;
-    this.initialProperties = [];
-    this.wrapperMethods    = [];
-    this.context           = window;
-    this.intervalId        = null;
+export default class StorageWrapper {
+    constructor (window, nativeStorage, nativeStorageKey) {
+        this.eventEmitter      = new EventEmitter();
+        this.on                = (ev, handler) => this.eventEmitter.on(ev, handler);
+        this.emit              = (ev, e) => this.eventEmitter.emit(ev, e);
+        this.nativeStorage     = nativeStorage;
+        this.nativeStorageKey  = nativeStorageKey;
+        this.lastState         = null;
+        this.window            = window;
+        this.initialProperties = [];
+        this.wrapperMethods    = [];
+        this.context           = window;
+        this.intervalId        = null;
 
-    this.STORAGE_CHANGED_EVENT = 'hammerhead|event|storage-changed';
-    this.EMPTY_OLD_VALUE_ARG   = isIE ? '' : null;
+        this.STORAGE_CHANGED_EVENT = 'hammerhead|event|storage-changed';
+        this.EMPTY_OLD_VALUE_ARG   = isIE ? '' : null;
 
-    const getAddedProperties = () => {
-        // NOTE: The standard doesn't regulate the order in which properties are enumerated.
-        // But we rely on the fact that they are enumerated in the order they were created in all the supported browsers.
-        // In this case we cannot use Object.getOwnPropertyNames
-        // because the enumeration order in Android 5.1 is different from all other browsers.
-        const properties = [];
+        const getAddedProperties = () => {
+            // NOTE: The standard doesn't regulate the order in which properties are enumerated.
+            // But we rely on the fact that they are enumerated in the order they were created in all the supported browsers.
+            // In this case we cannot use Object.getOwnPropertyNames
+            // because the enumeration order in Android 5.1 is different from all other browsers.
+            const properties = [];
 
-        for (const property in this) {
-            if (this.hasOwnProperty(property) && this.initialProperties.indexOf(property) === -1)
-                properties.push(property);
-        }
-
-        return properties;
-    };
-
-    nativeMethods.objectDefineProperty.call(window.Object, this, 'length', {
-        get: () => getAddedProperties().length,
-        set: () => void 0
-    });
-
-    const loadStorage = storage => {
-        if (!storage)
-            storage = this.nativeStorage[this.nativeStorageKey];
-
-        storage = JSON.parse(storage || '[[],[]]');
-
-        for (let i = 0; i < storage[KEY].length; i++)
-            this[storage[KEY][i]] = storage[VALUE][i];
-    };
-
-    const raiseStorageChanged = (key, oldValue, newValue) => {
-        let url = null;
-
-        try {
-            const parsedContextUrl = parseProxyUrl(this.context.location.toString());
-
-            url = parsedContextUrl ? parsedContextUrl.destUrl : destLocation.get();
-        }
-        catch (e) {
-            this.context = this.window;
-            url          = destLocation.get();
-        }
-
-        this.emit(this.STORAGE_CHANGED_EVENT, { key, oldValue, newValue, url });
-    };
-
-    const checkStorageChanged = () => {
-        const currentState = this.getCurrentState();
-
-        for (let i = 0; i < this.lastState[KEY].length; i++) {
-            const lastStateKey   = this.lastState[KEY][i];
-            const lastStateValue = this.lastState[VALUE][i];
-
-            const keyIndex = currentState[KEY].indexOf(lastStateKey);
-
-            if (keyIndex !== -1) {
-                if (currentState[VALUE][keyIndex] !== lastStateValue)
-                    raiseStorageChanged(currentState[KEY][keyIndex], lastStateValue, currentState[VALUE][keyIndex]);
-
-                currentState[KEY].splice(keyIndex, 1);
-                currentState[VALUE].splice(keyIndex, 1);
+            for (const property in this) {
+                if (this.hasOwnProperty(property) && this.initialProperties.indexOf(property) === -1)
+                    properties.push(property);
             }
-            else
-                raiseStorageChanged(lastStateKey, lastStateValue, null);
-        }
 
-        for (let j = 0; j < currentState[KEY].length; j++)
-            raiseStorageChanged(currentState[KEY][j], this.EMPTY_OLD_VALUE_ARG, currentState[VALUE][j]);
+            return properties;
+        };
 
-        this.lastState = this.getCurrentState();
-    };
+        nativeMethods.objectDefineProperty.call(window.Object, this, 'length', {
+            get: () => getAddedProperties().length,
+            set: () => void 0
+        });
 
-    const clearStorage = () => {
-        const addedProperties = getAddedProperties();
-        let changed           = false;
+        const loadStorage = storage => {
+            if (!storage)
+                storage = this.nativeStorage[this.nativeStorageKey];
 
-        for (const addedProperty of addedProperties) {
-            delete this[addedProperty];
-            changed = true;
-        }
+            storage = JSON.parse(storage || '[[],[]]');
 
-        return changed;
-    };
+            for (let i = 0; i < storage[KEY].length; i++)
+                this[storage[KEY][i]] = storage[VALUE][i];
+        };
 
-    const init = () => {
-        loadStorage();
-        this.lastState = this.getCurrentState();
+        const raiseStorageChanged = (key, oldValue, newValue) => {
+            let url = null;
 
-        this.intervalId = nativeMethods.setInterval.call(this.window, () => checkStorageChanged(), 10);
-    };
+            try {
+                const parsedContextUrl = parseProxyUrl(this.context.location.toString());
 
-    this.setContext = context => {
-        this.context = context;
-    };
+                url = parsedContextUrl ? parsedContextUrl.destUrl : destLocation.get();
+            }
+            catch (e) {
+                this.context = this.window;
+                url          = destLocation.get();
+            }
 
-    this.getContext = () => this.context;
+            this.emit(this.STORAGE_CHANGED_EVENT, { key, oldValue, newValue, url });
+        };
 
-    this.saveToNativeStorage = () => {
-        const state = JSON.stringify(this.getCurrentState());
+        const checkStorageChanged = () => {
+            const currentState = this.getCurrentState();
 
-        if (this.nativeStorage[this.nativeStorageKey] !== state)
-            this.nativeStorage[this.nativeStorageKey] = state;
-    };
+            for (let i = 0; i < this.lastState[KEY].length; i++) {
+                const lastStateKey   = this.lastState[KEY][i];
+                const lastStateValue = this.lastState[VALUE][i];
 
-    this.getCurrentState = () => {
-        const addedProperties = getAddedProperties();
-        const state           = [[], []];
+                const keyIndex = currentState[KEY].indexOf(lastStateKey);
 
-        for (const addedProperty of addedProperties) {
-            state[KEY].push(addedProperty);
-            state[VALUE].push(this[addedProperty]);
-        }
+                if (keyIndex !== -1) {
+                    if (currentState[VALUE][keyIndex] !== lastStateValue)
+                        raiseStorageChanged(currentState[KEY][keyIndex], lastStateValue, currentState[VALUE][keyIndex]);
 
-        return state;
-    };
+                    currentState[KEY].splice(keyIndex, 1);
+                    currentState[VALUE].splice(keyIndex, 1);
+                }
+                else
+                    raiseStorageChanged(lastStateKey, lastStateValue, null);
+            }
 
-    this.restore = storage => {
-        clearStorage();
-        loadStorage(storage);
+            for (let j = 0; j < currentState[KEY].length; j++)
+                raiseStorageChanged(currentState[KEY][j], this.EMPTY_OLD_VALUE_ARG, currentState[VALUE][j]);
 
-        this.lastState = this.getCurrentState();
-    };
-
-    const castToString = value => {
-        // NOTE: The browser automatically translates the key and the value to a string. To repeat this behavior,
-        // we use native storage:
-        // localStorage.setItem(null, null) equivalently to localStorage.setItem('null', 'null')
-        this.nativeStorage[STORAGES_SANDBOX_TEMP] = value;
-
-        return this.nativeStorage[STORAGES_SANDBOX_TEMP];
-    };
-
-    const getValidKey = key => {
-        const isWrapperMember = this.wrapperMethods.indexOf(key) !== -1 || this.initialProperties.indexOf(key) !== -1;
-
-        key = isWrapperMember ? API_KEY_PREFIX + key : key;
-
-        return castToString(key);
-    };
-
-    // API
-    this.clear = () => {
-        if (clearStorage()) {
-            raiseStorageChanged(null, null, null);
             this.lastState = this.getCurrentState();
-        }
-    };
+        };
 
-    this.getItem = key => {
-        if (arguments.length === 0)
-            throw new TypeError();
+        const clearStorage = () => {
+            const addedProperties = getAddedProperties();
+            let changed           = false;
 
-        key = getValidKey(key);
+            for (const addedProperty of addedProperties) {
+                delete this[addedProperty];
+                changed = true;
+            }
 
-        return this.hasOwnProperty(key) ? this[key] : null;
-    };
+            return changed;
+        };
 
-    this.key = keyNum => {
-        if (keyNum === void 0)
-            throw new TypeError();
+        const init = () => {
+            loadStorage();
+            this.lastState = this.getCurrentState();
 
-        // NOTE: http://w3c-test.org/webstorage/storage_key.html
-        keyNum %= 0x100000000;
+            this.intervalId = nativeMethods.setInterval.call(this.window, () => checkStorageChanged(), 10);
+        };
 
-        const addedProperties = getAddedProperties();
+        this.setContext = context => {
+            this.context = context;
+        };
 
-        return keyNum >= 0 && keyNum < addedProperties.length ? addedProperties[keyNum] : null;
-    };
+        this.getContext = () => this.context;
 
-    this.removeItem = key => {
-        if (arguments.length === 0)
-            throw new TypeError();
+        this.saveToNativeStorage = () => {
+            const state = JSON.stringify(this.getCurrentState());
 
-        key = getValidKey(key);
+            if (this.nativeStorage[this.nativeStorageKey] !== state)
+                this.nativeStorage[this.nativeStorageKey] = state;
+        };
 
-        delete this[key];
-        checkStorageChanged();
-    };
+        this.getCurrentState = () => {
+            const addedProperties = getAddedProperties();
+            const state           = [[], []];
 
-    this.setItem = (key, value) => {
-        if (arguments.length < 2)
-            throw new TypeError();
+            for (const addedProperty of addedProperties) {
+                state[KEY].push(addedProperty);
+                state[VALUE].push(this[addedProperty]);
+            }
 
-        key   = getValidKey(key);
-        value = castToString(value);
+            return state;
+        };
 
-        this[key] = value;
-        checkStorageChanged();
-    };
+        this.restore = storage => {
+            clearStorage();
+            loadStorage(storage);
 
-    // NOTE: Save wrapper properties and methods to be able to distinguish them from
-    // properties that will be created from the outside.
-    /*eslint-disable no-restricted-globals*/
-    this.initialProperties = Object.getOwnPropertyNames(this);
-    /*eslint-enable no-restricted-globals*/
-    this.wrapperMethods    = getWrapperMethods();
+            this.lastState = this.getCurrentState();
+        };
 
-    init();
+        const castToString = value => {
+            // NOTE: The browser automatically translates the key and the value to a string. To repeat this behavior,
+            // we use native storage:
+            // localStorage.setItem(null, null) equivalently to localStorage.setItem('null', 'null')
+            this.nativeStorage[STORAGES_SANDBOX_TEMP] = value;
+
+            return this.nativeStorage[STORAGES_SANDBOX_TEMP];
+        };
+
+        const getValidKey = key => {
+            const isWrapperMember = this.wrapperMethods.indexOf(key) !== -1 || this.initialProperties.indexOf(key) !==
+                                    -1;
+
+            key = isWrapperMember ? API_KEY_PREFIX + key : key;
+
+            return castToString(key);
+        };
+
+        // API
+        this.clear = () => {
+            if (clearStorage()) {
+                raiseStorageChanged(null, null, null);
+                this.lastState = this.getCurrentState();
+            }
+        };
+
+        this.getItem = key => {
+            if (arguments.length === 0)
+                throw new TypeError();
+
+            key = getValidKey(key);
+
+            return this.hasOwnProperty(key) ? this[key] : null;
+        };
+
+        this.key = keyNum => {
+            if (keyNum === void 0)
+                throw new TypeError();
+
+            // NOTE: http://w3c-test.org/webstorage/storage_key.html
+            keyNum %= 0x100000000;
+
+            const addedProperties = getAddedProperties();
+
+            return keyNum >= 0 && keyNum < addedProperties.length ? addedProperties[keyNum] : null;
+        };
+
+        this.removeItem = key => {
+            if (arguments.length === 0)
+                throw new TypeError();
+
+            key = getValidKey(key);
+
+            delete this[key];
+            checkStorageChanged();
+        };
+
+        this.setItem = (key, value) => {
+            if (arguments.length < 2)
+                throw new TypeError();
+
+            key   = getValidKey(key);
+            value = castToString(value);
+
+            this[key] = value;
+            checkStorageChanged();
+        };
+
+        // NOTE: Save wrapper properties and methods to be able to distinguish them from
+        // properties that will be created from the outside.
+        /*eslint-disable no-restricted-globals*/
+        this.initialProperties = Object.getOwnPropertyNames(this);
+        /*eslint-enable no-restricted-globals*/
+        this.wrapperMethods = getWrapperMethods();
+
+        init();
+    }
 }
 
 StorageWrapper.prototype = Storage.prototype;

--- a/src/client/transport.js
+++ b/src/client/transport.js
@@ -68,11 +68,14 @@ class Transport {
 
             const isAsyncRequest = !forced;
             const transport      = this;
-            const request        = XhrSandbox.createNativeXHR();
+            let request          = XhrSandbox.createNativeXHR();
             const msgCallback    = function () {
                 transport.activeServiceMessagesCounter--;
 
-                callback(this.responseText && parseJSON(this.responseText));
+                const response = this.responseText && parseJSON(this.responseText);
+
+                request = null;
+                callback(response);
             };
             const errorHandler   = function () {
                 if (msg.disableResending)

--- a/src/client/utils/event-emitter.js
+++ b/src/client/utils/event-emitter.js
@@ -49,5 +49,7 @@ export default class EventEmitter {
             this.eventsListeners[evt] = [];
 
         this.eventsListeners[evt].push(listener);
+
+        return listener;
     }
 }

--- a/src/client/utils/html.js
+++ b/src/client/utils/html.js
@@ -123,6 +123,8 @@ function processHtmlInternal (html, process) {
 
     let processedHtml = process(container) ? container.innerHTML : html;
 
+    container.parentNode.removeChild(container);
+
     processedHtml = unwrapHtmlText(processedHtml);
 
     // NOTE: hack for IE (GH-1083)
@@ -238,6 +240,11 @@ export function processHtml (html, parentTag, prepareDom) {
 
         return true;
     });
+}
+
+export function dispose () {
+    htmlParser   = null;
+    htmlDocument = null;
 }
 
 function removeExtraSvgNamespeces (html, processedHtml) {

--- a/src/client/utils/url-resolver.js
+++ b/src/client/utils/url-resolver.js
@@ -93,5 +93,9 @@ export default {
         resolver[prop] = value;
 
         return resolver.href;
+    },
+
+    dispose (doc) {
+        doc[DOCUMENT_URL_RESOLVER] = null;
     }
 };

--- a/test/client/fixtures/sandbox/event/unload-test.js
+++ b/test/client/fixtures/sandbox/event/unload-test.js
@@ -22,7 +22,8 @@ asyncTest('BEFORE_UNLOAD_EVENT must be called last (GH-400)', function () {
                 uploadEventCounter++;
             });
 
-            iframeWindow[INSTRUCTION.setProperty](iframeWindow, 'on' + unloadSandbox.beforeUnloadEventName, function () {
+            iframeWindow[INSTRUCTION.setProperty](iframeWindow, 'on' +
+                                                                unloadSandbox.beforeUnloadEventName, function () {
                 uploadEventCounter++;
             });
 
@@ -31,16 +32,21 @@ asyncTest('BEFORE_UNLOAD_EVENT must be called last (GH-400)', function () {
 });
 
 test('UNLOAD_EVENT should be called', function () {
-    var unloadSandbox        = hammerhead.sandbox.event.unload;
-    var unloadEventWasCalled = false;
-    var handler = function () {
+    var unloadSandbox          = hammerhead.sandbox.event.unload;
+    var unloadEventWasCalled   = false;
+    var handler                = function () {
         unloadEventWasCalled = true;
         hammerhead.off(hammerhead.EVENTS.unload, handler);
+    };
+    var storedSandboxDispose   = hammerhead.sandbox.dispose;
+    hammerhead.sandbox.dispose = function () {
     };
 
     hammerhead.on(hammerhead.EVENTS.unload, handler);
     unloadSandbox.emit(unloadSandbox.UNLOAD_EVENT);
     ok(unloadEventWasCalled);
+
+    hammerhead.sandbox.dispose = storedSandboxDispose;
 });
 
 if (browserUtils.isSafari && !browserUtils.isIOS) {

--- a/test/client/fixtures/sandbox/event/unload-test.js
+++ b/test/client/fixtures/sandbox/event/unload-test.js
@@ -22,8 +22,9 @@ asyncTest('BEFORE_UNLOAD_EVENT must be called last (GH-400)', function () {
                 uploadEventCounter++;
             });
 
-            iframeWindow[INSTRUCTION.setProperty](iframeWindow, 'on' +
-                                                                unloadSandbox.beforeUnloadEventName, function () {
+            var beforeUnloadEventName = 'on' + unloadSandbox.beforeUnloadEventName;
+
+            iframeWindow[INSTRUCTION.setProperty](iframeWindow, beforeUnloadEventName, function () {
                 uploadEventCounter++;
             });
 
@@ -32,13 +33,14 @@ asyncTest('BEFORE_UNLOAD_EVENT must be called last (GH-400)', function () {
 });
 
 test('UNLOAD_EVENT should be called', function () {
-    var unloadSandbox          = hammerhead.sandbox.event.unload;
-    var unloadEventWasCalled   = false;
-    var handler                = function () {
+    var unloadSandbox        = hammerhead.sandbox.event.unload;
+    var unloadEventWasCalled = false;
+    var handler              = function () {
         unloadEventWasCalled = true;
         hammerhead.off(hammerhead.EVENTS.unload, handler);
     };
-    var storedSandboxDispose   = hammerhead.sandbox.dispose;
+    var storedSandboxDispose = hammerhead.sandbox.dispose;
+
     hammerhead.sandbox.dispose = function () {
     };
 


### PR DESCRIPTION
Dispose:
- detached DOM nodes
- timers (created by `setInterval` function)
- unused xhr requests
- unused event listeners