### PR TITLE
fix 'Page without slash after location's host reloads if we set only hash' (close #1426)

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -13,7 +13,7 @@ import * as typeUtils from './utils/types';
 import * as positionUtils from './utils/position';
 import * as styleUtils from './utils/style';
 import trim from '../utils/string-trim';
-import { isRelativeUrl, parseProxyUrl } from '../utils/url';
+import { isRelativeUrl, parseProxyUrl, isSpecialPage, ensureHostEndedTrailingSlash } from '../utils/url';
 import * as urlUtils from './utils/url';
 import * as featureDetection from './utils/feature-detection';
 import * as htmlUtils from './utils/html';
@@ -197,10 +197,17 @@ class Hammerhead {
             destLocation = parsedProxyUrl && parsedProxyUrl.destUrl;
         }
 
-        if (destLocation === 'about:blank' && isRelativeUrl(url))
+        if (isSpecialPage(destLocation) && isRelativeUrl(url))
             return;
 
-        this.win.location = urlUtils.getProxyUrl(url);
+        // if (destLocation === 'about:blank' && isRelativeUrl(url)) {
+        //     debugger;
+        //     return;
+        // }
+
+        const proxyUrl = urlUtils.getProxyUrl(url);
+
+        this.win.location = ensureHostEndedTrailingSlash(proxyUrl);
     }
 
     start (initSettings, win) {
@@ -212,7 +219,7 @@ class Hammerhead {
             if (initSettings.isFirstPageLoad)
                 Hammerhead._cleanLocalStorageServiceData(initSettings.sessionId, this.win);
         }
-
+        // debugger;
         this.sandbox.attach(this.win);
         this.pageNavigationWatch.start();
     }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -200,14 +200,9 @@ class Hammerhead {
         if (isSpecialPage(destLocation) && isRelativeUrl(url))
             return;
 
-        // if (destLocation === 'about:blank' && isRelativeUrl(url)) {
-        //     debugger;
-        //     return;
-        // }
+        const proxyUrl = urlUtils.getProxyUrl(ensureHostEndedTrailingSlash(url));
 
-        const proxyUrl = urlUtils.getProxyUrl(url);
-
-        this.win.location = ensureHostEndedTrailingSlash(proxyUrl);
+        this.win.location = proxyUrl;
     }
 
     start (initSettings, win) {
@@ -219,7 +214,7 @@ class Hammerhead {
             if (initSettings.isFirstPageLoad)
                 Hammerhead._cleanLocalStorageServiceData(initSettings.sessionId, this.win);
         }
-        // debugger;
+
         this.sandbox.attach(this.win);
         this.pageNavigationWatch.start();
     }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -13,7 +13,7 @@ import * as typeUtils from './utils/types';
 import * as positionUtils from './utils/position';
 import * as styleUtils from './utils/style';
 import trim from '../utils/string-trim';
-import { isRelativeUrl, parseProxyUrl, isSpecialPage, ensureHostEndedTrailingSlash } from '../utils/url';
+import { isRelativeUrl, parseProxyUrl, isSpecialPage, ensureOriginTrailingSlash } from '../utils/url';
 import * as urlUtils from './utils/url';
 import * as featureDetection from './utils/feature-detection';
 import * as htmlUtils from './utils/html';
@@ -200,7 +200,9 @@ class Hammerhead {
         if (isSpecialPage(destLocation) && isRelativeUrl(url))
             return;
 
-        const proxyUrl = urlUtils.getProxyUrl(ensureHostEndedTrailingSlash(url));
+        url = ensureOriginTrailingSlash(url);
+
+        const proxyUrl = urlUtils.getProxyUrl(url);
 
         this.win.location = proxyUrl;
     }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -13,7 +13,7 @@ import * as typeUtils from './utils/types';
 import * as positionUtils from './utils/position';
 import * as styleUtils from './utils/style';
 import trim from '../utils/string-trim';
-import { isRelativeUrl, parseProxyUrl, isSpecialPage, ensureOriginTrailingSlash, LEADING_SLASHES_RE } from '../utils/url';
+import { isRelativeUrl, parseProxyUrl, isSpecialPage, ensureOriginTrailingSlash } from '../utils/url';
 import * as urlUtils from './utils/url';
 import * as featureDetection from './utils/feature-detection';
 import * as htmlUtils from './utils/html';
@@ -197,11 +197,10 @@ class Hammerhead {
             destLocation = parsedProxyUrl && parsedProxyUrl.destUrl;
         }
 
-        if (destLocation === 'about:blank' && isRelativeUrl(url))
+        if (isSpecialPage(destLocation) && isRelativeUrl(url))
             return;
 
-        if (!LEADING_SLASHES_RE.test(url) && !isSpecialPage(url))
-            url = ensureOriginTrailingSlash(url);
+        url = ensureOriginTrailingSlash(url);
 
         const proxyUrl = urlUtils.getProxyUrl(url);
 

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -13,7 +13,7 @@ import * as typeUtils from './utils/types';
 import * as positionUtils from './utils/position';
 import * as styleUtils from './utils/style';
 import trim from '../utils/string-trim';
-import { isRelativeUrl, parseProxyUrl, isSpecialPage, ensureOriginTrailingSlash } from '../utils/url';
+import { isRelativeUrl, parseProxyUrl, isSpecialPage, ensureOriginTrailingSlash, LEADING_SLASHES_RE } from '../utils/url';
 import * as urlUtils from './utils/url';
 import * as featureDetection from './utils/feature-detection';
 import * as htmlUtils from './utils/html';
@@ -197,10 +197,11 @@ class Hammerhead {
             destLocation = parsedProxyUrl && parsedProxyUrl.destUrl;
         }
 
-        if (isSpecialPage(destLocation) && isRelativeUrl(url))
+        if (destLocation === 'about:blank' && isRelativeUrl(url))
             return;
 
-        url = ensureOriginTrailingSlash(url);
+        if (!LEADING_SLASHES_RE.test(url) && !isSpecialPage(url))
+            url = ensureOriginTrailingSlash(url);
 
         const proxyUrl = urlUtils.getProxyUrl(url);
 

--- a/src/client/sandbox/code-instrumentation/location/wrapper.js
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.js
@@ -15,7 +15,7 @@ import {
     sameOriginCheck,
     ensureTrailingSlash,
     isSpecialPage,
-    ensureHostEndedTrailingSlash
+    ensureOriginTrailingSlash
 } from '../../../../utils/url';
 import nativeMethods from '../../native-methods';
 import urlResolver from '../../../utils/url-resolver';
