### PR TITLE
fix href-hammerhead-stored-value attribute duplication after the SVGImageElement.href.baseVal property value is changed

### DIFF
--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -749,9 +749,9 @@ export default class WindowSandbox extends SandboxBase {
                 const contextSVGImageElement = this[CONTEXT_SVG_IMAGE_ELEMENT];
 
                 if (contextSVGImageElement) {
-                    const isXlinkHrefAttrExists = nativeMethods.hasAttributeNS.call(contextSVGImageElement, XLINK_NAMESPACE, 'href');
+                    const hasXlinkHrefAttr = nativeMethods.hasAttributeNS.call(contextSVGImageElement, XLINK_NAMESPACE, 'href');
 
-                    windowSandbox.nodeSandbox.element.setAttributeCore(contextSVGImageElement, [isXlinkHrefAttrExists ? 'xlink:href' : 'href', value]);
+                    windowSandbox.nodeSandbox.element.setAttributeCore(contextSVGImageElement, [hasXlinkHrefAttr ? 'xlink:href' : 'href', value]);
                     value = getProxyUrl(value);
                 }
 

--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -749,11 +749,9 @@ export default class WindowSandbox extends SandboxBase {
                 const contextSVGImageElement = this[CONTEXT_SVG_IMAGE_ELEMENT];
 
                 if (contextSVGImageElement) {
-                    if (nativeMethods.hasAttributeNS.call(contextSVGImageElement, XLINK_NAMESPACE, 'href'))
-                        windowSandbox.nodeSandbox.element.setAttributeCore(contextSVGImageElement, ['xlink:href', value]);
-                    else
-                        windowSandbox.nodeSandbox.element.setAttributeCore(contextSVGImageElement, ['href', value]);
+                    const isXlinkHrefAttrExists = nativeMethods.hasAttributeNS.call(contextSVGImageElement, XLINK_NAMESPACE, 'href');
 
+                    windowSandbox.nodeSandbox.element.setAttributeCore(contextSVGImageElement, [isXlinkHrefAttrExists ? 'xlink:href' : 'href', value]);
                     value = getProxyUrl(value);
                 }
 

--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -746,13 +746,13 @@ export default class WindowSandbox extends SandboxBase {
                 return baseVal;
             },
             setter: function (value) {
-                const contextImageElemet = this[CONTEXT_SVG_IMAGE_ELEMENT];
+                const contextSVGImageElement = this[CONTEXT_SVG_IMAGE_ELEMENT];
 
-                if (contextImageElemet) {
-                    if (nativeMethods.hasAttributeNS.call(contextImageElemet, XLINK_NAMESPACE, 'href'))
-                        windowSandbox.nodeSandbox.element.setAttributeCore(contextImageElemet, [XLINK_NAMESPACE, 'href', value], true);
+                if (contextSVGImageElement) {
+                    if (nativeMethods.hasAttributeNS.call(contextSVGImageElement, XLINK_NAMESPACE, 'href'))
+                        windowSandbox.nodeSandbox.element.setAttributeCore(contextSVGImageElement, ['xlink:href', value]);
                     else
-                        windowSandbox.nodeSandbox.element.setAttributeCore(contextImageElemet, ['href', value]);
+                        windowSandbox.nodeSandbox.element.setAttributeCore(contextSVGImageElement, ['href', value]);
 
                     value = getProxyUrl(value);
                 }

--- a/src/client/utils/html.js
+++ b/src/client/utils/html.js
@@ -124,7 +124,7 @@ function processHtmlInternal (html, process) {
 
     // NOTE: hack for IE (GH-1083)
     if (isIE && !isMSEdge && html !== processedHtml)
-        processedHtml = removeExtraSvgNamespeces(html, processedHtml);
+        processedHtml = removeExtraSvgNamespaces(html, processedHtml);
 
     return processedHtml;
 }
@@ -243,7 +243,7 @@ export function dispose () {
     htmlDocument = null;
 }
 
-function removeExtraSvgNamespeces (html, processedHtml) {
+function removeExtraSvgNamespaces (html, processedHtml) {
     const initialSvgStrs = html.match(FIND_SVG_RE);
     let index            = 0;
 

--- a/src/processing/dom/base-dom-adapter.js
+++ b/src/processing/dom/base-dom-adapter.js
@@ -10,7 +10,7 @@ export default class BaseDomAdapter {
             'onkeypress', 'onkeyup', 'onload', 'onmousedown', 'onmouseenter', 'onmouseleave',
             'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'onmousewheel', 'onpaste', 'onreset',
             'onresize', 'onscroll', 'onselect', 'onsubmit', 'ontextinput', 'onunload', 'onwheel',
-            'onpointerdown', 'onpoi nterup', 'onpointercancel', 'onpointermove', 'onpointerover', 'onpointerout',
+            'onpointerdown', 'onpointerup', 'onpointercancel', 'onpointermove', 'onpointerover', 'onpointerout',
             'onpointerenter', 'onpointerleave', 'ongotpointercapture', 'onlostpointercapture',
             'onmspointerdown', 'onmspointerup', 'onmspointercancel', 'onmspointermove', 'onmspointerover',
             'onmspointerout', 'onmspointerenter', 'onmspointerleave', 'onmsgotpointercapture', 'onmslostpointercapture'

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -497,7 +497,10 @@ test('SVGImageElement with an existing xlink:href should contain only one stored
     var image = div.getElementsByTagName('image')[0];
 
     var checkHrefStoredAttribute = function () {
-        ok(nativeMethods.getAttribute.call(image, 'xlink:' + DomProcessor.getStoredAttrName('href')));
+        // NOTE: IE add extra 'ns1:' namespace to stored xlink href attribute
+        var extraNamespace = browserUtils.isIE ? 'ns1:' : '';
+
+        ok(nativeMethods.getAttribute.call(image, extraNamespace + 'xlink:' + DomProcessor.getStoredAttrName('href')));
         notOk(nativeMethods.getAttribute.call(image, DomProcessor.getStoredAttrName('href')));
         notOk(nativeMethods.getAttributeNS.call(image, xlinkNamespaceUrl, 'xlink:' + DomProcessor.getStoredAttrName('href')));
         notOk(nativeMethods.getAttributeNS.call(image, xlinkNamespaceUrl, DomProcessor.getStoredAttrName('href')));

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -483,6 +483,26 @@ test('element.innerHTML', function () {
     checkElement($container.find('script')[0], 'src', '!s');
 });
 
+test('SVGImageElement should not contain duplicate stored href attributes after href.baseVal is changed', function () {
+    var svgNameSpaceUrl = 'http://www.w3.org/2000/svg';
+    var svg             = document.createElementNS(svgNameSpaceUrl, 'svg');
+    var changedUrl      = 'http://domain.com/test-test.svg';
+
+    document.body.appendChild(svg);
+    svg.outerHTML = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' +
+                    '    <image id="svg-image-xlink-href" xlink:href="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png"></image>\n' +
+                    '</svg>';
+
+    document.getElementById('svg-image-xlink-href').href.baseVal = changedUrl;
+
+    var html = '<image id="svg-image-xlink-href" ' +
+               'xmlns:xlink="http://www.w3.org/1999/xlink" ' +
+               'xlink:href="http://localhost:2000/sessionId/http://domain.com/test-test.svg" ' +
+               'xlink:href-hammerhead-stored-value="http://domain.com/test-test.svg"></image>';
+
+    strictEqual(document.getElementById('svg-image-xlink-href').outerHTML, html);
+});
+
 test('anchor with target attribute', function () {
     var anchor   = document.createElement('a');
     var url      = 'http://url.com/';

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -484,30 +484,31 @@ test('element.innerHTML', function () {
 });
 
 test('SVGImageElement with an existing xlink:href should contain only one stored href attribute after href.baseVal is changed', function () {
-    function getStoredHrefAttrCount (obj) {
-        var count = 0;
+    var div               = document.createElement('div');
+    var svgNameSpaceUrl   = 'http://www.w3.org/2000/svg';
+    var xlinkNamespaceUrl = 'http://www.w3.org/1999/xlink';
+    var newBaseVal        = 'http://example.com/test-1.svg';
 
-        obj.getAttributeNames().forEach(function (attr) {
-            if (attr.indexOf(DomProcessor.getStoredAttrName('href')) !== -1)
-                count++;
-        });
+    var html = '<svg xmlns="' + svgNameSpaceUrl + '" xmlns:xlink="' + xlinkNamespaceUrl + '">\n' +
+               '<image xlink:href="http://example.com/test.svg"></image>\n' +
+               '</svg>';
 
-        return count;
-    }
+    setProperty(div, 'innerHTML', html);
 
-    var svgNameSpaceUrl = 'http://www.w3.org/2000/svg';
-    var svg             = document.createElementNS(svgNameSpaceUrl, 'svg');
-    var changedUrl      = 'http://domain.com/test-test.svg';
+    var image = div.getElementsByTagName('image')[0];
 
-    document.body.appendChild(svg);
-    svg.outerHTML = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' +
-                    '<image id="svg-image-xlink-href" ' +
-                    '       xlink:href="test.svg" ' +
-                    '       xlink:' + DomProcessor.getStoredAttrName('href') + '="test.svg"></image>\n' +
-                    '</svg>';
+    var checkHrefStoredAttribute = function () {
+        ok(nativeMethods.getAttribute.call(image, 'xlink:' + DomProcessor.getStoredAttrName('href')));
+        notOk(nativeMethods.getAttribute.call(image, DomProcessor.getStoredAttrName('href')));
+        notOk(nativeMethods.getAttributeNS.call(image, xlinkNamespaceUrl, 'xlink:' + DomProcessor.getStoredAttrName('href')));
+        notOk(nativeMethods.getAttributeNS.call(image, xlinkNamespaceUrl, DomProcessor.getStoredAttrName('href')));
+    };
 
-    document.getElementById('svg-image-xlink-href').href.baseVal = changedUrl;
-    strictEqual(getStoredHrefAttrCount(document.getElementById('svg-image-xlink-href')), 1);
+    checkHrefStoredAttribute();
+
+    image.href.baseVal = newBaseVal;
+
+    checkHrefStoredAttribute();
 });
 
 test('anchor with target attribute', function () {

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -485,11 +485,10 @@ test('element.innerHTML', function () {
 
 test('SVGImageElement with an existing xlink:href should contain only one stored href attribute after href.baseVal is changed', function () {
     var div               = document.createElement('div');
-    var svgNameSpaceUrl   = 'http://www.w3.org/2000/svg';
     var xlinkNamespaceUrl = 'http://www.w3.org/1999/xlink';
     var newBaseVal        = 'http://example.com/test-1.svg';
 
-    var html = '<svg xmlns="' + svgNameSpaceUrl + '" xmlns:xlink="' + xlinkNamespaceUrl + '">\n' +
+    var html = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="' + xlinkNamespaceUrl + '">\n' +
                '<image xlink:href="http://example.com/test.svg"></image>\n' +
                '</svg>';
 

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -483,35 +483,36 @@ test('element.innerHTML', function () {
     checkElement($container.find('script')[0], 'src', '!s');
 });
 
-test('SVGImageElement with an existing xlink:href should contain only one stored href attribute after href.baseVal is changed', function () {
-    var div               = document.createElement('div');
-    var xlinkNamespaceUrl = 'http://www.w3.org/1999/xlink';
-    var baseVal           = 'http://example.com/test.svg';
+// NOTE: IE11 adds extra 'NS' namespace to stored xlink href attribute during processing (GH-1083)
+if (!browserUtils.isIE11) {
+    test('SVGImageElement with an existing xlink:href should contain only one stored href attribute after href.baseVal is changed', function () {
+        var div               = document.createElement('div');
+        var xlinkNamespaceUrl = 'http://www.w3.org/1999/xlink';
+        var baseVal           = 'http://example.com/test.svg';
 
-    // NOTE: IE11 adds extra 'ns1:' namespace to stored xlink href attribute during processing,
-    // so we use div.innerHTML = html with existed xlink:href-hammerhead-stored-value attribute for all cases.
-    var html = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="' + xlinkNamespaceUrl + '">\n' +
-               '<image xlink:href="' + baseVal + '" xlink:href-hammerhead-stored-value="' + baseVal + '"></image>\n' +
-               '</svg>';
+        var html = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="' + xlinkNamespaceUrl + '">\n' +
+                   '<image xlink:href="' + baseVal + '"></image>\n' +
+                   '</svg>';
 
-    div.innerHTML = html;
+        setProperty(div, 'innerHTML', html);
 
-    var image = div.querySelector('image');
+        var image = div.querySelector('image');
 
-    var checkHrefStoredAttribute = function () {
-        strictEqual(nativeMethods.getAttribute.call(image, 'xlink:' + DomProcessor.getStoredAttrName('href')), baseVal);
-        notOk(nativeMethods.getAttribute.call(image, DomProcessor.getStoredAttrName('href')));
-        notOk(nativeMethods.getAttributeNS.call(image, xlinkNamespaceUrl, 'xlink:' + DomProcessor.getStoredAttrName('href')));
-        notOk(nativeMethods.getAttributeNS.call(image, xlinkNamespaceUrl, DomProcessor.getStoredAttrName('href')));
-    };
+        var checkHrefStoredAttribute = function (el) {
+            strictEqual(nativeMethods.getAttribute.call(el, 'xlink:' + DomProcessor.getStoredAttrName('href')), baseVal);
+            notOk(nativeMethods.getAttribute.call(el, DomProcessor.getStoredAttrName('href')));
+            notOk(nativeMethods.getAttributeNS.call(el, xlinkNamespaceUrl, 'xlink:' + DomProcessor.getStoredAttrName('href')));
+            notOk(nativeMethods.getAttributeNS.call(el, xlinkNamespaceUrl, DomProcessor.getStoredAttrName('href')));
+        };
 
-    checkHrefStoredAttribute();
+        checkHrefStoredAttribute(image);
 
-    baseVal            = 'http://example.com/test-1.svg';
-    image.href.baseVal = baseVal;
+        baseVal            = 'http://example.com/test-1.svg';
+        image.href.baseVal = baseVal;
 
-    checkHrefStoredAttribute();
-});
+        checkHrefStoredAttribute(image);
+    });
+}
 
 test('anchor with target attribute', function () {
     var anchor   = document.createElement('a');

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -483,14 +483,12 @@ test('element.innerHTML', function () {
     checkElement($container.find('script')[0], 'src', '!s');
 });
 
-test('SVGImageElement with an existing xlink:href should contain only one stored href attributes after href.baseVal is changed', function () {
-    var storedHrefAttr = 'href-hammerhead-stored-value';
-
+test('SVGImageElement with an existing xlink:href should contain only one stored href attribute after href.baseVal is changed', function () {
     function getStoredHrefAttrCount (obj) {
         var count = 0;
 
         obj.getAttributeNames().forEach(function (attr) {
-            if (attr.indexOf(storedHrefAttr) !== -1)
+            if (attr.indexOf(DomProcessor.getStoredAttrName('href')) !== -1)
                 count++;
         });
 
@@ -505,7 +503,7 @@ test('SVGImageElement with an existing xlink:href should contain only one stored
     svg.outerHTML = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' +
                     '<image id="svg-image-xlink-href" ' +
                     '       xlink:href="test.svg" ' +
-                    '       xlink:href-hammerhead-stored-value="test.svg"></image>\n' +
+                    '       xlink:' + DomProcessor.getStoredAttrName('href') + '="test.svg"></image>\n' +
                     '</svg>';
 
     document.getElementById('svg-image-xlink-href').href.baseVal = changedUrl;

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -483,24 +483,33 @@ test('element.innerHTML', function () {
     checkElement($container.find('script')[0], 'src', '!s');
 });
 
-test('SVGImageElement should not contain duplicate stored href attributes after href.baseVal is changed', function () {
+test('SVGImageElement with an existing xlink:href should contain only one stored href attributes after href.baseVal is changed', function () {
+    var storedHrefAttr = 'href-hammerhead-stored-value';
+
+    function getStoredHrefAttrCount (obj) {
+        var count = 0;
+
+        obj.getAttributeNames().forEach(function (attr) {
+            if (attr.indexOf(storedHrefAttr) !== -1)
+                count++;
+        });
+
+        return count;
+    }
+
     var svgNameSpaceUrl = 'http://www.w3.org/2000/svg';
     var svg             = document.createElementNS(svgNameSpaceUrl, 'svg');
     var changedUrl      = 'http://domain.com/test-test.svg';
 
     document.body.appendChild(svg);
     svg.outerHTML = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n' +
-                    '    <image id="svg-image-xlink-href" xlink:href="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png"></image>\n' +
+                    '<image id="svg-image-xlink-href" ' +
+                    '       xlink:href="test.svg" ' +
+                    '       xlink:href-hammerhead-stored-value="test.svg"></image>\n' +
                     '</svg>';
 
     document.getElementById('svg-image-xlink-href').href.baseVal = changedUrl;
-
-    var html = '<image id="svg-image-xlink-href" ' +
-               'xmlns:xlink="http://www.w3.org/1999/xlink" ' +
-               'xlink:href="http://localhost:2000/sessionId/http://domain.com/test-test.svg" ' +
-               'xlink:href-hammerhead-stored-value="http://domain.com/test-test.svg"></image>';
-
-    strictEqual(document.getElementById('svg-image-xlink-href').outerHTML, html);
+    strictEqual(getStoredHrefAttrCount(document.getElementById('svg-image-xlink-href')), 1);
 });
 
 test('anchor with target attribute', function () {

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -486,21 +486,20 @@ test('element.innerHTML', function () {
 test('SVGImageElement with an existing xlink:href should contain only one stored href attribute after href.baseVal is changed', function () {
     var div               = document.createElement('div');
     var xlinkNamespaceUrl = 'http://www.w3.org/1999/xlink';
-    var newBaseVal        = 'http://example.com/test-1.svg';
+    var baseVal           = 'http://example.com/test.svg';
 
+    // NOTE: IE11 adds extra 'ns1:' namespace to stored xlink href attribute during processing,
+    // so we use div.innerHTML = html with existed xlink:href-hammerhead-stored-value attribute for all cases.
     var html = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="' + xlinkNamespaceUrl + '">\n' +
-               '<image xlink:href="http://example.com/test.svg"></image>\n' +
+               '<image xlink:href="' + baseVal + '" xlink:href-hammerhead-stored-value="' + baseVal + '"></image>\n' +
                '</svg>';
 
-    setProperty(div, 'innerHTML', html);
+    div.innerHTML = html;
 
-    var image = div.getElementsByTagName('image')[0];
+    var image = div.querySelector('image');
 
     var checkHrefStoredAttribute = function () {
-        // NOTE: IE11 add extra 'ns1:' namespace to stored xlink href attribute
-        var extraNamespace = browserUtils.isIE11 ? 'ns1:' : '';
-
-        ok(nativeMethods.getAttribute.call(image, extraNamespace + 'xlink:' + DomProcessor.getStoredAttrName('href')));
+        strictEqual(nativeMethods.getAttribute.call(image, 'xlink:' + DomProcessor.getStoredAttrName('href')), baseVal);
         notOk(nativeMethods.getAttribute.call(image, DomProcessor.getStoredAttrName('href')));
         notOk(nativeMethods.getAttributeNS.call(image, xlinkNamespaceUrl, 'xlink:' + DomProcessor.getStoredAttrName('href')));
         notOk(nativeMethods.getAttributeNS.call(image, xlinkNamespaceUrl, DomProcessor.getStoredAttrName('href')));
@@ -508,7 +507,8 @@ test('SVGImageElement with an existing xlink:href should contain only one stored
 
     checkHrefStoredAttribute();
 
-    image.href.baseVal = newBaseVal;
+    baseVal            = 'http://example.com/test-1.svg';
+    image.href.baseVal = baseVal;
 
     checkHrefStoredAttribute();
 });

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -497,8 +497,8 @@ test('SVGImageElement with an existing xlink:href should contain only one stored
     var image = div.getElementsByTagName('image')[0];
 
     var checkHrefStoredAttribute = function () {
-        // NOTE: IE add extra 'ns1:' namespace to stored xlink href attribute
-        var extraNamespace = browserUtils.isIE ? 'ns1:' : '';
+        // NOTE: IE11 add extra 'ns1:' namespace to stored xlink href attribute
+        var extraNamespace = browserUtils.isIE11 ? 'ns1:' : '';
 
         ok(nativeMethods.getAttribute.call(image, extraNamespace + 'xlink:' + DomProcessor.getStoredAttrName('href')));
         notOk(nativeMethods.getAttribute.call(image, DomProcessor.getStoredAttrName('href')));


### PR DESCRIPTION
### Issue reproducing:
### 1. Processed page element
DevTools:Element:
```html
<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
    <image id="svg-image-xlink-href" 
           xlink:href="http://localhost:1401/HBGv6d7Vv/http://example.com" 
           height="200" 
           width="200" 
           xlink:href-hammerhead-stored-value="http://example.com">
    </image>
</svg>
```
### 2. Changing ```href.baseVal```
```javascript
var newHref = 'https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png';
__get$(document.getElementById('svg-image-xlink-href'),"href").baseVal = newHref;
```

### 3. Result. ```href-hammerhead-stored-value``` duplication
DevTools:Element:
```html
<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
    <image id="svg-image-xlink-href" 
           xlink:href="http://localhost:1401/HBGv6d7Vv/https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" 
           height="200" 
           width="200" 
           xlink:href-hammerhead-stored-value="http://example.com" 
           xlink:href-hammerhead-stored-value="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png">
    </image>
</svg>
```