### PR TITLE
fix `Hammerhead emit an error "Failed to find a DNS-record for the resource"` (#1384 part 2)

### DIFF
--- a/src/request-pipeline/destination-request/index.js
+++ b/src/request-pipeline/destination-request/index.js
@@ -121,7 +121,11 @@ export default class DestinationRequest extends EventEmitter {
     }
 
     _isSocketHangUpErr (err) {
-        return err.message && SOCKET_HANG_UP_ERR_RE.test(err.message);
+        return err.message && SOCKET_HANG_UP_ERR_RE.test(err.message) &&
+               // NOTE: Only for nodejs 4 error with a same message will be generated for different cases.
+               // This is why, we filter a 'SocketHangUpErr' by stack.
+               // Remove filtering by stack content after ending support of nodejs 4.
+               err.stack && err.stack.indexOf('createHangUpError') !== -1;
     }
 
     _onTimeout () {

--- a/src/request-pipeline/destination-request/index.js
+++ b/src/request-pipeline/destination-request/index.js
@@ -135,7 +135,7 @@ export default class DestinationRequest extends EventEmitter {
         if (this._isSocketHangUpErr(err))
             this.emit('socketHangUp');
 
-        if (requestAgent.shouldRegressHttps(err, this.opts)) {
+        else if (requestAgent.shouldRegressHttps(err, this.opts)) {
             requestAgent.regressHttps(this.opts);
             this._send();
         }

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -1876,7 +1876,7 @@ describe('Proxy', () => {
                 .end();
         });
 
-        it("Should close with error if destination server doesn't provide Access-Control-Allow-Origin header for cross-domain requests", done => {
+        it('Should close with error if destination server doesn`t provide Access-Control-Allow-Origin header for cross-domain requests', done => {
             const options = {
                 url:     proxy.openSession('http://127.0.0.1:2002/without-access-control-allow-origin-header', session),
                 headers: {
@@ -1989,7 +1989,7 @@ describe('Proxy', () => {
             });
         });
 
-        it("Should omit default ports from destination request and 'referrer' header urls (GH-738)", () => {
+        it('Should omit default ports from destination request and `referrer` header urls (GH-738)', () => {
             const testCases              = [
                 {
                     url:          'http://example.com:80',
@@ -2076,7 +2076,7 @@ describe('Proxy', () => {
             });
         });
 
-        it("Should handle `about:blank` requests for resources that doesn't require processing (GH-796)", done => {
+        it('Should handle `about:blank` requests for resources that doesn`t require processing (GH-796)', done => {
             const options = {
                 url: proxy.openSession('about:blank', session),
 
@@ -2489,6 +2489,7 @@ describe('Proxy', () => {
             });
             let mainPageSocket = null;
             let reqOptions     = null;
+            let error          = null;
 
             const server = net.createServer(socket => {
                 socket.on('data', data => {
@@ -2539,14 +2540,19 @@ describe('Proxy', () => {
                 });
             }
 
+            session.handlePageError = (ctx, err) => {
+                error = err;
+            };
+
             return getFreePort()
                 .then(port => new Promise(resolve => server.listen(port, resolve.bind(null, port))))
                 .then(port => {
                     const proxyUrl = proxy.openSession(`http://127.0.0.1:${port}/`, session);
 
                     reqOptions = Object.assign(urlLib.parse(proxyUrl), {
-                        method: 'GET',
-                        agent:  agent
+                        method:  'GET',
+                        agent:   agent,
+                        headers: { accept: 'text/html' }
                     });
 
                     return sendRequest(reqOptions);
@@ -2564,7 +2570,8 @@ describe('Proxy', () => {
                     return sendRequest(reqOptions);
                 })
                 .then(body => {
-                    expect(body).eql('Hello');
+                    expect(body).include('Hello');
+                    expect(error).to.be.null;
                     server.close();
                 });
         });


### PR DESCRIPTION
/cc @miherlosev @churkin 