### PR TITLE
fix `Testcafe doesn't handle state/url in Ionic/Angularjs app with tabs`

### DIFF
--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -17,7 +17,7 @@ const POINTER_EVENT_BUTTON = {
 };
 
 // NOTE: event.detail !=0 in some Mouse Events (User Interface Events).
-// See https://www.w3.org/TR/uievents/#events-uievents
+// See https://www.w3.org/TR/uievents/#events-mouseevents
 // https://github.com/DevExpress/testcafe/issues/2232
 const MOUSE_EVENT_DETAIL = {
     click:     browserUtils.isIE ? 0 : 1,

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -115,12 +115,14 @@ export default class EventSimulator {
     }
 
     static _getUIEventArgs (type, options = {}) {
+        const detail = 'detail' in options ? options.detail : MOUSE_EVENT_DETAIL[type];
+
         return {
             type:       type,
             canBubble:  options.canBubble !== false,
             cancelable: options.cancelable !== false,
             view:       options.view || window,
-            detail:     MOUSE_EVENT_DETAIL[type] || 0,
+            detail:     detail || 0,
             ctrlKey:    options.ctrlKey || false,
             altKey:     options.altKey || false,
             shiftKey:   options.shiftKey || false,

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -16,9 +16,8 @@ const POINTER_EVENT_BUTTON = {
     rightButton: 2
 };
 
-// NOTE: event.detail !=0 in some Mouse Events (User Interface Events).
+// NOTE: event.detail != 0 in some Mouse Events (User Interface Events).
 // See https://www.w3.org/TR/uievents/#events-mouseevents
-// https://github.com/DevExpress/testcafe/issues/2232
 const MOUSE_EVENT_DETAIL = {
     click:     browserUtils.isIE ? 0 : 1,
     dblclick:  browserUtils.isIE ? 0 : 2,

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -16,6 +16,16 @@ const POINTER_EVENT_BUTTON = {
     rightButton: 2
 };
 
+// NOTE: event.detail !=0 in some Mouse Events (User Interface Events).
+// See https://www.w3.org/TR/uievents/#events-uievents
+// https://github.com/DevExpress/testcafe/issues/2232
+const MOUSE_EVENT_DETAIL = {
+    click:     browserUtils.isIE ? 0 : 1,
+    dblclick:  browserUtils.isIE ? 0 : 2,
+    mousedown: 1,
+    mouseup:   1
+};
+
 const KEY_EVENT_NAME_RE          = /^key\w+$/;
 const MOUSE_EVENT_NAME_RE        = /^((mouse\w+)|((dbl)?click)|(contextmenu)|(drag\w*)|(drop))$/;
 const TOUCH_EVENT_NAME_RE        = /^touch\w+$/;
@@ -107,6 +117,8 @@ export default class EventSimulator {
 
     static _getUIEventArgs (type, options) {
         const opts = options || {};
+
+        opts.detail = MOUSE_EVENT_DETAIL[type];
 
         return {
             type:       type,

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -114,43 +114,37 @@ export default class EventSimulator {
         return el.dispatchEvent(ev);
     }
 
-    static _getUIEventArgs (type, options) {
-        const opts = options || {};
-
+    static _getUIEventArgs (type, options = {}) {
         return {
             type:       type,
-            canBubble:  opts.canBubble !== false,
-            cancelable: opts.cancelable !== false,
-            view:       opts.view || window,
+            canBubble:  options.canBubble !== false,
+            cancelable: options.cancelable !== false,
+            view:       options.view || window,
             detail:     MOUSE_EVENT_DETAIL[type] || 0,
-            ctrlKey:    opts.ctrlKey || false,
-            altKey:     opts.altKey || false,
-            shiftKey:   opts.shiftKey || false,
-            metaKey:    opts.metaKey || false
+            ctrlKey:    options.ctrlKey || false,
+            altKey:     options.altKey || false,
+            shiftKey:   options.shiftKey || false,
+            metaKey:    options.metaKey || false
         };
     }
 
-    static _getStorageEventArgs (options) {
-        const opts = options || {};
-
-        return extend(opts, {
-            canBubble:  opts.canBubble !== false,
-            cancelable: opts.cancelable !== false
+    static _getStorageEventArgs (options = {}) {
+        return extend(options, {
+            canBubble:  options.canBubble !== false,
+            cancelable: options.cancelable !== false
         });
     }
 
-    static _getMouseEventArgs (type, options) {
-        const opts = options || {};
-
+    static _getMouseEventArgs (type, options = {}) {
         return extend(EventSimulator._getUIEventArgs(type, options), {
-            screenX:       opts.screenX || 0,
-            screenY:       opts.screenY || 0,
-            clientX:       opts.clientX || 0,
-            clientY:       opts.clientY || 0,
-            button:        opts.button === void 0 ? eventUtils.BUTTON.left : opts.button,
-            buttons:       opts.buttons === void 0 ? eventUtils.BUTTONS_PARAMETER.leftButton : opts.buttons,
-            relatedTarget: opts.relatedTarget || null,
-            which:         opts.which === void 0 ? eventUtils.WHICH_PARAMETER.leftButton : opts.which
+            screenX:       options.screenX || 0,
+            screenY:       options.screenY || 0,
+            clientX:       options.clientX || 0,
+            clientY:       options.clientY || 0,
+            button:        options.button === void 0 ? eventUtils.BUTTON.left : options.button,
+            buttons:       options.buttons === void 0 ? eventUtils.BUTTONS_PARAMETER.leftButton : options.buttons,
+            relatedTarget: options.relatedTarget || null,
+            which:         options.which === void 0 ? eventUtils.WHICH_PARAMETER.leftButton : options.which
         });
     }
 
@@ -181,7 +175,7 @@ export default class EventSimulator {
         return modifiersString;
     }
 
-    _simulateEvent (el, event, userOptions, options) {
+    _simulateEvent (el, event, userOptions, options = {}) {
         let args     = null;
         let dispatch = null;
         // NOTE: We don't simulate a click on links with modifiers (ctrl, shift, ctrl+shift, alt),
@@ -200,7 +194,7 @@ export default class EventSimulator {
                 buttons:       userOptions.buttons,
                 relatedTarget: userOptions.relatedTarget
             } : {},
-            options || {});
+            options);
 
         if (!opts.relatedTarget)
             opts.relatedTarget = document.body;
@@ -251,15 +245,14 @@ export default class EventSimulator {
         return dispatch(el, args);
     }
 
-    _getTouchEventArgs (type, options) {
-        const opts = options || {};
-        const args = extend(EventSimulator._getUIEventArgs(type, opts), {
-            screenX:    opts.screenX || 0,
-            screenY:    opts.screenY || 0,
-            clientX:    opts.clientX || 0,
-            clientY:    opts.clientY || 0,
-            pageX:      opts.clientX || 0,
-            pageY:      opts.clientY || 0,
+    _getTouchEventArgs (type, options = {}) {
+        const args = extend(EventSimulator._getUIEventArgs(type, options), {
+            screenX:    options.screenX || 0,
+            screenY:    options.screenY || 0,
+            clientX:    options.clientX || 0,
+            clientY:    options.clientY || 0,
+            pageX:      options.clientX || 0,
+            pageY:      options.clientY || 0,
             identifier: this._getTouchIdentifier(type)
         });
 
@@ -699,9 +692,7 @@ export default class EventSimulator {
         });
     }
 
-    mousedown (el, options) {
-        options = options || {};
-
+    mousedown (el, options = {}) {
         options.button  = options.button === void 0 ? eventUtils.BUTTON.left : options.button;
         options.which   = options.which === void 0 || options.button !== eventUtils.BUTTON.right
             ? eventUtils.WHICH_PARAMETER.leftButton
@@ -711,9 +702,7 @@ export default class EventSimulator {
         return this._simulateEvent(el, 'mousedown', options);
     }
 
-    mouseup (el, options) {
-        options = options || {};
-
+    mouseup (el, options = {}) {
         options.button  = options.button === void 0 ? eventUtils.BUTTON.left : options.button;
         options.which   = options.which === void 0 || options.button !== eventUtils.BUTTON.right
             ? eventUtils.WHICH_PARAMETER.leftButton

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -114,17 +114,19 @@ export default class EventSimulator {
         return el.dispatchEvent(ev);
     }
 
-    static _getUIEventArgs (type, options = {}) {
+    static _getUIEventArgs (type, options) {
+        const opts = options || {};
+
         return {
             type:       type,
-            canBubble:  options.canBubble !== false,
-            cancelable: options.cancelable !== false,
-            view:       options.view || window,
+            canBubble:  opts.canBubble !== false,
+            cancelable: opts.cancelable !== false,
+            view:       opts.view || window,
             detail:     MOUSE_EVENT_DETAIL[type] || 0,
-            ctrlKey:    options.ctrlKey || false,
-            altKey:     options.altKey || false,
-            shiftKey:   options.shiftKey || false,
-            metaKey:    options.metaKey || false
+            ctrlKey:    opts.ctrlKey || false,
+            altKey:     opts.altKey || false,
+            shiftKey:   opts.shiftKey || false,
+            metaKey:    opts.metaKey || false
         };
     }
 

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -114,21 +114,17 @@ export default class EventSimulator {
         return el.dispatchEvent(ev);
     }
 
-    static _getUIEventArgs (type, options) {
-        const opts = options || {};
-
-        opts.detail = MOUSE_EVENT_DETAIL[type];
-
+    static _getUIEventArgs (type, options = {}) {
         return {
             type:       type,
-            canBubble:  opts.canBubble !== false,
-            cancelable: opts.cancelable !== false,
-            view:       opts.view || window,
-            detail:     opts.detail || 0,
-            ctrlKey:    opts.ctrlKey || false,
-            altKey:     opts.altKey || false,
-            shiftKey:   opts.shiftKey || false,
-            metaKey:    opts.metaKey || false
+            canBubble:  options.canBubble !== false,
+            cancelable: options.cancelable !== false,
+            view:       options.view || window,
+            detail:     MOUSE_EVENT_DETAIL[type] || 0,
+            ctrlKey:    options.ctrlKey || false,
+            altKey:     options.altKey || false,
+            shiftKey:   options.shiftKey || false,
+            metaKey:    options.metaKey || false
         };
     }
 

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -16,9 +16,9 @@ const POINTER_EVENT_BUTTON = {
     rightButton: 2
 };
 
-// NOTE: event.detail != 0 in some Mouse Events (User Interface Events).
-// See https://www.w3.org/TR/uievents/#events-mouseevents
-const MOUSE_EVENT_DETAIL = {
+// NOTE: (IE11 only) 'MouseEvent.detail' value always equals 0 for 'click' and 'dblclick' events.
+// Otherwise, MouseEvent.detail behave as described in specification - https://www.w3.org/TR/uievents/#events-mouseevents
+const DEFAULT_MOUSE_EVENT_DETAIL_PROP_VALUE = {
     click:     browserUtils.isIE ? 0 : 1,
     dblclick:  browserUtils.isIE ? 0 : 2,
     mousedown: 1,
@@ -115,7 +115,7 @@ export default class EventSimulator {
     }
 
     static _getUIEventArgs (type, options = {}) {
-        const detail = 'detail' in options ? options.detail : MOUSE_EVENT_DETAIL[type];
+        const detail = 'detail' in options ? options.detail : DEFAULT_MOUSE_EVENT_DETAIL_PROP_VALUE[type];
 
         return {
             type:       type,

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -10,6 +10,7 @@ var $domElement = null;
 var domElement  = null;
 var raised      = false;
 var bubbled     = false;
+var detail      = 0;
 
 var lastTouchIdentifier = null;
 
@@ -19,6 +20,7 @@ QUnit.testStart(function () {
     raised              = false;
     bubbled             = false;
     lastTouchIdentifier = null;
+    detail              = 0;
 });
 
 QUnit.testDone(function () {
@@ -31,8 +33,10 @@ var bindMouseEvent = function (eventType, btn) {
     domElement['on' + eventType] = function (e) {
         var ev = e || window.event;
 
-        if (ev.button === button)
+        if (ev.button === button) {
             raised = true;
+            detail = ev.detail;
+        }
     };
 };
 
@@ -60,6 +64,40 @@ var bindBubbleListener = function (eventType) {
 var removeBubbleListener = function (eventType) {
     document.removeEventListener(eventType, bubbleEventListener);
 };
+
+test('mouse click event detail value', function () {
+    bindMouseEvent('click', eventUtils.BUTTON.left);
+    eventSimulator.click(domElement);
+    strictEqual(detail, browserUtils.isIE ? 0 : 1);
+});
+
+test('mouse double click event detail value', function () {
+    bindMouseEvent('dblclick', eventUtils.BUTTON.left);
+    eventSimulator.dblclick(domElement);
+    strictEqual(detail, browserUtils.isIE ? 0 : 2);
+});
+
+test('mouse mouse down event detail value', function () {
+    bindMouseEvent('mousedown', eventUtils.BUTTON.left);
+    eventSimulator.mousedown(domElement);
+    strictEqual(detail, 1);
+
+    detail = 0;
+    bindMouseEvent('mousedown', eventUtils.BUTTON.right);
+    eventSimulator.mousedown(domElement);
+    strictEqual(detail, 0);
+});
+
+test('mouse mouse up event detail value', function () {
+    bindMouseEvent('mouseup', eventUtils.BUTTON.left);
+    eventSimulator.mouseup(domElement);
+    strictEqual(detail, 1);
+
+    detail = 0;
+    bindMouseEvent('mouseup', eventUtils.BUTTON.right);
+    eventSimulator.mouseup(domElement);
+    strictEqual(detail, 0);
+});
 
 test('mouse left button click', function () {
     bindMouseEvent('click', eventUtils.BUTTON.left);

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -65,40 +65,6 @@ var removeBubbleListener = function (eventType) {
     document.removeEventListener(eventType, bubbleEventListener);
 };
 
-test('mouse click event detail value', function () {
-    bindMouseEvent('click', eventUtils.BUTTON.left);
-    eventSimulator.click(domElement);
-    strictEqual(detail, browserUtils.isIE ? 0 : 1);
-});
-
-test('mouse double click event detail value', function () {
-    bindMouseEvent('dblclick', eventUtils.BUTTON.left);
-    eventSimulator.dblclick(domElement);
-    strictEqual(detail, browserUtils.isIE ? 0 : 2);
-});
-
-test('mouse mouse down event detail value', function () {
-    bindMouseEvent('mousedown', eventUtils.BUTTON.left);
-    eventSimulator.mousedown(domElement);
-    strictEqual(detail, 1);
-
-    detail = 0;
-    bindMouseEvent('mousedown', eventUtils.BUTTON.right);
-    eventSimulator.mousedown(domElement);
-    strictEqual(detail, 0);
-});
-
-test('mouse mouse up event detail value', function () {
-    bindMouseEvent('mouseup', eventUtils.BUTTON.left);
-    eventSimulator.mouseup(domElement);
-    strictEqual(detail, 1);
-
-    detail = 0;
-    bindMouseEvent('mouseup', eventUtils.BUTTON.right);
-    eventSimulator.mouseup(domElement);
-    strictEqual(detail, 0);
-});
-
 test('mouse left button click', function () {
     bindMouseEvent('click', eventUtils.BUTTON.left);
     eventSimulator.click(domElement);
@@ -480,6 +446,50 @@ test('drag and drop events', function () {
     document.body.removeChild(input);
 });
 
+module('e.detail');
+
+test('mouse left click', function () {
+    bindMouseEvent('click', eventUtils.BUTTON.left);
+    eventSimulator.click(domElement);
+    strictEqual(detail, browserUtils.isIE ? 0 : 1);
+});
+
+// Check native behavior
+// test('mouse right click', function () {
+//     bindMouseEvent('click', eventUtils.BUTTON.left);
+//     eventSimulator.click(domElement);
+//     strictEqual(detail, browserUtils.isFirefox ? 1 : 0);
+// });
+
+test('mouse double click', function () {
+    bindMouseEvent('dblclick', eventUtils.BUTTON.left);
+    eventSimulator.dblclick(domElement);
+    strictEqual(detail, browserUtils.isIE ? 0 : 2);
+});
+
+test('mouse down left', function () {
+    bindMouseEvent('mousedown', eventUtils.BUTTON.left);
+    eventSimulator.mousedown(domElement);
+    strictEqual(detail, 1);
+});
+
+test('mouse up left', function () {
+    bindMouseEvent('mouseup', eventUtils.BUTTON.left);
+    eventSimulator.mouseup(domElement);
+    strictEqual(detail, 1);
+});
+
+test('mouse down right', function () {
+    bindMouseEvent('mousedown', eventUtils.BUTTON.right);
+    eventSimulator.mousedown(domElement);
+    strictEqual(detail, 0);
+});
+
+test('mouse up right', function () {
+    bindMouseEvent('mouseup', eventUtils.BUTTON.right);
+    eventSimulator.mouseup(domElement);
+    strictEqual(detail, 0);
+});
 
 module('regression');
 

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -69,12 +69,14 @@ test('mouse left button click', function () {
     bindMouseEvent('click', eventUtils.BUTTON.left);
     eventSimulator.click(domElement);
     ok(raised);
+    strictEqual(detail, browserUtils.isIE ? 0 : 1, 'should provide the correct event.detail value');
 });
 
 test('mouse double click', function () {
     bindMouseEvent('dblclick', eventUtils.BUTTON.left);
     eventSimulator.dblclick(domElement);
     ok(raised);
+    strictEqual(detail, browserUtils.isIE ? 0 : 2, 'should provide the correct event.detail value');
 });
 
 test('mouse right click', function () {
@@ -83,30 +85,35 @@ test('mouse right click', function () {
     bindMouseEvent('mouseup', eventUtils.BUTTON.right);
     eventSimulator.rightclick(domElement);
     ok(raised);
+    strictEqual(detail, browserUtils.isIE ? 0 : 1, 'should provide the correct event.detail value');
 });
 
-test('mouse down', function () {
+test('mouse down left', function () {
     bindMouseEvent('mousedown', eventUtils.BUTTON.left);
     eventSimulator.mousedown(domElement);
     ok(raised);
+    strictEqual(detail, 1, 'should provide the correct event.detail value');
 });
 
-test('mouse up', function () {
+test('mouse up left', function () {
     bindMouseEvent('mouseup', eventUtils.BUTTON.left);
     eventSimulator.mouseup(domElement);
     ok(raised);
+    strictEqual(detail, 1, 'should provide the correct event.detail value');
 });
 
 test('mouse down right', function () {
     bindMouseEvent('mousedown', eventUtils.BUTTON.right);
     eventSimulator.mousedown(domElement, { button: eventUtils.BUTTON.right });
     ok(raised);
+    strictEqual(detail, 1, 'should provide the correct event.detail value');
 });
 
-test('mouse up  right', function () {
+test('mouse up right', function () {
     bindMouseEvent('mouseup', eventUtils.BUTTON.right);
     eventSimulator.mouseup(domElement, { button: eventUtils.BUTTON.right });
     ok(raised);
+    strictEqual(detail, 1, 'should provide the correct event.detail value');
 });
 
 test('context menu', function () {
@@ -444,50 +451,6 @@ test('drag and drop events', function () {
 
     document.body.removeChild(anchor);
     document.body.removeChild(input);
-});
-
-module('e.detail');
-
-test('mouse left click', function () {
-    bindMouseEvent('click', eventUtils.BUTTON.left);
-    eventSimulator.click(domElement);
-    strictEqual(detail, browserUtils.isIE ? 0 : 1);
-});
-
-test('mouse right click', function () {
-    bindMouseEvent('click', eventUtils.BUTTON.right);
-    eventSimulator.rightclick(domElement);
-    strictEqual(detail, browserUtils.isIE ? 0 : 1);
-});
-
-test('mouse double click', function () {
-    bindMouseEvent('dblclick', eventUtils.BUTTON.left);
-    eventSimulator.dblclick(domElement);
-    strictEqual(detail, browserUtils.isIE ? 0 : 2);
-});
-
-test('mouse down left', function () {
-    bindMouseEvent('mousedown', eventUtils.BUTTON.left);
-    eventSimulator.mousedown(domElement);
-    strictEqual(detail, 1);
-});
-
-test('mouse up left', function () {
-    bindMouseEvent('mouseup', eventUtils.BUTTON.left);
-    eventSimulator.mouseup(domElement);
-    strictEqual(detail, 1);
-});
-
-test('mouse down right', function () {
-    bindMouseEvent('mousedown', eventUtils.BUTTON.right);
-    eventSimulator.mousedown(domElement, { button: eventUtils.BUTTON.right });
-    strictEqual(detail, 1);
-});
-
-test('mouse up right', function () {
-    bindMouseEvent('mouseup', eventUtils.BUTTON.right);
-    eventSimulator.mouseup(domElement, { button: eventUtils.BUTTON.right });
-    strictEqual(detail, 1);
 });
 
 module('regression');

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -455,8 +455,8 @@ test('mouse left click', function () {
 });
 
 test('mouse right click', function () {
-    bindMouseEvent('click', eventUtils.BUTTON.left);
-    eventSimulator.click(domElement);
+    bindMouseEvent('click', eventUtils.BUTTON.right);
+    eventSimulator.rightclick(domElement);
     strictEqual(detail, browserUtils.isIE ? 0 : 1);
 });
 
@@ -480,14 +480,14 @@ test('mouse up left', function () {
 
 test('mouse down right', function () {
     bindMouseEvent('mousedown', eventUtils.BUTTON.right);
-    eventSimulator.mousedown(domElement);
-    strictEqual(detail, 0);
+    eventSimulator.mousedown(domElement, { button: eventUtils.BUTTON.right });
+    strictEqual(detail, 1);
 });
 
 test('mouse up right', function () {
     bindMouseEvent('mouseup', eventUtils.BUTTON.right);
-    eventSimulator.mouseup(domElement);
-    strictEqual(detail, 0);
+    eventSimulator.mouseup(domElement, { button: eventUtils.BUTTON.right });
+    strictEqual(detail, 1);
 });
 
 module('regression');

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -453,6 +453,7 @@ test('drag and drop events', function () {
     document.body.removeChild(input);
 });
 
+
 module('regression');
 
 if (browserUtils.isIE) {

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -454,12 +454,11 @@ test('mouse left click', function () {
     strictEqual(detail, browserUtils.isIE ? 0 : 1);
 });
 
-// Check native behavior
-// test('mouse right click', function () {
-//     bindMouseEvent('click', eventUtils.BUTTON.left);
-//     eventSimulator.click(domElement);
-//     strictEqual(detail, browserUtils.isFirefox ? 1 : 0);
-// });
+test('mouse right click', function () {
+    bindMouseEvent('click', eventUtils.BUTTON.left);
+    eventSimulator.click(domElement);
+    strictEqual(detail, browserUtils.isIE ? 0 : 1);
+});
 
 test('mouse double click', function () {
     bindMouseEvent('dblclick', eventUtils.BUTTON.left);


### PR DESCRIPTION
Close: https://github.com/DevExpress/testcafe/issues/2232

Note: example from testcafe issue fails in Internet Explorer 11 (without proxy) because ```e.detail```  = 0 in ```click``` event.

### Changes:
1. Actual event.detail value for some [Mouse Events](https://www.w3.org/TR/uievents/#events-mouseevents): ```click```, ```dblclick```, ```mousedown```, ```mouseup``` is added.
2. Refactor default ```options``` argument in simulator.js

### Links:
https://www.w3.org/TR/uievents/#events-mouseevents

https://www.w3.org/TR/uievents/#dom-uievent-detail:
> UIEvent . detail
Specifies some detail information about the Event, depending on the type of event.
**The un-initialized value of this attribute MUST be 0.**

https://www.w3.org/TR/uievents/#current-click-count:
> Implementations MUST maintain the current click count when generating mouse events. This MUST be a non-negative integer indicating the number of consecutive clicks of a pointing device button within a specific time. The delay after which the count resets is specific to the environment configuration.

### Current click count rule
If ```e.details``` is not defined in ```_getUIEventArgs()``` ```options``` argument, we set it according to rule: each event is considered separately. 

### Events from hardware mouse actions. 

```click```, ```contextmenu```(not in W3C UI Events, e.detail = 1 for right click), ```dblclick```, ```mousedown```, ```mouseup```:
```javascript
function logDetail(e) {
    console.log(e.type + ' e.detail = ' + e.detail)
}

window.addEventListener('click', logDetail);
window.addEventListener('contextmenu', logDetail);
window.addEventListener('dblclick', logDetail);
window.addEventListener('mouseup', logDetail);
window.addEventListener('mousedown', logDetail);
```
**Left click.**
Chrome, Firefox, Edge:
```
mousedown e.detail = 1
mouseup e.detail   = 1
click e.detail     = 1
```
Internet Explorer 11:
```
mousedown e.detail = 1
mouseup e.detail   = 1
click e.detail     = 0
```
**Right click.**
Chrome, Edge, Internet Explorer 11:
```
mousedown e.detail   = 1
mouseup e.detail     = 1
contextmenu e.detail = 0
```
Firefox:
```
mousedown e.detail   = 1
mouseup e.detail     = 1
click e.detail       = 1
contextmenu e.detail = 1 (!)
```

**Double click.**
Chrome, Firefox, Edge:
```
mousedown e.detail = 1 
mouseup e.detail   = 1 
click e.detail     = 1
mousedown e.detail = 2
mouseup e.detail   = 2
click e.detail     = 2
dblclick e.detail  = 2
```
Internet Explorer 11:
```
mousedown e.detail = 1 
mouseup e.detail   = 1 
click e.detail     = 0
mousedown e.detail = 2
mouseup e.detail   = 2
click e.detail     = 0
dblclick e.detail  = 0
```