### PR TITLE
Location header modification

### DIFF
--- a/src/request-pipeline/header-transforms.js
+++ b/src/request-pipeline/header-transforms.js
@@ -49,9 +49,14 @@ function transformCookie (src, ctx) {
 }
 
 function resolveAndGetProxyUrl (url, ctx) {
+    if (ctx.req.httpVersion === '1.1' && ctx.destRes.statusCode === 202)
+        return url;
+
     const { host }    = parseUrl(url);
     let isCrossDomain = false;
 
+    // NOTE: The RFC 1945 standard requires location URLs to be absolute. However, most popular browsers
+    // accept relative URLs. We transform relative URLs to absolute to correctly handle this situation.
     if (!host)
         url = resolveUrl(ctx.dest.url, url);
 
@@ -135,8 +140,6 @@ const responseTransforms = {
     'content-length': (src, ctx) => ctx.contentInfo.requireProcessing ? ctx.destResBody.length : src,
 
     'location': (src, ctx) => {
-        // NOTE: The RFC 1945 standard requires location URLs to be absolute. However, most popular browsers
-        // accept relative URLs. We transform relative URLs to absolute to correctly handle this situation.
         return resolveAndGetProxyUrl(src, ctx);
     },
 


### PR DESCRIPTION
Hey guys, we run into some troubles with hammerhead recently.

Hammerhead modifies the location header whenever it comes from the server to such form that url in the location header is always absolute no matter the HTTP version the responses are sent with.

In our company, GoodData, all server responses are according to the HTTP/1.1 standard which allows for relative url in the location header.

For complex reasons with our backend architecture, we’re not able to switch to absolute URLs.

There’s one special case we use for polling we had troubles with:
```
HTTP/1.1 202 Accepted
Host: secure.gooddata.com
Location: /url/to/be/polled/on
Content-Type: application/json;charset=utf-8
```

You see if the hammerhead modifies location header to be absolute, we get a CORS violation on the follow-up request and the request fails.

Therefore we had to came up with a patch that enables us to use TestCafe against GoodData backend.