### PR TITLE
Custom proxy protocol

### DIFF
--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -22,24 +22,25 @@ function parseAsJson (msg) {
     }
 }
 
-function createServerInfo (hostname, port, crossDomainPort) {
+function createServerInfo (hostname, port, crossDomainPort, protocol = 'http') {
     return {
         hostname:        hostname,
         port:            port,
         crossDomainPort: crossDomainPort,
-        domain:          `http://${hostname}:${port}`
+        domain:          `${protocol}://${hostname}:${port}`,
+        protocol:        `${protocol}:`
     };
 }
 
 // Proxy
 export default class Proxy extends Router {
-    constructor (hostname, port1, port2) {
+    constructor (hostname, port1, port2, protocol) {
         super();
 
         this.openSessions = {};
 
-        this.server1Info = createServerInfo(hostname, port1, port2);
-        this.server2Info = createServerInfo(hostname, port2, port1);
+        this.server1Info = createServerInfo(hostname, port1, port2, protocol);
+        this.server2Info = createServerInfo(hostname, port2, port1, protocol);
         this.server1     = http.createServer((req, res) => this._onRequest(req, res, this.server1Info));
         this.server2     = http.createServer((req, res) => this._onRequest(req, res, this.server2Info));
 
@@ -167,6 +168,7 @@ export default class Proxy extends Router {
             session.setExternalProxySettings(externalProxyUrl);
 
         return urlUtils.getProxyUrl(url, {
+            proxyProtocol: this.server1Info.protocol,
             proxyHostname: this.server1Info.hostname,
             proxyPort:     this.server1Info.port,
             sessionId:     session.id

--- a/src/request-pipeline/context.js
+++ b/src/request-pipeline/context.js
@@ -257,11 +257,13 @@ export default class RequestPipelineContext {
     }
 
     toProxyUrl (url, isCrossDomain, resourceType, charset) {
+        const proxyProtocol = this.serverInfo.protocol;
         const proxyHostname = this.serverInfo.hostname;
         const proxyPort     = isCrossDomain ? this.serverInfo.crossDomainPort : this.serverInfo.port;
         const sessionId     = this.session.id;
 
         return urlUtils.getProxyUrl(url, {
+            proxyProtocol,
             proxyHostname,
             proxyPort,
             sessionId,

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -1086,6 +1086,17 @@ describe('Proxy', () => {
         });
     });
 
+    describe('https protocol', () => {
+        it('Should be same as the session protocol', () => {
+            proxy.close();
+            proxy = new Proxy('127.0.0.1', 1836, 1837, 'https');
+
+            const url = proxy.openSession('http://127.0.0.1:2000/page', session);
+
+            expect(url).contains('https://127.0.0.1:1836');
+        });
+    });
+
     describe('file:// protocol', () => {
         it('Should process page and ignore search string', done => {
             session.id = 'sessionId';


### PR DESCRIPTION
@LavrovArtem @miherlosev

Currently the poxy is always created with `http` protocol. I would like to customize proxy protocol with `https` and keep its default value as `http`.  Would you help to review the changes and to check if there is any concerns? Thank you.