### PR TITLE
fix vulnerabilities (publish-please, ws)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ addons:
    - dbus
 
 before_install:
- - npm i -g npm@latest
+ # Update npm version (GH-1644)
+ - npm_version=$(npm -v); if [ ${npm_version:1:1} = 3 ]; then npm i -g npm@latest; fi
  - export $(dbus-launch)
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
    - dbus
 
 before_install:
- - if [[ `npm -v` == 3* ]]; then npm i -g npm@latest; fi echo "npm latest version is installed"
+ - npm i -g npm@latest
  - export $(dbus-launch)
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ before_install:
  # https://github.com/inikulin/publish-please/issues/66
  - |
    npm_version=$(npm -v);
-   if [ ${npm_version:0:1} = 3 ]; then
-    echo "succes";
+   if [ ${npm_version:0:1} <= 3 ]; then
     npm install -g npm@latest;
    fi
  - export $(dbus-launch)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,13 @@ addons:
    - dbus
 
 before_install:
- # Update npm version (GH-1644)
- - npm_version=$(npm -v); if [ ${npm_version:1:1} = 3 ]; then npm i -g npm@latest; fi
+ # https://github.com/inikulin/publish-please/issues/66
+ - |
+   npm_version=$(npm -v);
+   if [ ${npm_version:0:1} = 3 ]; then
+    echo "succes";
+    npm install -g npm@latest;
+   fi
  - export $(dbus-launch)
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
  # https://github.com/inikulin/publish-please/issues/66
  - |
    npm_version=$(npm -v);
-   if [ ${npm_version:0:1} <= 3 ]; then
+   if [ ${npm_version:0:1} -le 3 ]; then
     npm install -g npm@latest;
    fi
  - export $(dbus-launch)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
    - dbus
 
 before_install:
+ - if [[ `npm -v` == 3* ]]; then npm i -g npm@latest; fi echo "npm latest version is installed"
  - export $(dbus-launch)
 
 matrix:

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "request-promise-native": "^1.0.5",
     "tmp": "0.0.26",
     "webmake": "0.3.42",
-    "ws": "3.2.0"
+    "ws": "^5.2.0"
   },
   "main": "lib/index",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "bowser": "1.6.0",
     "brotli": "^1.3.1",
+    "chalk": "^1.1.0",
     "crypto-md5": "^1.0.0",
     "css": "2.2.3",
     "gulp-run-command": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "bowser": "1.6.0",
     "brotli": "^1.3.1",
-    "chalk": "^1.1.0",
     "crypto-md5": "^1.0.0",
     "css": "2.2.3",
     "gulp-run-command": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "gulp-webmake": "0.0.4",
     "multiline": "^1.0.2",
     "openssl-self-signed-certificate": "1.1.6",
-    "publish-please": "^2.0.0",
+    "publish-please": "^3.0.1",
     "request": "^2.34.0",
     "request-promise-native": "^1.0.5",
     "tmp": "0.0.26",

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -1933,7 +1933,7 @@ describe('Proxy', () => {
                 });
         });
 
-        it('Should exposes number of bytes received', function (done) {
+        it('Should send/receive message', function (done) {
             getFreePort()
                 .then(port => {
                     const url = urlUtils.getProxyUrl('http://localhost:' + port, {
@@ -1948,8 +1948,8 @@ describe('Proxy', () => {
                     const wsTemporaryServer = new WebSocket.Server({ port: port }, () => {
                         const ws = new WebSocket(url);
 
-                        ws.on('message', () => {
-                            expect(ws.bytesReceived).eql(8);
+                        ws.on('message', message => {
+                            expect(message).eql('foobar');
                             wsTemporaryServer.close(done);
                         });
                     });


### PR DESCRIPTION
Before:
```
found 20 vulnerabilities (6 low, 11 moderate, 3 high)
```

Current:
```
found 13 vulnerabilities (5 low, 7 moderate, 1 high)
```

### Changes
1. Update `publish-please`.
2. Update `ws`.

### `npm install --save-dev publish-please@3.0.1`
**Workaround:** update `npm` version in Travis `nvm install 6` case.

### `npm install --save-dev ws@5.2.0`
https://github.com/websockets/ws/releases/tag/4.0.0:

> The non-standard `protocolVersion` and `bytesReceived` attributes have been
> removed
