### PR TITLE
fix mocha timeout in debug mode

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -170,10 +170,8 @@ gulp.task('build', ['client-scripts', 'server-scripts', 'templates', 'lint']);
 gulp.task('test-server', ['build'], () => {
     return gulp.src('./test/server/*-test.js', { read: false })
         .pipe(mocha({
-            ui:        'bdd',
-            reporter:  'spec',
             // NOTE: Disable timeouts in debug mode.
-            timeout:   typeof v8debug === 'undefined' ? 2000 : Infinity,
+            timeout:   typeof v8debug !== 'undefined' || !!process.debugPort ? Infinity : 2000,
             fullTrace: true
         }));
 });


### PR DESCRIPTION
@LavrovArtem 

Changes
* Fix timeout for mocha debug mode. In new odejs versions (6.x and later) `v8debug` global object was removed (https://github.com/nodejs/node/pull/6599).
* remove mocha config properties with default values: `ui`, `reporter`.