### PR TITLE
remove confirm before publish

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -12,7 +12,7 @@
     "branch": "master",
     "gitTag": true
   },
-  "confirm": true,
+  "confirm": false,
   "publishTag": "latest",
   "prePublishScript": "gulp test-server"
 }


### PR DESCRIPTION
@LavrovArtem 

Now, before each publish I forced to press 'Y' character. I don't want to do this.