@@ -64,7 +64,7 @@ export default class LocationWrapper extends EventEmitter {
         };
         const getProxiedHref = href => {
             if (!isSpecialPage(href))
-                href = ensureHostEndedTrailingSlash(href);
+                href = ensureOriginTrailingSlash(href);
 
             if (isJsProtocol(href))
                 return processJsAttrValue(href, { isJsProtocol: true, isEventAttr: false });

--- a/src/client/sandbox/code-instrumentation/location/wrapper.js
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.js
@@ -9,7 +9,13 @@ import {
     isChangedOnlyHash,
     getCrossDomainProxyPort
 } from '../../../utils/url';
-import { getDomain, getResourceTypeString, sameOriginCheck, ensureTrailingSlash } from '../../../../utils/url';
+import {
+    getDomain,
+    getResourceTypeString,
+    sameOriginCheck,
+    ensureTrailingSlash,
+    ensureHostEndedTrailingSlash
+} from '../../../../utils/url';
 import nativeMethods from '../../native-methods';
 import urlResolver from '../../../utils/url-resolver';
 import { processJsAttrValue, isJsProtocol } from '../../../../processing/dom/index';
@@ -56,6 +62,8 @@ export default class LocationWrapper extends EventEmitter {
             return ensureTrailingSlash(href, locationUrl);
         };
         const getProxiedHref = href => {
+            href = ensureHostEndedTrailingSlash(href);
+
             if (isJsProtocol(href))
                 return processJsAttrValue(href, { isJsProtocol: true, isEventAttr: false });
 

--- a/src/client/sandbox/code-instrumentation/location/wrapper.js
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.js
@@ -14,7 +14,6 @@ import {
     getResourceTypeString,
     sameOriginCheck,
     ensureTrailingSlash,
-    isSpecialPage,
     ensureOriginTrailingSlash
 } from '../../../../utils/url';
 import nativeMethods from '../../native-methods';
@@ -63,8 +62,7 @@ export default class LocationWrapper extends EventEmitter {
             return ensureTrailingSlash(href, locationUrl);
         };
         const getProxiedHref = href => {
-            if (!isSpecialPage(href))
-                href = ensureOriginTrailingSlash(href);
+            href = ensureOriginTrailingSlash(href);
 
             if (isJsProtocol(href))
                 return processJsAttrValue(href, { isJsProtocol: true, isEventAttr: false });

--- a/src/client/sandbox/code-instrumentation/location/wrapper.js
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.js
@@ -14,6 +14,7 @@ import {
     getResourceTypeString,
     sameOriginCheck,
     ensureTrailingSlash,
+    isSpecialPage,
     ensureHostEndedTrailingSlash
 } from '../../../../utils/url';
 import nativeMethods from '../../native-methods';
@@ -62,7 +63,8 @@ export default class LocationWrapper extends EventEmitter {
             return ensureTrailingSlash(href, locationUrl);
         };
         const getProxiedHref = href => {
-            href = ensureHostEndedTrailingSlash(href);
+            if (!isSpecialPage(href))
+                href = ensureHostEndedTrailingSlash(href);
 
             if (isJsProtocol(href))
                 return processJsAttrValue(href, { isJsProtocol: true, isEventAttr: false });

--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -121,7 +121,7 @@ export default class Proxy extends Router {
     }
 
     _onTaskScriptRequest (req, res, serverInfo, isIframe) {
-        const referer     = req.headers['referer']; // + '/'; // ?
+        const referer     = req.headers['referer'];
         const refererDest = referer && urlUtils.parseProxyUrl(referer);
         const session     = refererDest && this.openSessions[refererDest.sessionId];
 
@@ -135,8 +135,6 @@ export default class Proxy extends Router {
     }
 
     _onRequest (req, res, serverInfo) {
-        // console.log('hammerhead _onRequest req.url = ' + req.url);
-
         // NOTE: Not a service request, execute the proxy pipeline.
         if (!this._route(req, res, serverInfo))
             runRequestPipeline(req, res, serverInfo, this.openSessions);
@@ -170,8 +168,6 @@ export default class Proxy extends Router {
 
         if (!urlUtils.isSpecialPage(url))
             url = urlUtils.ensureHostEndedTrailingSlash(url);
-
-        // console.log('hammerhead openSession() url = ' + url);
 
         return urlUtils.getProxyUrl(url, {
             proxyHostname: this.server1Info.hostname,

--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -166,8 +166,7 @@ export default class Proxy extends Router {
         if (externalProxyUrl)
             session.setExternalProxySettings(externalProxyUrl);
 
-        if (!urlUtils.isSpecialPage(url))
-            url = urlUtils.ensureOriginTrailingSlash(url);
+        url = urlUtils.ensureOriginTrailingSlash(url);
 
         return urlUtils.getProxyUrl(url, {
             proxyHostname: this.server1Info.hostname,

--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -121,7 +121,7 @@ export default class Proxy extends Router {
     }
 
     _onTaskScriptRequest (req, res, serverInfo, isIframe) {
-        const referer     = req.headers['referer'];
+        const referer     = req.headers['referer']; // + '/'; // ?
         const refererDest = referer && urlUtils.parseProxyUrl(referer);
         const session     = refererDest && this.openSessions[refererDest.sessionId];
 
@@ -135,6 +135,8 @@ export default class Proxy extends Router {
     }
 
     _onRequest (req, res, serverInfo) {
+        // console.log('hammerhead _onRequest req.url = ' + req.url);
+
         // NOTE: Not a service request, execute the proxy pipeline.
         if (!this._route(req, res, serverInfo))
             runRequestPipeline(req, res, serverInfo, this.openSessions);
@@ -165,6 +167,11 @@ export default class Proxy extends Router {
 
         if (externalProxyUrl)
             session.setExternalProxySettings(externalProxyUrl);
+
+        if (!urlUtils.isSpecialPage(url))
+            url = urlUtils.ensureHostEndedTrailingSlash(url);
+
+        // console.log('hammerhead openSession() url = ' + url);
 
         return urlUtils.getProxyUrl(url, {
             proxyHostname: this.server1Info.hostname,

--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -167,7 +167,7 @@ export default class Proxy extends Router {
             session.setExternalProxySettings(externalProxyUrl);
 
         if (!urlUtils.isSpecialPage(url))
-            url = urlUtils.ensureHostEndedTrailingSlash(url);
+            url = urlUtils.ensureOriginTrailingSlash(url);
 
         return urlUtils.getProxyUrl(url, {
             proxyHostname: this.server1Info.hostname,

--- a/src/request-pipeline/header-transforms.js
+++ b/src/request-pipeline/header-transforms.js
@@ -136,10 +136,11 @@ const responseTransforms = {
     'location': (src, ctx) => {
         // NOTE: The RFC 1945 standard requires location URLs to be absolute. However, most popular browsers
         // accept relative URLs. We transform relative URLs to absolute to correctly handle this situation.
+        // ???
         if (ctx.contentInfo.isRedirect)
             return resolveAndGetProxyUrl(src, ctx);
 
-        return src;
+        return urlUtils.ensureHostEndedTrailingSlash(src);
     },
 
     'x-frame-options': (src, ctx) => {
@@ -148,9 +149,14 @@ const responseTransforms = {
 
         src = src.replace('ALLOW-FROM', '').trim();
 
+        // src = urlUtils.ensureHostEndedTrailingSlash(src);
+
         const isCrossDomain = ctx.isIframe && !urlUtils.sameOriginCheck(ctx.dest.url, src);
         const proxiedUrl    = ctx.toProxyUrl(src, isCrossDomain, ctx.contentInfo.contentTypeUrlToken);
 
+        // console.log('[!] x-frame-options url = ' + proxiedUrl);
+        // console.log('[!] x-frame-options ctx.dest.url = ' + ctx.dest.url);
+        // console.log('[!] x-frame-options src = ' + src);
         return 'ALLOW-FROM ' + proxiedUrl;
     },
 

--- a/src/request-pipeline/header-transforms.js
+++ b/src/request-pipeline/header-transforms.js
@@ -136,10 +136,12 @@ const responseTransforms = {
     'location': (src, ctx) => {
         // NOTE: The RFC 1945 standard requires location URLs to be absolute. However, most popular browsers
         // accept relative URLs. We transform relative URLs to absolute to correctly handle this situation.
-        // ???
         if (ctx.contentInfo.isRedirect)
             return resolveAndGetProxyUrl(src, ctx);
 
+        // console.log('responseTransforms location:');
+        // console.log('src =  ' + src);
+        // console.log('src_ = ' + urlUtils.ensureHostEndedTrailingSlash(src));
         return urlUtils.ensureHostEndedTrailingSlash(src);
     },
 
@@ -154,9 +156,9 @@ const responseTransforms = {
         const isCrossDomain = ctx.isIframe && !urlUtils.sameOriginCheck(ctx.dest.url, src);
         const proxiedUrl    = ctx.toProxyUrl(src, isCrossDomain, ctx.contentInfo.contentTypeUrlToken);
 
-        // console.log('[!] x-frame-options url = ' + proxiedUrl);
-        // console.log('[!] x-frame-options ctx.dest.url = ' + ctx.dest.url);
-        // console.log('[!] x-frame-options src = ' + src);
+        // console.log('x-frame-options url = ' + proxiedUrl);
+        // console.log('x-frame-options ctx.dest.url = ' + ctx.dest.url);
+        // console.log('x-frame-options src = ' + src);
         return 'ALLOW-FROM ' + proxiedUrl;
     },
 

--- a/src/request-pipeline/header-transforms.js
+++ b/src/request-pipeline/header-transforms.js
@@ -49,6 +49,8 @@ function transformCookie (src, ctx) {
 }
 
 function resolveAndGetProxyUrl (url, ctx) {
+    url = urlUtils.ensureOriginTrailingSlash(url);
+
     const { host }    = parseUrl(url);
     let isCrossDomain = false;
 
@@ -139,7 +141,7 @@ const responseTransforms = {
         if (ctx.contentInfo.isRedirect)
             return resolveAndGetProxyUrl(src, ctx);
 
-        return urlUtils.ensureOriginTrailingSlash(src);
+        return src;
     },
 
     'x-frame-options': (src, ctx) => {

--- a/src/request-pipeline/header-transforms.js
+++ b/src/request-pipeline/header-transforms.js
@@ -139,9 +139,6 @@ const responseTransforms = {
         if (ctx.contentInfo.isRedirect)
             return resolveAndGetProxyUrl(src, ctx);
 
-        // console.log('responseTransforms location:');
-        // console.log('src =  ' + src);
-        // console.log('src_ = ' + urlUtils.ensureOriginTrailingSlash(src));
         return urlUtils.ensureOriginTrailingSlash(src);
     },
 

--- a/src/request-pipeline/header-transforms.js
+++ b/src/request-pipeline/header-transforms.js
@@ -141,8 +141,8 @@ const responseTransforms = {
 
         // console.log('responseTransforms location:');
         // console.log('src =  ' + src);
-        // console.log('src_ = ' + urlUtils.ensureHostEndedTrailingSlash(src));
-        return urlUtils.ensureHostEndedTrailingSlash(src);
+        // console.log('src_ = ' + urlUtils.ensureOriginTrailingSlash(src));
+        return urlUtils.ensureOriginTrailingSlash(src);
     },
 
     'x-frame-options': (src, ctx) => {
@@ -151,14 +151,17 @@ const responseTransforms = {
 
         src = src.replace('ALLOW-FROM', '').trim();
 
-        // src = urlUtils.ensureHostEndedTrailingSlash(src);
+        // src = urlUtils.ensureOriginTrailingSlash(src);
 
         const isCrossDomain = ctx.isIframe && !urlUtils.sameOriginCheck(ctx.dest.url, src);
         const proxiedUrl    = ctx.toProxyUrl(src, isCrossDomain, ctx.contentInfo.contentTypeUrlToken);
 
-        // console.log('x-frame-options url = ' + proxiedUrl);
-        // console.log('x-frame-options ctx.dest.url = ' + ctx.dest.url);
-        // console.log('x-frame-options src = ' + src);
+        // console.log('x-frame-options:');
+        // console.log('url          = ' + proxiedUrl);
+        // console.log('ctx.dest.url = ' + ctx.dest.url);
+        // console.log('src          = ' + src);
+        // console.log('proxiedUrl   = ' + proxiedUrl);
+        // console.log('return = ' + 'ALLOW-FROM ' + proxiedUrl);
         return 'ALLOW-FROM ' + proxiedUrl;
     },
 

--- a/src/request-pipeline/header-transforms.js
+++ b/src/request-pipeline/header-transforms.js
@@ -151,17 +151,9 @@ const responseTransforms = {
 
         src = src.replace('ALLOW-FROM', '').trim();
 
-        // src = urlUtils.ensureOriginTrailingSlash(src);
-
         const isCrossDomain = ctx.isIframe && !urlUtils.sameOriginCheck(ctx.dest.url, src);
         const proxiedUrl    = ctx.toProxyUrl(src, isCrossDomain, ctx.contentInfo.contentTypeUrlToken);
 
-        // console.log('x-frame-options:');
-        // console.log('url          = ' + proxiedUrl);
-        // console.log('ctx.dest.url = ' + ctx.dest.url);
-        // console.log('src          = ' + src);
-        // console.log('proxiedUrl   = ' + proxiedUrl);
-        // console.log('return = ' + 'ALLOW-FROM ' + proxiedUrl);
         return 'ALLOW-FROM ' + proxiedUrl;
     },
 

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -7,13 +7,14 @@ import trim from './string-trim';
 
 //Const
 const PROTOCOL_RE        = /^([\w-]+?:)(\/\/|[^\\/]|$)/;
+const LEADING_SLASHES_RE = /^(\/\/)/;
 const HOST_RE            = /^(.*?)(\/|%|\?|;|#|$)/;
 const PORT_RE            = /:([0-9]*)$/;
 const QUERY_AND_HASH_RE  = /(\?.+|#[^#]*)$/;
 const PATH_AFTER_HOST_RE = /^\/([^/]+?)\/([\S\s]+)$/;
+const HTTP_RE            = /^(?:https?):/;
 
 export const SUPPORTED_PROTOCOL_RE               = /^(?:https?|file):/i;
-export const LEADING_SLASHES_RE                  = /^(\/\/)/;
 export const HASH_RE                             = /^#/;
 export const REQUEST_DESCRIPTOR_VALUES_SEPARATOR = '!';
 export const TRAILING_SLASH_RE                   = /\/$/;
@@ -378,7 +379,7 @@ export function ensureOriginTrailingSlash (url) {
     // then browser adds the trailing slash to window.location.href.
     const parsedUrl = parseUrl(url);
 
-    if (!parsedUrl.partAfterHost)
+    if (!parsedUrl.partAfterHost && HTTP_RE.test(parsedUrl.protocol))
         return url + '/';
 
     return url;

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -12,11 +12,11 @@ const HOST_RE            = /^(.*?)(\/|%|\?|;|#|$)/;
 const PORT_RE            = /:([0-9]*)$/;
 const QUERY_AND_HASH_RE  = /(\?.+|#[^#]*)$/;
 const PATH_AFTER_HOST_RE = /^\/([^/]+?)\/([\S\s]+)$/;
-const TRAILING_SLASH_RE  = /\/$/;
 
 export const SUPPORTED_PROTOCOL_RE               = /^(?:https?|file):/i;
 export const HASH_RE                             = /^#/;
 export const REQUEST_DESCRIPTOR_VALUES_SEPARATOR = '!';
+export const TRAILING_SLASH_RE                   = /\/$/;
 export const SPECIAL_PAGES                       = ['about:blank', 'about:error'];
 
 export function parseResourceType (resourceType) {
@@ -375,7 +375,7 @@ export function isValidUrl (url) {
 
 export function ensureOriginTrailingSlash (url) {
     // NOTE: If you request an url containing only port, host and protocol
-    // then browser adds the trailing slash itself.
+    // then browser adds the trailing slash to window.location.href.
     const parsedUrl = parseUrl(url);
 
     if (!parsedUrl.partAfterHost)

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -211,10 +211,12 @@ export function parseProxyUrl (proxyUrl) {
 }
 
 export function getPathname (path) {
+    // console.log('hammerhead getPathname(' + path + ')');
     return path.replace(QUERY_AND_HASH_RE, '');
 }
 
 export function parseUrl (url) {
+    // console.log('hammerhead parseUrl(' + url + ')');
     const parsed = {};
 
     url = prepareUrl(url);
@@ -283,10 +285,12 @@ export function resolveUrlAsDest (url, getProxyUrlMeth) {
         return formatUrl(parsedProxyUrl.destResourceInfo);
     }
 
+    // console.log('hammerhead resolveUrlAsDest() return url = ' + url);
     return url;
 }
 
 export function formatUrl (parsedUrl) {
+    // console.log('hammerhead formatUrl(' + parsedUrl.protocol + parsedUrl.hostname + parsedUrl.partAfterHost + ')');
     // NOTE: the URL is relative.
     if (parsedUrl.protocol !== 'file:' && !parsedUrl.host && (!parsedUrl.hostname || !parsedUrl.port))
         return parsedUrl.partAfterHost;
@@ -310,6 +314,13 @@ export function formatUrl (parsedUrl) {
 
     if (parsedUrl.partAfterHost)
         url += parsedUrl.partAfterHost;
+
+    // console.log('hammerhead formatUrl');
+    // console.log('parsedUrl.protocol + parsedUrl.hostname = ' + parsedUrl.protocol + parsedUrl.hostname);
+    // console.log('parsedUrl.host = ' + parsedUrl.host);
+    // console.log('parsedUrl.partAfterHost = ' + parsedUrl.partAfterHost);
+    // console.log('return url = ' + url);
+    // console.log('======================');
 
     return url;
 }
@@ -337,6 +348,9 @@ export function prepareUrl (url) {
 }
 
 export function ensureTrailingSlash (srcUrl, processedUrl) {
+    // console.log('hammerhead ensureTrailingSlash():');
+    // console.log('srcUrl =              ' + srcUrl);
+    // console.log('processedUrl =        ' + processedUrl);
     const srcUrlEndsWithTrailingSlash       = TRAILING_SLASH_RE.test(srcUrl);
     const processedUrlEndsWithTrailingSlash = TRAILING_SLASH_RE.test(processedUrl);
 
@@ -345,6 +359,7 @@ export function ensureTrailingSlash (srcUrl, processedUrl) {
     else if (!srcUrlEndsWithTrailingSlash && processedUrlEndsWithTrailingSlash)
         processedUrl = processedUrl.replace(TRAILING_SLASH_RE, '');
 
+    // console.log('return processedUrl = ' + processedUrl);
     return processedUrl;
 }
 
@@ -368,4 +383,25 @@ export function isValidUrl (url) {
     const parsedUrl = parseUrl(url);
 
     return parsedUrl.protocol === 'file:' || parsedUrl.hostname && (!parsedUrl.port || isValidPort(parsedUrl.port));
+}
+
+export function ensureHostEndedTrailingSlash (url) {
+    // if (isSpecialPage(url)) {
+    //     console.log('ensureHostEndedTrailingSlash:');
+    //     console.log('SpecialPage = ' + url);
+    //     return url;
+    // }
+
+    const parsedUrl = parseUrl(url);
+
+    // console.log('ensureHostEndedTrailingSlash:');
+    // console.log('url = ' + url);
+    // console.log('parsedUrl.partAfterHost = ' + parsedUrl.partAfterHost);
+
+    if (parsedUrl.partAfterHost === '') {
+        // console.log('[partAfterHost = \'\']return ' + url + '/');
+        return url + '/';
+    }
+
+    return url;
 }

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -7,13 +7,13 @@ import trim from './string-trim';
 
 //Const
 const PROTOCOL_RE        = /^([\w-]+?:)(\/\/|[^\\/]|$)/;
-const LEADING_SLASHES_RE = /^(\/\/)/;
 const HOST_RE            = /^(.*?)(\/|%|\?|;|#|$)/;
 const PORT_RE            = /:([0-9]*)$/;
 const QUERY_AND_HASH_RE  = /(\?.+|#[^#]*)$/;
 const PATH_AFTER_HOST_RE = /^\/([^/]+?)\/([\S\s]+)$/;
 
 export const SUPPORTED_PROTOCOL_RE               = /^(?:https?|file):/i;
+export const LEADING_SLASHES_RE                  = /^(\/\/)/;
 export const HASH_RE                             = /^#/;
 export const REQUEST_DESCRIPTOR_VALUES_SEPARATOR = '!';
 export const TRAILING_SLASH_RE                   = /\/$/;

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -112,9 +112,6 @@ function convertHostToLowerCase (url) {
 }
 
 export function getProxyUrl (url, opts) {
-    // if (!isSpecialPage(url))
-    //     url = ensureOriginTrailingSlash(url);
-
     let params = [opts.sessionId];
 
     if (opts.resourceType)

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -111,6 +111,9 @@ function convertHostToLowerCase (url) {
 }
 
 export function getProxyUrl (url, opts) {
+    // if (!isSpecialPage(url))
+    //     url = ensureHostEndedTrailingSlash(url);
+
     let params = [opts.sessionId];
 
     if (opts.resourceType)
@@ -211,12 +214,10 @@ export function parseProxyUrl (proxyUrl) {
 }
 
 export function getPathname (path) {
-    // console.log('hammerhead getPathname(' + path + ')');
     return path.replace(QUERY_AND_HASH_RE, '');
 }
 
 export function parseUrl (url) {
-    // console.log('hammerhead parseUrl(' + url + ')');
     const parsed = {};
 
     url = prepareUrl(url);
@@ -285,12 +286,10 @@ export function resolveUrlAsDest (url, getProxyUrlMeth) {
         return formatUrl(parsedProxyUrl.destResourceInfo);
     }
 
-    // console.log('hammerhead resolveUrlAsDest() return url = ' + url);
     return url;
 }
 
 export function formatUrl (parsedUrl) {
-    // console.log('hammerhead formatUrl(' + parsedUrl.protocol + parsedUrl.hostname + parsedUrl.partAfterHost + ')');
     // NOTE: the URL is relative.
     if (parsedUrl.protocol !== 'file:' && !parsedUrl.host && (!parsedUrl.hostname || !parsedUrl.port))
         return parsedUrl.partAfterHost;
@@ -314,13 +313,6 @@ export function formatUrl (parsedUrl) {
 
     if (parsedUrl.partAfterHost)
         url += parsedUrl.partAfterHost;
-
-    // console.log('hammerhead formatUrl');
-    // console.log('parsedUrl.protocol + parsedUrl.hostname = ' + parsedUrl.protocol + parsedUrl.hostname);
-    // console.log('parsedUrl.host = ' + parsedUrl.host);
-    // console.log('parsedUrl.partAfterHost = ' + parsedUrl.partAfterHost);
-    // console.log('return url = ' + url);
-    // console.log('======================');
 
     return url;
 }
@@ -348,9 +340,6 @@ export function prepareUrl (url) {
 }
 
 export function ensureTrailingSlash (srcUrl, processedUrl) {
-    // console.log('hammerhead ensureTrailingSlash():');
-    // console.log('srcUrl =              ' + srcUrl);
-    // console.log('processedUrl =        ' + processedUrl);
     const srcUrlEndsWithTrailingSlash       = TRAILING_SLASH_RE.test(srcUrl);
     const processedUrlEndsWithTrailingSlash = TRAILING_SLASH_RE.test(processedUrl);
 
@@ -359,7 +348,6 @@ export function ensureTrailingSlash (srcUrl, processedUrl) {
     else if (!srcUrlEndsWithTrailingSlash && processedUrlEndsWithTrailingSlash)
         processedUrl = processedUrl.replace(TRAILING_SLASH_RE, '');
 
-    // console.log('return processedUrl = ' + processedUrl);
     return processedUrl;
 }
 
@@ -386,22 +374,10 @@ export function isValidUrl (url) {
 }
 
 export function ensureHostEndedTrailingSlash (url) {
-    // if (isSpecialPage(url)) {
-    //     console.log('ensureHostEndedTrailingSlash:');
-    //     console.log('SpecialPage = ' + url);
-    //     return url;
-    // }
-
     const parsedUrl = parseUrl(url);
 
-    // console.log('ensureHostEndedTrailingSlash:');
-    // console.log('url = ' + url);
-    // console.log('parsedUrl.partAfterHost = ' + parsedUrl.partAfterHost);
-
-    if (parsedUrl.partAfterHost === '') {
-        // console.log('[partAfterHost = \'\']return ' + url + '/');
+    if (!parsedUrl.partAfterHost)
         return url + '/';
-    }
 
     return url;
 }

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -373,7 +373,7 @@ export function isValidUrl (url) {
 
 export function ensureOriginTrailingSlash (url) {
     // NOTE: If you request an url containing only port, host and protocol
-    // then browser adds the trailing slash to window.location.href.
+    // then browser adds the trailing slash itself.
     const parsedUrl = parseUrl(url);
 
     if (!parsedUrl.partAfterHost && HTTP_RE.test(parsedUrl.protocol))

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -112,7 +112,7 @@ function convertHostToLowerCase (url) {
 
 export function getProxyUrl (url, opts) {
     // if (!isSpecialPage(url))
-    //     url = ensureHostEndedTrailingSlash(url);
+    //     url = ensureOriginTrailingSlash(url);
 
     let params = [opts.sessionId];
 
@@ -373,7 +373,9 @@ export function isValidUrl (url) {
     return parsedUrl.protocol === 'file:' || parsedUrl.hostname && (!parsedUrl.port || isValidPort(parsedUrl.port));
 }
 
-export function ensureHostEndedTrailingSlash (url) {
+export function ensureOriginTrailingSlash (url) {
+    // NOTE: If you request an url containing only port, host and protocol
+    // then browser adds the trailing slash itself.
     const parsedUrl = parseUrl(url);
 
     if (!parsedUrl.partAfterHost)

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -157,6 +157,50 @@ test('special pages (GH-339)', function () {
     destLocation.forceLocation(storedForcedLocation);
 });
 
+test('should add the trailing slash to location.href if url consist of origin', function () {
+    var storedForcedLocation = destLocation.getLocation();
+
+    const SHOULD_ADD_TRAILING_SLASH = [
+        'http://example.com',
+        'https://example.com',
+        'http://localhost',
+        'https://localhost',
+        'http://localhost:8080',
+        'https://localhost:8080',
+        'http://127.0.0.1',
+        'https://127.0.0.1',
+        'http://127.0.0.1:8080',
+        'https://127.0.0.1:8080'
+    ];
+
+    const SHOULD_NOT_ADD_TRAILING_SLASH = [
+        'about:blank',
+        'about:error',
+        'http://example.com/page.html',
+        'https://example.com/page.html'
+    ];
+
+    function checkTrailingSlash (urls, trailingSlashIsNeeded) {
+        urls.forEach(function (url) {
+            destLocation.forceLocation(urlUtils.getProxyUrl(url));
+
+            var windowMock = {
+                location: {},
+                document: document
+            };
+
+            var locationWrapper = new LocationWrapper(windowMock);
+
+            strictEqual(locationWrapper.href, url + (trailingSlashIsNeeded ? '/' : ''));
+        });
+    }
+
+    checkTrailingSlash(SHOULD_ADD_TRAILING_SLASH, true);
+    checkTrailingSlash(SHOULD_NOT_ADD_TRAILING_SLASH, false);
+
+    destLocation.forceLocation(storedForcedLocation);
+});
+
 module('regression');
 
 if (browserUtils.compareVersions([browserUtils.webkitVersion, '603.1.30']) === -1) {
@@ -280,7 +324,7 @@ test('emulate a native browser behaviour related with trailing slashes for locat
     var overrideGetResolverElement = function (resolvedHref) {
         urlResolver.getResolverElement = function () {
             var storedAnchorHrefGetter = nativeMethods.anchorHrefGetter;
-            var anchor = document.createElement('a');
+            var anchor                 = document.createElement('a');
 
             nativeMethods.anchorHrefGetter = function () {
                 nativeMethods.anchorHrefGetter = storedAnchorHrefGetter;

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -112,7 +112,7 @@ test('iframe', function () {
     wrapper = LocationInstrumentation.getLocationWrapper(windowMock);
 
     wrapper.assign('http://new.domain.com:1444');
-    strictEqual(windowMock.location.toString(), getProxy('http://new.domain.com:1444'));
+    strictEqual(windowMock.location.toString(), getProxy('http://new.domain.com:1444/'));
 
     wrapper.replace('https://domain.com:1555/index.html');
     strictEqual(windowMock.location.toString(), getProxy('https://domain.com:1555/index.html'));

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -221,7 +221,7 @@ test('should ensure a trailing slash on page navigation using href setter, assig
 
     var locationWrapper = new LocationWrapper(windowMock);
 
-    function checkTrailingSlash (testCases) {
+    function testAddingTrailingSlash (testCases) {
         testCases.forEach(function (testCase) {
             locationWrapper.href = testCase.url;
             strictEqual(windowMock.location.href, getExpectedProxyUrl(testCase));
@@ -234,7 +234,7 @@ test('should ensure a trailing slash on page navigation using href setter, assig
         });
     }
 
-    checkTrailingSlash(ENSURE_URL_TRAILING_SLASH_TEST_CASES);
+    testAddingTrailingSlash(ENSURE_URL_TRAILING_SLASH_TEST_CASES);
 });
 
 test('should ensure a trailing slash on page navigation using hammerhead.navigateTo method (GH-1426)', function () {
@@ -246,24 +246,20 @@ test('should ensure a trailing slash on page navigation using hammerhead.navigat
         return proxiedUrl + (testCase.shoudAddTrailingSlash ? '/' : '');
     }
 
-    var getWindowMock = function () {
-        return {
-            location: ''
-        };
+    var windowMock = {
+        location: ''
     };
-
-    var windowMock = getWindowMock();
 
     hammerhead.win = windowMock;
 
-    function checkTrailingSlash (testCases) {
+    function testAddingTrailingSlash (testCases) {
         testCases.forEach(function (testCase) {
             hammerhead.navigateTo(testCase.url);
             strictEqual(hammerhead.win.location, getExpectedProxyUrl(testCase));
         });
     }
 
-    checkTrailingSlash(ENSURE_URL_TRAILING_SLASH_TEST_CASES);
+    testAddingTrailingSlash(ENSURE_URL_TRAILING_SLASH_TEST_CASES);
 
     hammerhead.win = storedWindow;
 });

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -11,7 +11,7 @@ var nativeMethods = hammerhead.nativeMethods;
 var browserUtils  = hammerhead.utils.browser;
 var domUtils      = hammerhead.utils.dom;
 
-var URL_TEST_CASES = [
+var ENSURE_URL_TRAILING_SLASH_TEST_CASES = [
     {
         url:                   'http://example.com',
         shoudAddTrailingSlash: true
@@ -192,28 +192,27 @@ test('special pages (GH-339)', function () {
     destLocation.forceLocation(storedForcedLocation);
 });
 
-test('should add the trailing slash to location.href using href.set(), assign() and replace() functions if url consist of origin (GH-1426)', function () {
-    var setHref = function (url) {
-        this.href = url;
-    };
+test('should ensure a trailing slash on page navigation using href setter, assign and replace methods (GH-1426)', function () {
+    function getExpectedProxyUrl (testCase) {
+        var proxiedUrl = urlUtils.getProxyUrl(testCase.url);
 
-    function proxyUrl (url) {
-        urlUtils.getProxyUrl(url);
-    }
-
-    function proxyUrlTrailingSlash (urlCase) {
-        var proxiedUrl = urlUtils.getProxyUrl(urlCase.url);
-
-        return proxiedUrl + (urlCase.shoudAddTrailingSlash ? '/' : '');
+        return proxiedUrl + (testCase.shoudAddTrailingSlash ? '/' : '');
     }
 
     var windowMock = {
         location: {
-            href:     '',
-            replace:  setHref,
-            assign:   setHref,
+            href: '',
+
+            replace: function (url) {
+                this.href = url;
+            },
+
+            assign: function (url) {
+                this.href = url;
+            },
+
             toString: function () {
-                return proxyUrl(this.location.href);
+                return urlUtils.getProxyUrl(this.location.href);
             }
         }
     };
@@ -222,29 +221,29 @@ test('should add the trailing slash to location.href using href.set(), assign() 
 
     var locationWrapper = new LocationWrapper(windowMock);
 
-    function checkTrailingSlash (urlCases) {
-        urlCases.forEach(function (urlCase) {
-            locationWrapper.href = urlCase.url;
-            strictEqual(windowMock.location.href, proxyUrlTrailingSlash(urlCase));
+    function checkTrailingSlash (testCases) {
+        testCases.forEach(function (testCase) {
+            locationWrapper.href = testCase.url;
+            strictEqual(windowMock.location.href, getExpectedProxyUrl(testCase));
 
-            locationWrapper.replace(urlCase.url);
-            strictEqual(windowMock.location.href, proxyUrlTrailingSlash(urlCase));
+            locationWrapper.replace(testCase.url);
+            strictEqual(windowMock.location.href, getExpectedProxyUrl(testCase));
 
-            locationWrapper.assign(urlCase.url);
-            strictEqual(windowMock.location.href, proxyUrlTrailingSlash(urlCase));
+            locationWrapper.assign(testCase.url);
+            strictEqual(windowMock.location.href, getExpectedProxyUrl(testCase));
         });
     }
 
-    checkTrailingSlash(URL_TEST_CASES);
+    checkTrailingSlash(ENSURE_URL_TRAILING_SLASH_TEST_CASES);
 });
 
-test('should add the trailing slash to location when navigateTo() is called (GH-1426)', function () {
+test('should ensure a trailing slash on page navigation using hammerhead.navigateTo method (GH-1426)', function () {
     var storedWindow = hammerhead.win;
 
-    function proxyUrlTrailingSlash (urlCase) {
-        var proxiedUrl = urlUtils.getProxyUrl(urlCase.url);
+    function getExpectedProxyUrl (testCase) {
+        var proxiedUrl = urlUtils.getProxyUrl(testCase.url);
 
-        return proxiedUrl + (urlCase.shoudAddTrailingSlash ? '/' : '');
+        return proxiedUrl + (testCase.shoudAddTrailingSlash ? '/' : '');
     }
 
     var getWindowMock = function () {
@@ -257,14 +256,14 @@ test('should add the trailing slash to location when navigateTo() is called (GH-
 
     hammerhead.win = windowMock;
 
-    function checkTrailingSlash (urlCases) {
-        urlCases.forEach(function (urlCase) {
-            hammerhead.navigateTo(urlCase.url);
-            strictEqual(hammerhead.win.location, proxyUrlTrailingSlash(urlCase));
+    function checkTrailingSlash (testCases) {
+        testCases.forEach(function (testCase) {
+            hammerhead.navigateTo(testCase.url);
+            strictEqual(hammerhead.win.location, getExpectedProxyUrl(testCase));
         });
     }
 
-    checkTrailingSlash(URL_TEST_CASES);
+    checkTrailingSlash(ENSURE_URL_TRAILING_SLASH_TEST_CASES);
 
     hammerhead.win = storedWindow;
 });

--- a/test/client/fixtures/utils/url-test.js
+++ b/test/client/fixtures/utils/url-test.js
@@ -106,7 +106,7 @@ test('isRelativeUrl', function () {
 });
 
 test('ensureOriginTrailingSlash', function () {
-    var URL_TEST_CASES = [
+    var ENSURE_URL_TRAILING_SLASH_TEST_CASES = [
         {
             url:                   'http://example.com',
             shoudAddTrailingSlash: true
@@ -141,15 +141,15 @@ test('ensureOriginTrailingSlash', function () {
         }
     ];
 
-    function checkTrailingSlash (urlCases) {
-        urlCases.forEach(function (urlCase) {
-            var actualUrl = sharedUrlUtils.ensureOriginTrailingSlash(urlCase.url);
+    function checkTrailingSlash (testCases) {
+        testCases.forEach(function (testCase) {
+            var actualUrl = sharedUrlUtils.ensureOriginTrailingSlash(testCase.url);
 
-            strictEqual(actualUrl, urlCase.url + (urlCase.shoudAddTrailingSlash ? '/' : ''));
+            strictEqual(actualUrl, testCase.url + (testCase.shoudAddTrailingSlash ? '/' : ''));
         });
     }
 
-    checkTrailingSlash(URL_TEST_CASES);
+    checkTrailingSlash(ENSURE_URL_TRAILING_SLASH_TEST_CASES);
 });
 
 module('parse url');

--- a/test/client/fixtures/utils/url-test.js
+++ b/test/client/fixtures/utils/url-test.js
@@ -105,53 +105,6 @@ test('isRelativeUrl', function () {
     ok(sharedUrlUtils.isRelativeUrl('C:\\index.htm'));
 });
 
-test('ensureOriginTrailingSlash', function () {
-    var ENSURE_URL_TRAILING_SLASH_TEST_CASES = [
-        {
-            url:                   'http://example.com',
-            shoudAddTrailingSlash: true
-        },
-        {
-            url:                   'https://localhost:8080',
-            shoudAddTrailingSlash: true
-        },
-        {
-            url:                   'about:blank',
-            shoudAddTrailingSlash: false
-        },
-        {
-            url:                   'http://example.com/page.html',
-            shoudAddTrailingSlash: false
-        },
-        {
-            url:                   'file://localhost/etc/fstab', // Unix file URI scheme
-            shoudAddTrailingSlash: false
-        },
-        {
-            url:                   'file:///etc/fstab', // Unix file URI scheme
-            shoudAddTrailingSlash: false
-        },
-        {
-            url:                   'file://localhost/c:/WINDOWS/clock.avi', // Windows file URI scheme
-            shoudAddTrailingSlash: false
-        },
-        {
-            url:                   'file:///c:/WINDOWS/clock.avi', // Windows file URI scheme
-            shoudAddTrailingSlash: false
-        }
-    ];
-
-    function checkTrailingSlash (testCases) {
-        testCases.forEach(function (testCase) {
-            var actualUrl = sharedUrlUtils.ensureOriginTrailingSlash(testCase.url);
-
-            strictEqual(actualUrl, testCase.url + (testCase.shoudAddTrailingSlash ? '/' : ''));
-        });
-    }
-
-    checkTrailingSlash(ENSURE_URL_TRAILING_SLASH_TEST_CASES);
-});
-
 module('parse url');
 
 test('newline characters', function () {

--- a/test/client/fixtures/utils/url-test.js
+++ b/test/client/fixtures/utils/url-test.js
@@ -105,6 +105,41 @@ test('isRelativeUrl', function () {
     ok(sharedUrlUtils.isRelativeUrl('C:\\index.htm'));
 });
 
+test('ensureOriginTrailingSlash', function () {
+    const SHOULD_ADD_TRAILING_SLASH = [
+        'http://example.com',
+        // '//example.com',
+        // 'example.com',
+        'http://localhost:8080',
+        // '//localhost:8080',
+        // 'localhost:8080',
+        'http://127.0.0.1:8080'
+        // '//127.0.0.1:8080',
+        // '127.0.0.1:8080'
+    ];
+
+    const SHOULD_NOT_ADD_TRAILING_SLASH = [
+        'about:blank',
+        'about:error',
+        'file://file.txt',
+        '//file.txt',
+        'http://example.com/page',
+        'http://example.com/page.html'
+    ];
+
+    SHOULD_ADD_TRAILING_SLASH.forEach(function (url) {
+        var processedUrl = sharedUrlUtils.ensureOriginTrailingSlash(url);
+
+        strictEqual(processedUrl, url + '/');
+    });
+
+    SHOULD_NOT_ADD_TRAILING_SLASH.forEach(function (url) {
+        var processedUrl = sharedUrlUtils.ensureOriginTrailingSlash(url);
+
+        strictEqual(processedUrl, url);
+    });
+});
+
 module('parse url');
 
 test('newline characters', function () {

--- a/test/client/fixtures/utils/url-test.js
+++ b/test/client/fixtures/utils/url-test.js
@@ -108,36 +108,36 @@ test('isRelativeUrl', function () {
 test('ensureOriginTrailingSlash', function () {
     const SHOULD_ADD_TRAILING_SLASH = [
         'http://example.com',
-        // '//example.com',
-        // 'example.com',
+        'https://example.com',
+        'http://localhost',
+        'https://localhost',
         'http://localhost:8080',
-        // '//localhost:8080',
-        // 'localhost:8080',
-        'http://127.0.0.1:8080'
-        // '//127.0.0.1:8080',
-        // '127.0.0.1:8080'
+        'https://localhost:8080',
+        'http://127.0.0.1',
+        'https://127.0.0.1',
+        'http://127.0.0.1:8080',
+        'https://127.0.0.1:8080'
     ];
 
     const SHOULD_NOT_ADD_TRAILING_SLASH = [
         'about:blank',
         'about:error',
-        'file://file.txt',
-        '//file.txt',
-        'http://example.com/page',
-        'http://example.com/page.html'
+        'file://C:\\file.txt',
+        '//C:\\file.txt',
+        'http://example.com/page.html',
+        'https://example.com/page.html'
     ];
 
-    SHOULD_ADD_TRAILING_SLASH.forEach(function (url) {
-        var processedUrl = sharedUrlUtils.ensureOriginTrailingSlash(url);
+    function checkTrailingSlash (urls, trailingSlashIsNeeded) {
+        urls.forEach(function (url) {
+            var processedUrl = sharedUrlUtils.ensureOriginTrailingSlash(url);
 
-        strictEqual(processedUrl, url + '/');
-    });
+            strictEqual(processedUrl, url + (trailingSlashIsNeeded ? '/' : ''));
+        });
+    }
 
-    SHOULD_NOT_ADD_TRAILING_SLASH.forEach(function (url) {
-        var processedUrl = sharedUrlUtils.ensureOriginTrailingSlash(url);
-
-        strictEqual(processedUrl, url);
-    });
+    checkTrailingSlash(SHOULD_ADD_TRAILING_SLASH, true);
+    checkTrailingSlash(SHOULD_NOT_ADD_TRAILING_SLASH, false);
 });
 
 module('parse url');

--- a/test/client/fixtures/utils/url-test.js
+++ b/test/client/fixtures/utils/url-test.js
@@ -106,38 +106,50 @@ test('isRelativeUrl', function () {
 });
 
 test('ensureOriginTrailingSlash', function () {
-    const SHOULD_ADD_TRAILING_SLASH = [
-        'http://example.com',
-        'https://example.com',
-        'http://localhost',
-        'https://localhost',
-        'http://localhost:8080',
-        'https://localhost:8080',
-        'http://127.0.0.1',
-        'https://127.0.0.1',
-        'http://127.0.0.1:8080',
-        'https://127.0.0.1:8080'
+    var URL_TEST_CASES = [
+        {
+            url:                   'http://example.com',
+            shoudAddTrailingSlash: true
+        },
+        {
+            url:                   'https://localhost:8080',
+            shoudAddTrailingSlash: true
+        },
+        {
+            url:                   'about:blank',
+            shoudAddTrailingSlash: false
+        },
+        {
+            url:                   'http://example.com/page.html',
+            shoudAddTrailingSlash: false
+        },
+        {
+            url:                   'file://localhost/etc/fstab', // Unix file URI scheme
+            shoudAddTrailingSlash: false
+        },
+        {
+            url:                   'file:///etc/fstab', // Unix file URI scheme
+            shoudAddTrailingSlash: false
+        },
+        {
+            url:                   'file://localhost/c:/WINDOWS/clock.avi', // Windows file URI scheme
+            shoudAddTrailingSlash: false
+        },
+        {
+            url:                   'file:///c:/WINDOWS/clock.avi', // Windows file URI scheme
+            shoudAddTrailingSlash: false
+        }
     ];
 
-    const SHOULD_NOT_ADD_TRAILING_SLASH = [
-        'about:blank',
-        'about:error',
-        'file://C:\\file.txt',
-        '//C:\\file.txt',
-        'http://example.com/page.html',
-        'https://example.com/page.html'
-    ];
+    function checkTrailingSlash (urlCases) {
+        urlCases.forEach(function (urlCase) {
+            var actualUrl = sharedUrlUtils.ensureOriginTrailingSlash(urlCase.url);
 
-    function checkTrailingSlash (urls, trailingSlashIsNeeded) {
-        urls.forEach(function (url) {
-            var processedUrl = sharedUrlUtils.ensureOriginTrailingSlash(url);
-
-            strictEqual(processedUrl, url + (trailingSlashIsNeeded ? '/' : ''));
+            strictEqual(actualUrl, urlCase.url + (urlCase.shoudAddTrailingSlash ? '/' : ''));
         });
     }
 
-    checkTrailingSlash(SHOULD_ADD_TRAILING_SLASH, true);
-    checkTrailingSlash(SHOULD_NOT_ADD_TRAILING_SLASH, false);
+    checkTrailingSlash(URL_TEST_CASES);
 });
 
 module('parse url');

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -360,7 +360,7 @@ describe('Proxy', () => {
     describe('Session', () => {
         it('Should pass DNS errors to session', done => {
             session.handlePageError = (ctx, err) => {
-                expect(err).eql('Failed to find a DNS-record for the resource at <a href="http://www.some-unresolvable.url">http://www.some-unresolvable.url</a>.');
+                expect(err).eql('Failed to find a DNS-record for the resource at <a href="http://www.some-unresolvable.url/">http://www.some-unresolvable.url/</a>.');
                 ctx.res.end();
                 done();
                 return true;
@@ -378,7 +378,7 @@ describe('Proxy', () => {
 
         it('Should pass protocol DNS errors for existing host to session', done => {
             session.handlePageError = (ctx, err) => {
-                expect(err).eql('Failed to find a DNS-record for the resource at <a href="https://127.0.0.1:2000">https://127.0.0.1:2000</a>.');
+                expect(err).eql('Failed to find a DNS-record for the resource at <a href="https://127.0.0.1:2000/">https://127.0.0.1:2000/</a>.');
                 ctx.res.end();
                 done();
                 return true;
@@ -1813,8 +1813,8 @@ describe('Proxy', () => {
                     const host = 'http://127.0.0.1:' + port;
 
                     session.handlePageError = (ctx, err) => {
-                        expect(err).eql('Failed to find a DNS-record for the resource at <a href="' + host + '">' +
-                                        host + '</a>.');
+                        expect(err).eql('Failed to find a DNS-record for the resource at <a href="' + host + '/' + '">' +
+                                        host + '/' + '</a>.');
                         ctx.res.end();
                         done();
                         return true;

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -365,6 +365,14 @@ describe('Proxy', () => {
     });
 
     describe('Session', () => {
+        it('Should add the trailing slash to the proxied url if it consist of origin (GH-1426)', () => {
+            const shouldAddTralingSlash    = proxy.openSession('http://example.com', session);
+            const shouldNotAddTralingSlash = proxy.openSession('http://example.com/index', session);
+
+            expect(urlUtils.parseProxyUrl(shouldAddTralingSlash).destUrl).eql('http://example.com/');
+            expect(urlUtils.parseProxyUrl(shouldNotAddTralingSlash).destUrl).eql('http://example.com/index');
+        });
+
         it('Should pass DNS errors to session', done => {
             session.handlePageError = (ctx, err) => {
                 expect(err).eql('Failed to find a DNS-record for the resource at <a href="http://www.some-unresolvable.url/">http://www.some-unresolvable.url/</a>.');
@@ -2615,7 +2623,7 @@ describe('Proxy', () => {
             ]);
         });
 
-        it('Should add the trailing slash to location header if url consist of origin', () => {
+        it('Should add the trailing slash to location header if url consist of origin (GH-1426)', () => {
             proxy.openSession('http://127.0.0.1:2000/', session);
 
             function testRedirectRequest (redirectLocation, trailingSlashIsNeeded) {

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -404,7 +404,7 @@ describe('Proxy', () => {
                 return proxiedUrl + (testCase.shoudAddTrailingSlash ? '/' : '');
             }
 
-            function checkTrailingSlash (testCases) {
+            function testAddingTrailingSlash (testCases) {
                 testCases.forEach(function (testCase) {
                     const actualUrl = proxy.openSession(testCase.url, session);
 
@@ -412,7 +412,7 @@ describe('Proxy', () => {
                 });
             }
 
-            checkTrailingSlash(ENSURE_URL_TRAILING_SLASH_TEST_CASES);
+            testAddingTrailingSlash(ENSURE_URL_TRAILING_SLASH_TEST_CASES);
         });
 
         it('Should pass DNS errors to session', done => {
@@ -2666,26 +2666,19 @@ describe('Proxy', () => {
         });
 
         it('Should ensure a trailing slash on location header (GH-1426)', () => {
-            function getExpectedProxyUrl (proxiedCase) {
-                const proxiedUrl = urlUtils.getProxyUrl(proxiedCase.url, {
+            function getExpectedProxyUrl (testCase) {
+                const proxiedUrl = urlUtils.getProxyUrl(testCase.url, {
                     proxyHostname: '127.0.0.1',
                     proxyPort:     1836,
                     sessionId:     session.id
                 });
 
-                return proxiedUrl + (proxiedCase.shoudAddTrailingSlash ? '/' : '');
+                return proxiedUrl + (testCase.shoudAddTrailingSlash ? '/' : '');
             }
 
-            const proxyUrls = ENSURE_URL_TRAILING_SLASH_TEST_CASES.map(testCase => {
-                return {
-                    proxiedUrl:            proxy.openSession(testCase.url, session),
-                    shoudAddTrailingSlash: testCase.shoudAddTrailingSlash,
-                    url:                   testCase.url
-                };
-            });
-
-            const testPageRequest = proxiedCase => {
-                const encodedUrl = encodeURIComponent(proxiedCase.proxiedUrl);
+            const testLocationHeaderValue = testCase => {
+                const proxiedUrl = proxy.openSession(testCase.url, session);
+                const encodedUrl = encodeURIComponent(proxiedUrl);
                 const options    = {
                     url: 'http://127.0.0.1:2000/redirect/' + encodedUrl,
 
@@ -2696,11 +2689,11 @@ describe('Proxy', () => {
 
                 return request(options)
                     .then(res => {
-                        expect(res.headers['location']).eql(getExpectedProxyUrl(proxiedCase));
+                        expect(res.headers['location']).eql(getExpectedProxyUrl(testCase));
                     });
             };
 
-            return Promise.all(proxyUrls.map(testPageRequest));
+            return Promise.all(ENSURE_URL_TRAILING_SLASH_TEST_CASES.map(testLocationHeaderValue));
         });
     });
 });

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -29,7 +29,7 @@ const nodeVersion                          = parseFloat(require('node-version').
 
 const EMPTY_PAGE_MARKUP = '<html></html>';
 
-const URL_TEST_CASES = [
+const ENSURE_URL_TRAILING_SLASH_TEST_CASES = [
     {
         url:                   'http://example.com',
         shoudAddTrailingSlash: true
@@ -393,26 +393,26 @@ describe('Proxy', () => {
     });
 
     describe('Session', () => {
-        it('Should add the trailing slash to the proxied url using openSession() if url consist of origin (GH-1426)', () => {
-            function proxyUrlTrailingSlash (urlCase) {
-                const proxiedUrl = urlUtils.getProxyUrl(urlCase.url, {
+        it('Should ensure a trailing slash on openSession() (GH-1426)', () => {
+            function getExpectedProxyUrl (testCase) {
+                const proxiedUrl = urlUtils.getProxyUrl(testCase.url, {
                     proxyHostname: '127.0.0.1',
                     proxyPort:     1836,
                     sessionId:     session.id,
                 });
 
-                return proxiedUrl + (urlCase.shoudAddTrailingSlash ? '/' : '');
+                return proxiedUrl + (testCase.shoudAddTrailingSlash ? '/' : '');
             }
 
-            function checkTrailingSlash (urlCases) {
-                urlCases.forEach(function (urlCase) {
-                    const actualUrl = proxy.openSession(urlCase.url, session);
+            function checkTrailingSlash (testCases) {
+                testCases.forEach(function (testCase) {
+                    const actualUrl = proxy.openSession(testCase.url, session);
 
-                    expect(actualUrl).eql(proxyUrlTrailingSlash(urlCase));
+                    expect(actualUrl).eql(getExpectedProxyUrl(testCase));
                 });
             }
 
-            checkTrailingSlash(URL_TEST_CASES);
+            checkTrailingSlash(ENSURE_URL_TRAILING_SLASH_TEST_CASES);
         });
 
         it('Should pass DNS errors to session', done => {
@@ -2665,8 +2665,8 @@ describe('Proxy', () => {
             ]);
         });
 
-        it('Should add the trailing slash to location header if url consist of origin (GH-1426)', () => {
-            function proxyUrlTrailingSlash (proxiedCase) {
+        it('Should ensure a trailing slash on location header (GH-1426)', () => {
+            function getExpectedProxyUrl (proxiedCase) {
                 const proxiedUrl = urlUtils.getProxyUrl(proxiedCase.url, {
                     proxyHostname: '127.0.0.1',
                     proxyPort:     1836,
@@ -2676,11 +2676,11 @@ describe('Proxy', () => {
                 return proxiedUrl + (proxiedCase.shoudAddTrailingSlash ? '/' : '');
             }
 
-            const proxyUrls = URL_TEST_CASES.map(urlCase => {
+            const proxyUrls = ENSURE_URL_TRAILING_SLASH_TEST_CASES.map(testCase => {
                 return {
-                    proxiedUrl:            proxy.openSession(urlCase.url, session),
-                    shoudAddTrailingSlash: urlCase.shoudAddTrailingSlash,
-                    url:                   urlCase.url
+                    proxiedUrl:            proxy.openSession(testCase.url, session),
+                    shoudAddTrailingSlash: testCase.shoudAddTrailingSlash,
+                    url:                   testCase.url
                 };
             });
 
@@ -2696,7 +2696,7 @@ describe('Proxy', () => {
 
                 return request(options)
                     .then(res => {
-                        expect(res.headers['location']).eql(proxyUrlTrailingSlash(proxiedCase));
+                        expect(res.headers['location']).eql(getExpectedProxyUrl(proxiedCase));
                     });
             };
 

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -2238,7 +2238,7 @@ describe('Proxy', () => {
                 },
                 {
                     url:                 proxy.openSession('http://127.0.0.1:2000/x-frame-options/ALLOW-FROM%20https%3A%2F%2Fexample.com', session),
-                    expectedHeaderValue: 'ALLOW-FROM ' + proxy.openSession('https://example.com', session)
+                    expectedHeaderValue: 'ALLOW-FROM ' + proxy.openSession('https://example.com', session).replace(urlUtils.TRAILING_SLASH_RE, '')
                 },
                 {
                     url:                 proxy.openSession('http://127.0.0.1:2000/x-frame-options/ALLOW-FROM%20http%3A%2F%2F127.0.0.1%3A2000%2Fpage', session),


### PR DESCRIPTION
Reference: https://github.com/DevExpress/testcafe/issues/2005

Example test is passed (https://github.com/DevExpress/testcafe/issues/2005)

Todo:
- [x] ensureOriginTrailingSlash test (test/client/fixtures/utils/url-test.js)
- [x] location header test (test/server/proxy-test.js)
- [x] openSession test
- [x] navigateTo test
- [x] getProxiedHref (href.set(), assign() and replace())
- [x] investigate a necessary of ensureTrailingSlash function