### PR TITLE
Remove ie 9 10 related code part5

### DIFF
--- a/src/client/sandbox/xhr.js
+++ b/src/client/sandbox/xhr.js
@@ -20,10 +20,6 @@ export default class XhrSandbox extends SandboxBase {
         this.BEFORE_XHR_SEND_EVENT = 'hammerhead|event|before-xhr-send';
 
         this.cookieSandbox = cookieSandbox;
-
-        const xhr = new nativeMethods.XMLHttpRequest();
-
-        this.corsSupported = typeof xhr.withCredentials !== 'undefined';
     }
 
     static isOpenedXhr (obj) {
@@ -120,11 +116,6 @@ export default class XhrSandbox extends SandboxBase {
         xmlHttpRequestProto.open = function () {
             this[IS_OPENED_XHR] = true;
 
-            // NOTE: Emulate CORS, so that 3rd party libs (e.g. jQuery) allow requests with the proxy host as well as
-            // the destination page host.
-            if (!xhrSandbox.corsSupported)
-                this.withCredentials = false;
-
             if (typeof arguments[1] === 'string')
                 arguments[1] = getProxyUrl(arguments[1]);
 
@@ -140,9 +131,6 @@ export default class XhrSandbox extends SandboxBase {
             // Access-Control_Allow_Origin flag and skip "preflight" requests.
             nativeMethods.xhrSetRequestHeader.call(this, XHR_HEADERS.requestMarker, 'true');
             nativeMethods.xhrSetRequestHeader.call(this, XHR_HEADERS.origin, getOriginHeader());
-
-            if (xhrSandbox.corsSupported)
-                nativeMethods.xhrSetRequestHeader.call(this, XHR_HEADERS.corsSupported, 'true');
 
             if (this.withCredentials)
                 nativeMethods.xhrSetRequestHeader.call(this, XHR_HEADERS.withCredentials, 'true');

--- a/src/request-pipeline/header-transforms.js
+++ b/src/request-pipeline/header-transforms.js
@@ -13,8 +13,7 @@ function skipIfStateSnapshotIsApplied (src, ctx) {
 }
 
 function isCrossDomainXhrWithoutCredentials (ctx) {
-    return ctx.isXhr && !!ctx.req.headers[XHR_HEADERS.corsSupported] && !ctx.req.headers[XHR_HEADERS.withCredentials] &&
-           ctx.dest.reqOrigin !== ctx.dest.domain;
+    return ctx.isXhr && !ctx.req.headers[XHR_HEADERS.withCredentials] && ctx.dest.reqOrigin !== ctx.dest.domain;
 }
 
 function transformAuthorizationHeader (src, ctx) {
@@ -79,7 +78,6 @@ const requestTransforms = Object.assign({
     'if-modified-since':                   skipIfStateSnapshotIsApplied,
     'if-none-match':                       skipIfStateSnapshotIsApplied,
     [XHR_HEADERS.requestMarker]:           skip,
-    [XHR_HEADERS.corsSupported]:           skip,
     [XHR_HEADERS.withCredentials]:         skip,
     [XHR_HEADERS.origin]:                  skip,
     [XHR_HEADERS.fetchRequestCredentials]: skip

--- a/src/request-pipeline/xhr/headers.js
+++ b/src/request-pipeline/xhr/headers.js
@@ -6,7 +6,6 @@
 
 export default {
     requestMarker:           'x-hammerhead|xhr|request-marker',
-    corsSupported:           'x-hammerhead|xhr|cors-supported',
     withCredentials:         'x-hammerhead|xhr|with-credentials',
     origin:                  'x-hammerhead|xhr|origin',
     setCookie:               'x-hammerhead|xhr|set-cookie',

--- a/src/request-pipeline/xhr/same-origin-policy.js
+++ b/src/request-pipeline/xhr/same-origin-policy.js
@@ -10,13 +10,6 @@ export function check (ctx) {
     if (ctx.dest.domain === reqOrigin)
         return true;
 
-    // NOTE: Ok, we have a cross-origin request.
-    const corsSupported = !!ctx.req.headers[XHR_HEADERS.corsSupported] || ctx.isFetch;
-
-    // FAILED: CORS not supported (IE9 only).
-    if (!corsSupported)
-        return false;
-
     // PASSED: We have a "preflight" request.
     if (ctx.req.method === 'OPTIONS')
         return true;

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -558,24 +558,7 @@ describe('Proxy', () => {
             });
         });
 
-        it('Should restrict preflight requests from other domain', done => {
-            const options = {
-                method:  'OPTIONS',
-                url:     proxy.openSession('http://127.0.0.1:2000/preflight', session),
-                headers: {
-                    referer:                     proxy.openSession('http://example.com', session),
-                    [XHR_HEADERS.requestMarker]: 'true'
-                }
-            };
-
-            request(options, (err, res, body) => {
-                expect(res.statusCode).eql(SAME_ORIGIN_CHECK_FAILED_STATUS_CODE);
-                expect(body).to.be.empty;
-                done();
-            });
-        });
-
-        it('Should allow preflight requests from other domain if CORS is enabled', done => {
+        it('Should allow preflight requests from other domain', done => {
             const options = {
                 method:  'OPTIONS',
                 url:     proxy.openSession('http://127.0.0.1:2000/preflight', session),

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -531,8 +531,7 @@ describe('Proxy', () => {
                 url:     proxy.openSession('http://127.0.0.1:2000/page/plain-text', session),
                 headers: {
                     referer:                     proxy.openSession('file:///path/page.html', session),
-                    [XHR_HEADERS.requestMarker]: 'true',
-                    [XHR_HEADERS.corsSupported]: 'true'
+                    [XHR_HEADERS.requestMarker]: 'true'
                 }
             };
 
@@ -548,8 +547,7 @@ describe('Proxy', () => {
                 url:     proxy.openSession(getFileProtocolUrl('./data/stylesheet/src.css'), session),
                 headers: {
                     referer:                     proxy.openSession('file:///path/page.html', session),
-                    [XHR_HEADERS.requestMarker]: 'true',
-                    [XHR_HEADERS.corsSupported]: 'true'
+                    [XHR_HEADERS.requestMarker]: 'true'
                 }
             };
 
@@ -583,8 +581,7 @@ describe('Proxy', () => {
                 url:     proxy.openSession('http://127.0.0.1:2000/preflight', session),
                 headers: {
                     referer:                     proxy.openSession('http://example.com', session),
-                    [XHR_HEADERS.requestMarker]: 'true',
-                    [XHR_HEADERS.corsSupported]: 'true'
+                    [XHR_HEADERS.requestMarker]: 'true'
                 }
             };
 
@@ -600,8 +597,7 @@ describe('Proxy', () => {
                 url:     proxy.openSession('http://127.0.0.1:2000/xhr-origin/allow-any', session),
                 headers: {
                     referer:                     proxy.openSession('http://example.com', session),
-                    [XHR_HEADERS.requestMarker]: 'true',
-                    [XHR_HEADERS.corsSupported]: 'true'
+                    [XHR_HEADERS.requestMarker]: 'true'
                 }
             };
 
@@ -618,8 +614,7 @@ describe('Proxy', () => {
                 headers: {
                     referer:                     proxy.openSession('http://example.com', session),
                     'x-allow-origin':            'http://example.com',
-                    [XHR_HEADERS.requestMarker]: 'true',
-                    [XHR_HEADERS.corsSupported]: 'true'
+                    [XHR_HEADERS.requestMarker]: 'true'
                 }
             };
 
@@ -1613,8 +1608,7 @@ describe('Proxy', () => {
                 url:     proxy.openSession('http://127.0.0.1:2000/B234325,GH-284/reply-with-origin', session),
                 headers: {
                     referer:                     proxy.openSession('http://example.com', session),
-                    [XHR_HEADERS.requestMarker]: 'true',
-                    [XHR_HEADERS.corsSupported]: 'true'
+                    [XHR_HEADERS.requestMarker]: 'true'
                 }
             };
 
@@ -1798,8 +1792,7 @@ describe('Proxy', () => {
                 headers: {
                     origin:                      'http://127.0.0.1:1836',
                     [XHR_HEADERS.origin]:        'http://example.com',
-                    [XHR_HEADERS.requestMarker]: 'true',
-                    [XHR_HEADERS.corsSupported]: 'true'
+                    [XHR_HEADERS.requestMarker]: 'true'
                 }
             };
 
@@ -1889,8 +1882,7 @@ describe('Proxy', () => {
                 url:     proxy.openSession('http://127.0.0.1:2002/without-access-control-allow-origin-header', session),
                 headers: {
                     referer:                     proxy.openSession('http://example.com', session),
-                    [XHR_HEADERS.requestMarker]: 'true',
-                    [XHR_HEADERS.corsSupported]: 'true'
+                    [XHR_HEADERS.requestMarker]: 'true'
                 }
             };
 
@@ -1912,8 +1904,7 @@ describe('Proxy', () => {
                     'authentication-info':       'value',
                     'proxy-authenticate':        'value',
                     'proxy-authorization':       'value',
-                    [XHR_HEADERS.requestMarker]: true,
-                    [XHR_HEADERS.corsSupported]: true
+                    [XHR_HEADERS.requestMarker]: true
                 }
             };
 
@@ -1936,7 +1927,6 @@ describe('Proxy', () => {
                 headers: {
                     referer:                               proxy.openSession('http://127.0.0.1:2000', session),
                     [XHR_HEADERS.requestMarker]:           'true',
-                    [XHR_HEADERS.corsSupported]:           'true',
                     [XHR_HEADERS.withCredentials]:         'true',
                     [XHR_HEADERS.origin]:                  'origin_value',
                     [XHR_HEADERS.fetchRequestCredentials]: 'omit'
@@ -1947,7 +1937,6 @@ describe('Proxy', () => {
                 const requestHeaders = JSON.parse(body);
 
                 expect(requestHeaders[XHR_HEADERS.requestMarker]).to.be.undefined;
-                expect(requestHeaders[XHR_HEADERS.corsSupported]).to.be.undefined;
                 expect(requestHeaders[XHR_HEADERS.withCredentials]).to.be.undefined;
                 expect(requestHeaders[XHR_HEADERS.origin]).to.be.undefined;
                 expect(requestHeaders[XHR_HEADERS.fetchRequestCredentials]).to.be.undefined;
@@ -1962,7 +1951,6 @@ describe('Proxy', () => {
                 headers: {
                     referer:                               proxy.openSession('http://127.0.0.1:2000', session),
                     [XHR_HEADERS.requestMarker]:           'true',
-                    [XHR_HEADERS.corsSupported]:           'true',
                     [XHR_HEADERS.withCredentials]:         'true',
                     [XHR_HEADERS.origin]:                  'origin_value',
                     [XHR_HEADERS.fetchRequestCredentials]: 'omit'
@@ -1973,7 +1961,6 @@ describe('Proxy', () => {
                 const requestHeaders = JSON.parse(body);
 
                 expect(requestHeaders[XHR_HEADERS.requestMarker]).to.be.undefined;
-                expect(requestHeaders[XHR_HEADERS.corsSupported]).to.be.undefined;
                 expect(requestHeaders[XHR_HEADERS.withCredentials]).to.be.undefined;
                 expect(requestHeaders[XHR_HEADERS.origin]).to.be.undefined;
                 expect(requestHeaders[XHR_HEADERS.fetchRequestCredentials]).to.be.undefined;
@@ -2223,8 +2210,7 @@ describe('Proxy', () => {
                     'proxy-authenticate':        'proxy-authenticate',
                     'proxy-authorization':       'proxy-authorization',
                     referer:                     proxy.openSession('http://127.0.0.1:2000', session),
-                    [XHR_HEADERS.requestMarker]: 'true',
-                    [XHR_HEADERS.corsSupported]: 'true'
+                    [XHR_HEADERS.requestMarker]: 'true'
                 }
             };
 


### PR DESCRIPTION
@LavrovArtem 

Remove `XHR_HEADERS.corsSupported` header.
CORS unsupported only in IE9