### PR TITLE
fix `Cookie processing problem related to applications running on 'localhost' with non-default port` (close #1491)

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -13,7 +13,7 @@ import * as typeUtils from './utils/types';
 import * as positionUtils from './utils/position';
 import * as styleUtils from './utils/style';
 import trim from '../utils/string-trim';
-import { isRelativeUrl, parseProxyUrl, isSpecialPage, ensureOriginTrailingSlash } from '../utils/url';
+import { isRelativeUrl, parseProxyUrl, isSpecialPage, prepareUrl } from '../utils/url';
 import * as urlUtils from './utils/url';
 import * as featureDetection from './utils/feature-detection';
 import * as htmlUtils from './utils/html';
@@ -201,7 +201,7 @@ class Hammerhead {
         if (isSpecialPage(destLocation) && isRelativeUrl(url))
             return;
 
-        url = ensureOriginTrailingSlash(url);
+        url = prepareUrl(url);
 
         const proxyUrl = urlUtils.getProxyUrl(url);
 

--- a/src/client/sandbox/code-instrumentation/location/wrapper.js
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.js
@@ -14,7 +14,7 @@ import {
     getResourceTypeString,
     sameOriginCheck,
     ensureTrailingSlash,
-    ensureOriginTrailingSlash
+    prepareUrl
 } from '../../../../utils/url';
 import nativeMethods from '../../native-methods';
 import urlResolver from '../../../utils/url-resolver';
@@ -62,7 +62,7 @@ export default class LocationWrapper extends EventEmitter {
             return ensureTrailingSlash(href, locationUrl);
         };
         const getProxiedHref = href => {
-            href = ensureOriginTrailingSlash(href);
+            href = prepareUrl(href);
 
             if (isJsProtocol(href))
                 return processJsAttrValue(href, { isJsProtocol: true, isEventAttr: false });

--- a/src/client/sandbox/code-instrumentation/properties/index.js
+++ b/src/client/sandbox/code-instrumentation/properties/index.js
@@ -7,7 +7,7 @@ import * as destLocation from '../../../utils/destination-location';
 import * as domUtils from '../../../utils/dom';
 import * as typeUtils from '../../../utils/types';
 import * as urlUtils from '../../../utils/url';
-import { ensureOriginTrailingSlash } from '../../../../utils/url';
+import { prepareUrl } from '../../../../utils/url';
 import { cleanUpHtml, processHtml } from '../../../utils/html';
 import { getAttributesProperty } from './attributes';
 import styleProcessor from '../../../../processing/style';
@@ -266,7 +266,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
                         /*eslint-disable no-restricted-properties*/
                         if (!locationWrapper) {
                             if (!isJsProtocol(location)) {
-                                const url          = ensureOriginTrailingSlash(location);
+                                const url          = prepareUrl(location);
                                 const resourceType = urlUtils.stringifyResourceType({ isIframe: true });
 
                                 owner.location = destLocation.sameOriginCheck(location.toString(), url)

--- a/src/client/sandbox/cookie/index.js
+++ b/src/client/sandbox/cookie/index.js
@@ -68,21 +68,22 @@ export default class CookieSandbox extends SandboxBase {
         if (parsedCookie.httponly)
             return false;
 
+        const parsedDestLocation = destLocation.getParsed();
+
         /*eslint-disable no-restricted-properties*/
-        const destProtocol = destLocation.getParsed().protocol;
+        const destProtocol = parsedDestLocation.protocol;
         /*eslint-enable no-restricted-properties*/
 
         // NOTE: Hammerhead tunnels HTTPS requests via HTTP, so we need to validate the Secure attribute manually.
         if (parsedCookie.secure && destProtocol !== 'https:')
             return false;
 
-        // NOTE: Add a relative protocol portion to the domain, so that we can use urlUtils for the same origin check.
-        const domain = parsedCookie.domain && '//' + parsedCookie.domain;
-
 
         // NOTE: All Hammerhad sessions have the same domain, so we need to validate the Domain attribute manually
         // according to a test url.
-        return !domain || destLocation.sameOriginCheck(destLocation.get(), domain);
+        /*eslint-disable no-restricted-properties*/
+        return !parsedCookie.domain || parsedDestLocation.hostname === parsedCookie.domain;
+        /*eslint-enable no-restricted-properties*/
     }
 
     _updateClientCookieStr (cookieKey, newCookieStr) {

--- a/src/client/utils/destination-location.js
+++ b/src/client/utils/destination-location.js
@@ -31,14 +31,11 @@ export function sameOriginCheck (location, checkedUrl, rejectForSubdomains) {
     if (checkedUrl)
         checkedUrl = resolveUrl(checkedUrl);
 
-    // NOTE: exclude the default port from 'same origin check'
-    location = location.replace(sharedUrlUtils.DEFAULT_PORT, '');
-
     return sharedUrlUtils.sameOriginCheck(location, checkedUrl, rejectForSubdomains);
 }
 
 export function resolveUrl (url, doc) {
-    url = sharedUrlUtils.prepareUrl(url);
+    url = sharedUrlUtils.processSpecialChars(url);
 
     /*eslint-disable no-restricted-properties*/
     if (url && url.indexOf('//') === 0)

--- a/src/client/utils/destination-location.js
+++ b/src/client/utils/destination-location.js
@@ -31,6 +31,9 @@ export function sameOriginCheck (location, checkedUrl, rejectForSubdomains) {
     if (checkedUrl)
         checkedUrl = resolveUrl(checkedUrl);
 
+    // NOTE: exclude the default port from 'same origin check'
+    location = location.replace(sharedUrlUtils.DEFAULT_PORT, '');
+
     return sharedUrlUtils.sameOriginCheck(location, checkedUrl, rejectForSubdomains);
 }
 

--- a/src/processing/resources/index.js
+++ b/src/processing/resources/index.js
@@ -20,7 +20,7 @@ function getResourceUrlReplacer (ctx) {
 
         // NOTE: Resolves base URLs without a protocol ('//google.com/path' for example).
         baseUrl     = baseUrl ? url.resolve(ctx.dest.url, baseUrl) : '';
-        resourceUrl = urlUtil.prepareUrl(resourceUrl);
+        resourceUrl = urlUtil.processSpecialChars(resourceUrl);
 
         let resolvedUrl = url.resolve(baseUrl || ctx.dest.url, resourceUrl);
 

--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -166,7 +166,7 @@ export default class Proxy extends Router {
         if (externalProxySettings)
             session.setExternalProxySettings(externalProxySettings);
 
-        url = urlUtils.ensureOriginTrailingSlash(url);
+        url = urlUtils.prepareUrl(url);
 
         return urlUtils.getProxyUrl(url, {
             proxyHostname: this.server1Info.hostname,

--- a/src/request-pipeline/context.js
+++ b/src/request-pipeline/context.js
@@ -5,8 +5,6 @@ import * as contentTypeUtils from '../utils/content-type';
 import genearateUniqueId from '../utils/generate-unique-id';
 
 const REDIRECT_STATUS_CODES = [301, 302, 303, 307, 308];
-const HTTP_DEFAUL_PORT      = '80';
-const HTTPS_DEFAUL_PORT     = '443';
 
 export default class RequestPipelineContext {
     constructor (req, res, serverInfo) {
@@ -51,7 +49,7 @@ export default class RequestPipelineContext {
         if (parsed) {
             const parsedResourceType = urlUtils.parseResourceType(parsed.resourceType);
 
-            let dest = {
+            const dest = {
                 url:           parsed.destUrl,
                 protocol:      parsed.destResourceInfo.protocol,
                 host:          parsed.destResourceInfo.host,
@@ -68,8 +66,6 @@ export default class RequestPipelineContext {
                 reqOrigin:     parsed.reqOrigin
             };
 
-            dest = this._omitDefaultPort(dest);
-
             return {
                 dest:      dest,
                 sessionId: parsed.sessionId
@@ -77,21 +73,6 @@ export default class RequestPipelineContext {
         }
 
         return null;
-    }
-
-    _omitDefaultPort (dest) {
-        // NOTE: Browsers may send the default port in the 'referer' header. But since we compose the destination
-        // URL from it, we need to skip the port number if it's the protocol's default port. Some servers have
-        // host conditions that do not include a port number.
-        const hasDefaultPort = dest.protocol === 'https:' && dest.port === HTTPS_DEFAUL_PORT ||
-                               dest.protocol === 'http:' && dest.port === HTTP_DEFAUL_PORT;
-
-        if (hasDefaultPort) {
-            dest.host = dest.host.split(':')[0];
-            dest.port = '';
-        }
-
-        return dest;
     }
 
     _getDestFromReferer (parsedReferer) {

--- a/src/request-pipeline/header-transforms.js
+++ b/src/request-pipeline/header-transforms.js
@@ -49,7 +49,7 @@ function transformCookie (src, ctx) {
 }
 
 function resolveAndGetProxyUrl (url, ctx) {
-    url = urlUtils.ensureOriginTrailingSlash(url);
+    url = urlUtils.prepareUrl(url);
 
     const { host }    = parseUrl(url);
     let isCrossDomain = false;

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -20,6 +20,8 @@ export const REQUEST_DESCRIPTOR_VALUES_SEPARATOR = '!';
 export const TRAILING_SLASH_RE                   = /\/$/;
 export const SPECIAL_PAGES                       = ['about:blank', 'about:error'];
 
+export const DEFAULT_PORT = ':80';
+
 export function parseResourceType (resourceType) {
     if (!resourceType) {
         return {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -394,14 +394,11 @@ export function omitDefaultPort (url) {
     // then browser remove this one itself.
     const parsedUrl = parseUrl(url);
 
-    // NOTE: Browsers may send the default port in the 'referer' header. But since we compose the destination
-    // URL from it, we need to skip the port number if it's the protocol's default port. Some servers have
-    // host conditions that do not include a port number.
     const hasDefaultPort = parsedUrl.protocol === 'https:' && parsedUrl.port === HTTPS_DEFAULT_PORT ||
                            parsedUrl.protocol === 'http:' && parsedUrl.port === HTTP_DEFAULT_PORT;
 
     if (hasDefaultPort) {
-        parsedUrl.host = parsedUrl.host.split(':')[0];
+        parsedUrl.host = parsedUrl.hostname;
         parsedUrl.port = '';
 
         return formatUrl(parsedUrl);

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -301,7 +301,7 @@ test('should omit the default port on page navigation', function () {
         location: ''
     };
 
-    function testCase (url, shouldOmitPort) {
+    function testUrl (url, shouldOmitPort) {
         locationWrapper.href = url;
         strictEqual(windowMock.location.href, getExpectedProxyUrl(url, shouldOmitPort), 'href = ' + url);
 
@@ -316,12 +316,12 @@ test('should omit the default port on page navigation', function () {
     }
 
     function testDefaultPortOmitting (protocol, defaultPort, defaultPortForAnotherProtocol) {
-        testCase(protocol + '//localhost:' + defaultPort + '/', true);
-        testCase(protocol + '//127.0.0.1:' + defaultPort + '/', true);
-        testCase(protocol + '//example.com:' + defaultPort + '/', true);
-        testCase(protocol + '//example.com:' + defaultPort + '/page.html', true);
-        testCase(protocol + '//localhost:' + defaultPortForAnotherProtocol + '/', false);
-        testCase(protocol + '//localhost:2343/', false);
+        testUrl(protocol + '//localhost:' + defaultPort + '/', true);
+        testUrl(protocol + '//127.0.0.1:' + defaultPort + '/', true);
+        testUrl(protocol + '//example.com:' + defaultPort + '/', true);
+        testUrl(protocol + '//example.com:' + defaultPort + '/page.html', true);
+        testUrl(protocol + '//localhost:' + defaultPortForAnotherProtocol + '/', false);
+        testUrl(protocol + '//localhost:2343/', false);
     }
 
     testDefaultPortOmitting('http:', '80', '443');

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -591,8 +591,8 @@ describe('Proxy', () => {
                 });
         });
 
-        describe('Should process SET_COOKIE service message', () => {
-            it('Without set-cookie domain', () => {
+        describe.only('SET_COOKIE service message', () => {
+            it('Should process the message without domain directive', () => {
                 const options = {
                     method:                  'POST',
                     url:                     'http://localhost:1836/cookie-sync',
@@ -620,7 +620,7 @@ describe('Proxy', () => {
                     });
             });
 
-            it('With correct set-cookie domain and default port', () => {
+            it('Should process the message with correct domain directive on default port', () => {
                 const options = {
                     method:                  'POST',
                     url:                     'http://localhost:1836/cookie-sync',
@@ -669,7 +669,7 @@ describe('Proxy', () => {
                     });
             });
 
-            it('With correct set-cookie domain and non-default port', () => {
+            it('Should process the message with correct domain directive on non-default port', () => {
                 const options = {
                     method:                  'POST',
                     url:                     'http://localhost:1836/cookie-sync',
@@ -721,7 +721,7 @@ describe('Proxy', () => {
                     });
             });
 
-            it('With wrong set-cookie domain and default port', () => {
+            it('Should process the message with wrong domain directive on default port', () => {
                 const options = {
                     method:                  'POST',
                     url:                     'http://localhost:1836/cookie-sync',
@@ -750,23 +750,23 @@ describe('Proxy', () => {
                                 cookie: 'Test=Data; Domain=anotherdomain.com'
                             },
                             {
-                                url:    proxy.openSession('https://localhost:80', session),
+                                url:    proxy.openSession('https://localhost:443', session),
                                 cookie: 'TestSecure=Data; Domain=127.0.0.1; Secure'
                             },
                             {
-                                url:    proxy.openSession('https://127.0.0.1:80', session),
+                                url:    proxy.openSession('https://127.0.0.1:443', session),
                                 cookie: 'TestSecure=Data; Domain=localhost; Secure'
                             },
                             {
-                                url:    proxy.openSession('https://127.0.0.1:80', session),
+                                url:    proxy.openSession('https://127.0.0.1:443', session),
                                 cookie: 'TestSecure=Data; Domain=localhost:4512; Secure'
                             },
                             {
-                                url:    proxy.openSession('https://localhost:80', session),
+                                url:    proxy.openSession('https://localhost:443', session),
                                 cookie: 'TestSecure=Data; Domain=127.0.0.1:4723; Secure'
                             },
                             {
-                                url:    proxy.openSession('https://example.com:80', session),
+                                url:    proxy.openSession('https://example.com:443', session),
                                 cookie: 'TestSecure=Data; Domain=anotherdomain.com; Secure'
                             }
                         ]

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -591,7 +591,7 @@ describe('Proxy', () => {
                 });
         });
 
-        describe.only('SET_COOKIE service message', () => {
+        describe('SET_COOKIE service message', () => {
             it('Should process the message without domain directive', () => {
                 const options = {
                     method:                  'POST',


### PR DESCRIPTION
### Example
https://github.com/DevExpress/testcafe-hammerhead/issues/1491

### Changes:
1. Refactor default port omitting (the default port is omitted in Chrome, Firefox, Edge, Internet Explorer browsers)
2. localhost/127.0.0.1 (http/https) with default port (80/443) case. If the cookie domain and the current url hostname are equal to localhost/127.0.0.1, we should remove Domain=... form cookie (see tough-cookie: getPublicSuffix('localhost') check)
3. Non-default localhost/127.0.0.1 (http/https) case. Host name check in `_isValidCookie()` instead of same origin check

### Reference:
https://github.com/DevExpress/testcafe-hammerhead/issues/659