### PR TITLE
fix `The 'formtarget' attribute should be overriden` (close #1513)

### DIFF
--- a/src/client/dom-processor/client-dom-adapter.js
+++ b/src/client/dom-processor/client-dom-adapter.js
@@ -113,6 +113,6 @@ export default class ClientDomAdapter extends BaseDomAdapter {
     }
 
     isExistingTarget (target) {
-        return findByName(target);
+        return !!findByName(target);
     }
 }

--- a/src/client/dom-processor/client-dom-adapter.js
+++ b/src/client/dom-processor/client-dom-adapter.js
@@ -8,6 +8,7 @@ import { getProxyUrl } from '../utils/url';
 import * as domUtils from '../utils/dom';
 import fastApply from '../utils/fast-apply';
 import { hasUnclosedElementFlag } from '../sandbox/node/document/writer';
+import { findByName } from '../sandbox/windows-storage';
 
 export default class ClientDomAdapter extends BaseDomAdapter {
     removeAttr (el, attr) {
@@ -109,5 +110,9 @@ export default class ClientDomAdapter extends BaseDomAdapter {
 
     sameOriginCheck (location, checkedUrl) {
         return sameOriginCheck(location, checkedUrl);
+    }
+
+    isExistingTarget (target) {
+        return findByName(target);
     }
 }

--- a/src/client/sandbox/native-methods.js
+++ b/src/client/sandbox/native-methods.js
@@ -259,6 +259,8 @@ class NativeMethods {
         const formTargetDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLFormElement.prototype, 'target');
         const areaTargetDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLAreaElement.prototype, 'target');
         const baseTargetDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLBaseElement.prototype, 'target');
+        const inputFormTargetDescriptor      = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'formTarget');
+        const buttonFormTargetDescriptor     = win.Object.getOwnPropertyDescriptor(win.HTMLButtonElement.prototype, 'formTarget');
         const svgImageHrefDescriptor         = win.Object.getOwnPropertyDescriptor(win.SVGImageElement.prototype, 'href');
         const svgAnimStrAnimValDescriptor    = win.Object.getOwnPropertyDescriptor(win.SVGAnimatedString.prototype, 'animVal');
         const svgAnimStrBaseValDescriptor    = win.Object.getOwnPropertyDescriptor(win.SVGAnimatedString.prototype, 'baseVal');
@@ -304,6 +306,8 @@ class NativeMethods {
         this.formTargetSetter        = formTargetDescriptor.set;
         this.areaTargetSetter        = areaTargetDescriptor.set;
         this.baseTargetSetter        = baseTargetDescriptor.set;
+        this.inputFormTargetSetter   = inputFormTargetDescriptor.set;
+        this.buttonFormTargetSetter  = buttonFormTargetDescriptor.set;
         this.svgAnimStrBaseValSetter = svgAnimStrBaseValDescriptor.set;
         this.inputAutocompleteSetter = inputAutocompleteDescriptor.set;
         this.formActionSetter        = formActionDescriptor.set;
@@ -380,6 +384,8 @@ class NativeMethods {
         this.formTargetGetter               = formTargetDescriptor.get;
         this.areaTargetGetter               = areaTargetDescriptor.get;
         this.baseTargetGetter               = baseTargetDescriptor.get;
+        this.inputFormTargetGetter          = inputFormTargetDescriptor.get;
+        this.buttonFormTargetGetter         = buttonFormTargetDescriptor.get;
         this.svgImageHrefGetter             = svgImageHrefDescriptor.get;
         this.svgAnimStrAnimValGetter        = svgAnimStrAnimValDescriptor.get;
         this.svgAnimStrBaseValGetter        = svgAnimStrBaseValDescriptor.get;

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -198,6 +198,19 @@ export default class ElementSandbox extends SandboxBase {
             else
                 return null;
         }
+        else if (loweredAttr === 'formtarget' && DomProcessor.isTagWithFormTargetAttr(tagName)) {
+            const currentFormTarget = nativeMethods.getAttribute.call(el, 'formtarget');
+            const newFormTarget     = this.getTarget(el, value);
+
+            if (newFormTarget !== currentFormTarget) {
+                const storedFormTargetAttr = DomProcessor.getStoredAttrName(attr);
+
+                setAttrMeth.apply(el, isNs ? [ns, storedFormTargetAttr, value] : [storedFormTargetAttr, value]);
+                args[valueIndex] = newFormTarget;
+            }
+            else
+                return null;
+        }
         else if (attr === 'sandbox') {
             const storedSandboxAttr = DomProcessor.getStoredAttrName(attr);
             const allowSameOrigin   = value.indexOf('allow-same-origin') !== -1;
@@ -281,7 +294,8 @@ export default class ElementSandbox extends SandboxBase {
         if (domProcessor.isUrlAttr(el, formatedAttr, isNs ? args[0] : null) || formatedAttr === 'sandbox' ||
             formatedAttr === 'autocomplete' ||
             domProcessor.EVENTS.indexOf(formatedAttr) !== -1 ||
-            formatedAttr === 'target' && DomProcessor.isTagWithTargetAttr(tagName)) {
+            formatedAttr === 'target' && DomProcessor.isTagWithTargetAttr(tagName) ||
+            formatedAttr === 'formtarget' && DomProcessor.isTagWithFormTargetAttr(tagName)) {
             const storedAttr = DomProcessor.getStoredAttrName(attr);
 
             if (formatedAttr === 'autocomplete')

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -158,10 +158,10 @@ export default class ElementSandbox extends SandboxBase {
                     let resourceType       = domProcessor.getElementResourceType(el);
                     const elCharset        = isScript && el.charset;
 
-                    if (loweredAttr === 'formaction' && !el.hasAttribute('formtarget')) {
+                    if (loweredAttr === 'formaction' && !nativeMethods.hasAttribute.call(el, 'formtarget')) {
                         resourceType = 'f';
 
-                        if (el.form && el.form.hasAttribute('action')) {
+                        if (el.form && nativeMethods.hasAttribute.call(el.form, 'action')) {
                             const parsedFormAction = urlUtils.parseProxyUrl(nativeMethods.formActionGetter.call(el.form));
 
                             if (parsedFormAction)

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -792,7 +792,9 @@ export default class ElementSandbox extends SandboxBase {
 
         // NOTE: we need to reprocess a tag client-side if it wasn't processed on the server.
         // See the usage of Parse5DomAdapter.needToProcessUrl
-        if (DomProcessor.isIframeFlagTag(tagName) && nativeMethods.getAttribute.call(el, 'target') === '_parent')
+        const targetAttr = domProcessor.getTargetAttr(el);
+
+        if (DomProcessor.isIframeFlagTag(tagName) && nativeMethods.getAttribute.call(el, targetAttr) === '_parent')
             domProcessor.processElement(el, urlUtils.convertToProxyUrl);
     }
 }

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -161,7 +161,7 @@ export default class ElementSandbox extends SandboxBase {
                     if (loweredAttr === 'formaction' && !el.hasAttribute('formtarget')) {
                         resourceType = 'f';
 
-                        if (el.form) {
+                        if (el.form && el.form.hasAttribute('action')) {
                             const parsedFormAction = urlUtils.parseProxyUrl(nativeMethods.formActionGetter.call(el.form));
 
                             if (parsedFormAction)

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -184,8 +184,9 @@ export default class ElementSandbox extends SandboxBase {
 
             args[valueIndex] = 'off';
         }
-        else if (loweredAttr === 'target' && DomProcessor.isTagWithTargetAttr(tagName)) {
-            const currentTarget = nativeMethods.getAttribute.call(el, 'target');
+        else if (loweredAttr === 'target' && DomProcessor.isTagWithTargetAttr(tagName) ||
+                 loweredAttr === 'formtarget' && DomProcessor.isTagWithFormTargetAttr(tagName)) {
+            const currentTarget = nativeMethods.getAttribute.call(el, loweredAttr);
             const newTarget     = this.getTarget(el, value);
 
             if (newTarget !== currentTarget) {
@@ -194,19 +195,6 @@ export default class ElementSandbox extends SandboxBase {
                 setAttrMeth.apply(el, isNs ? [ns, storedTargetAttr, value] : [storedTargetAttr, value]);
                 args[valueIndex]        = newTarget;
                 needToCallTargetChanged = true;
-            }
-            else
-                return null;
-        }
-        else if (loweredAttr === 'formtarget' && DomProcessor.isTagWithFormTargetAttr(tagName)) {
-            const currentFormTarget = nativeMethods.getAttribute.call(el, 'formtarget');
-            const newFormTarget     = this.getTarget(el, value);
-
-            if (newFormTarget !== currentFormTarget) {
-                const storedFormTargetAttr = DomProcessor.getStoredAttrName(attr);
-
-                setAttrMeth.apply(el, isNs ? [ns, storedFormTargetAttr, value] : [storedFormTargetAttr, value]);
-                args[valueIndex] = newFormTarget;
             }
             else
                 return null;

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -193,8 +193,10 @@ export default class ElementSandbox extends SandboxBase {
                 const storedTargetAttr = DomProcessor.getStoredAttrName(attr);
 
                 setAttrMeth.apply(el, isNs ? [ns, storedTargetAttr, value] : [storedTargetAttr, value]);
-                args[valueIndex]        = newTarget;
-                needToCallTargetChanged = true;
+                args[valueIndex] = newTarget;
+
+                if (loweredAttr === 'target')
+                    needToCallTargetChanged = true;
             }
             else
                 return null;

--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -783,6 +783,11 @@ export default class WindowSandbox extends SandboxBase {
             window.HTMLBaseElement
         ]);
 
+        this._overrideAttrDescriptors('formTarget', [
+            window.HTMLInputElement,
+            window.HTMLButtonElement
+        ]);
+
         this._overrideAttrDescriptors('autocomplete', [window.HTMLInputElement]);
 
         // NOTE: Some browsers (for example, Edge, Internet Explorer 11, Safari) don't support the 'integrity' property.
@@ -1001,8 +1006,12 @@ export default class WindowSandbox extends SandboxBase {
                         processedValue = styleProcessor.process(processedValue, getProxyUrl, true);
                     else if (isScriptEl)
                         processedValue = processScript(processedValue, true);
-                    else
-                        processedValue = processHtml(processedValue, { parentTag: el.tagName });
+                    else {
+                        processedValue = processHtml(processedValue, {
+                            parentTag:        el.tagName,
+                            processedContext: el[INTERNAL_PROPS.processedContext]
+                        });
+                    }
                 }
 
                 if (!isStyleEl && !isScriptEl)

--- a/src/processing/dom/attributes.js
+++ b/src/processing/dom/attributes.js
@@ -9,4 +9,11 @@ export const URL_ATTR_TAGS = {
 
 export const URL_ATTRS = Object.keys(URL_ATTR_TAGS);
 
+export const TARGET_ATTR_TAGS = {
+    target:     ['a', 'form', 'area', 'base'],
+    formtarget: ['input', 'button']
+};
+
+export const TARGET_ATTRS = Object.keys(TARGET_ATTR_TAGS);
+
 export const ATTRS_WITH_SPECIAL_PROXYING_LOGIC = ['sandbox', 'autocomplete', 'target', 'formtarget', 'style'];

--- a/src/processing/dom/attributes.js
+++ b/src/processing/dom/attributes.js
@@ -9,4 +9,4 @@ export const URL_ATTR_TAGS = {
 
 export const URL_ATTRS = Object.keys(URL_ATTR_TAGS);
 
-export const ATTRS_WITH_SPECIAL_PROXYING_LOGIC = ['sandbox', 'autocomplete', 'target', 'style'];
+export const ATTRS_WITH_SPECIAL_PROXYING_LOGIC = ['sandbox', 'autocomplete', 'target', 'formtarget', 'style'];

--- a/src/processing/dom/base-dom-adapter.js
+++ b/src/processing/dom/base-dom-adapter.js
@@ -96,4 +96,8 @@ export default class BaseDomAdapter {
     getClassName () {
         throw new Error('Not implemented');
     }
+
+    isExistingTarget () {
+        throw new Error('Not implemented');
+    }
 }

--- a/src/processing/dom/index.js
+++ b/src/processing/dom/index.js
@@ -107,6 +107,10 @@ export default class DomProcessor {
 
             HAS_FORMACTION_ATTR: el => this.isUrlAttr(el, 'formaction'),
 
+            HAS_TARGET_ATTR: el => {
+                return DomProcessor.isTagWithTargetAttr(adapter.getTagName(el)) && adapter.hasAttr(el, 'target');
+            },
+
             HAS_FORMTARGET_ATTR: el => {
                 return DomProcessor.isTagWithFormTargetAttr(adapter.getTagName(el)) && adapter.hasAttr(el, 'formtarget');
             },
@@ -152,27 +156,32 @@ export default class DomProcessor {
             {
                 selector:          selectors.HAS_HREF_ATTR,
                 urlAttr:           'href',
-                elementProcessors: [this._processTargetBlank, this._processUrlAttrs, this._processUrlJsAttr]
+                elementProcessors: [this._processUrlAttrs, this._processUrlJsAttr]
             },
             {
                 selector:          selectors.HAS_SRC_ATTR,
                 urlAttr:           'src',
-                elementProcessors: [this._processTargetBlank, this._processUrlAttrs, this._processUrlJsAttr]
+                elementProcessors: [this._processUrlAttrs, this._processUrlJsAttr]
             },
             {
                 selector:          selectors.HAS_ACTION_ATTR,
                 urlAttr:           'action',
-                elementProcessors: [this._processTargetBlank, this._processUrlAttrs, this._processUrlJsAttr]
+                elementProcessors: [this._processUrlAttrs, this._processUrlJsAttr]
             },
             {
                 selector:          selectors.HAS_FORMACTION_ATTR,
                 urlAttr:           'formaction',
-                elementProcessors: [this._processTargetBlank, this._processUrlAttrs, this._processUrlJsAttr]
+                elementProcessors: [this._processUrlAttrs, this._processUrlJsAttr]
+            },
+            {
+                selector:          selectors.HAS_TARGET_ATTR,
+                targetAttr:        'target',
+                elementProcessors: [this._processTargetBlank]
             },
             {
                 selector:          selectors.HAS_FORMTARGET_ATTR,
-                urlAttr:           'formtarget',
-                elementProcessors: [this._processFormTargetBlank]
+                targetAttr:        'formtarget',
+                elementProcessors: [this._processTargetBlank]
             },
             {
                 selector:          selectors.HAS_MANIFEST_ATTR,
@@ -448,35 +457,19 @@ export default class DomProcessor {
         }
     }
 
-    _processTargetBlank (el) {
-        const storedTargetAttr = DomProcessor.getStoredAttrName('target');
-        const processed        = this.adapter.hasAttr(el, storedTargetAttr);
-
-        if (!processed) {
-            let attrValue = this.adapter.getAttr(el, 'target');
-
-            // NOTE: Value may have whitespace.
-            attrValue = attrValue && attrValue.replace(/\s/g, '');
-
-            if (attrValue === '_blank' || attrValue === 'blank') {
-                this.adapter.setAttr(el, 'target', '_top');
-                this.adapter.setAttr(el, storedTargetAttr, attrValue);
-            }
-        }
-    }
-
-    _processFormTargetBlank (el) {
-        const storedFormTargetAttr = DomProcessor.getStoredAttrName('formtarget');
+    _processTargetBlank (el, urlReplacer, pattern) {
+        const targetAttr           = pattern.targetAttr;
+        const storedFormTargetAttr = DomProcessor.getStoredAttrName(targetAttr);
         const processed            = this.adapter.hasAttr(el, storedFormTargetAttr);
 
         if (!processed) {
-            let attrValue = this.adapter.getAttr(el, 'formtarget');
+            let attrValue = this.adapter.getAttr(el, targetAttr);
 
             // NOTE: Value may have whitespace.
             attrValue = attrValue && attrValue.replace(/\s/g, '');
 
             if (attrValue === '_blank' || attrValue === 'blank') {
-                this.adapter.setAttr(el, 'formtarget', '_top');
+                this.adapter.setAttr(el, targetAttr, '_top');
                 this.adapter.setAttr(el, storedFormTargetAttr, attrValue);
             }
         }

--- a/src/processing/dom/index.js
+++ b/src/processing/dom/index.js
@@ -458,9 +458,9 @@ export default class DomProcessor {
     }
 
     _processTargetBlank (el, urlReplacer, pattern) {
-        const targetAttr           = pattern.targetAttr;
-        const storedFormTargetAttr = DomProcessor.getStoredAttrName(targetAttr);
-        const processed            = this.adapter.hasAttr(el, storedFormTargetAttr);
+        const targetAttr       = pattern.targetAttr;
+        const storedTargetAttr = DomProcessor.getStoredAttrName(targetAttr);
+        const processed        = this.adapter.hasAttr(el, storedTargetAttr);
 
         if (!processed) {
             let attrValue = this.adapter.getAttr(el, targetAttr);
@@ -470,7 +470,7 @@ export default class DomProcessor {
 
             if (attrValue === '_blank' || attrValue === 'blank') {
                 this.adapter.setAttr(el, targetAttr, '_top');
-                this.adapter.setAttr(el, storedFormTargetAttr, attrValue);
+                this.adapter.setAttr(el, storedTargetAttr, attrValue);
             }
         }
     }

--- a/src/processing/dom/index.js
+++ b/src/processing/dom/index.js
@@ -156,16 +156,19 @@ export default class DomProcessor {
             {
                 selector:          selectors.HAS_HREF_ATTR,
                 urlAttr:           'href',
+                targetAttr:        'target',
                 elementProcessors: [this._processTargetBlank, this._processUrlAttrs, this._processUrlJsAttr]
             },
             {
                 selector:          selectors.HAS_SRC_ATTR,
                 urlAttr:           'src',
+                targetAttr:        'target',
                 elementProcessors: [this._processTargetBlank, this._processUrlAttrs, this._processUrlJsAttr]
             },
             {
                 selector:          selectors.HAS_ACTION_ATTR,
                 urlAttr:           'action',
+                targetAttr:        'target',
                 elementProcessors: [this._processTargetBlank, this._processUrlAttrs, this._processUrlJsAttr]
             },
             {
@@ -461,18 +464,17 @@ export default class DomProcessor {
     }
 
     _processTargetBlank (el, urlReplacer, pattern) {
-        const targetAttr       = pattern.targetAttr || 'target';
-        const storedTargetAttr = DomProcessor.getStoredAttrName(targetAttr);
+        const storedTargetAttr = DomProcessor.getStoredAttrName(pattern.targetAttr);
         const processed        = this.adapter.hasAttr(el, storedTargetAttr);
 
         if (!processed) {
-            let attrValue = this.adapter.getAttr(el, targetAttr);
+            let attrValue = this.adapter.getAttr(el, pattern.targetAttr);
 
             // NOTE: Value may have whitespace.
             attrValue = attrValue && attrValue.replace(/\s/g, '');
 
             if (attrValue === '_blank' || attrValue === 'blank') {
-                this.adapter.setAttr(el, targetAttr, '_top');
+                this.adapter.setAttr(el, pattern.targetAttr, '_top');
                 this.adapter.setAttr(el, storedTargetAttr, attrValue);
             }
         }
@@ -488,12 +490,11 @@ export default class DomProcessor {
             // NOTE: Page resource URL with proxy URL.
             if ((resourceUrl || resourceUrl === '') && !processedOnServer) {
                 if (urlUtils.isSupportedProtocol(resourceUrl) || isSpecialPage) {
-                    const elTagName  = this.adapter.getTagName(el);
-                    const isIframe   = elTagName === 'iframe' || elTagName === 'frame';
-                    const isScript   = elTagName === 'script';
-                    const isAnchor   = elTagName === 'a';
-                    const targetAttr = pattern.targetAttr || 'target';
-                    const target     = this.adapter.getAttr(el, targetAttr);
+                    const elTagName = this.adapter.getTagName(el);
+                    const isIframe  = elTagName === 'iframe' || elTagName === 'frame';
+                    const isScript  = elTagName === 'script';
+                    const isAnchor  = elTagName === 'a';
+                    const target    = this.adapter.getAttr(el, pattern.targetAttr);
 
                     // NOTE: Elements with target=_parent shouldn’t be processed on the server,because we don't
                     // know what is the parent of the processed page (an iframe or the top window).

--- a/src/processing/dom/index.js
+++ b/src/processing/dom/index.js
@@ -106,10 +106,6 @@ export default class DomProcessor {
 
             HAS_FORMACTION_ATTR: el => this.isUrlAttr(el, 'formaction'),
 
-            HAS_TARGET_ATTR: el => {
-                return DomProcessor.isTagWithTargetAttr(adapter.getTagName(el)) && adapter.hasAttr(el, 'target');
-            },
-
             HAS_FORMTARGET_ATTR: el => {
                 return DomProcessor.isTagWithFormTargetAttr(adapter.getTagName(el)) && adapter.hasAttr(el, 'formtarget');
             },
@@ -153,30 +149,24 @@ export default class DomProcessor {
 
         return [
             {
-                selector:          selectors.HAS_TARGET_ATTR,
-                targetAttr:        'target',
-                elementProcessors: [this._processTargetBlank]
-            },
-            {
                 selector:          selectors.HAS_FORMTARGET_ATTR,
-                urlAttr:           'formaction',
                 targetAttr:        'formtarget',
-                elementProcessors: [this._processTargetBlank, this._processUrlAttrs, this._processUrlJsAttr]
+                elementProcessors: [this._processTargetBlank]
             },
             {
                 selector:          selectors.HAS_HREF_ATTR,
                 urlAttr:           'href',
-                elementProcessors: [this._processUrlAttrs, this._processUrlJsAttr]
+                elementProcessors: [this._processTargetBlank, this._processUrlAttrs, this._processUrlJsAttr]
             },
             {
                 selector:          selectors.HAS_SRC_ATTR,
                 urlAttr:           'src',
-                elementProcessors: [this._processUrlAttrs, this._processUrlJsAttr]
+                elementProcessors: [this._processTargetBlank, this._processUrlAttrs, this._processUrlJsAttr]
             },
             {
                 selector:          selectors.HAS_ACTION_ATTR,
                 urlAttr:           'action',
-                elementProcessors: [this._processUrlAttrs, this._processUrlJsAttr]
+                elementProcessors: [this._processTargetBlank, this._processUrlAttrs, this._processUrlJsAttr]
             },
             {
                 selector:          selectors.HAS_FORMACTION_ATTR,
@@ -471,7 +461,7 @@ export default class DomProcessor {
     }
 
     _processTargetBlank (el, urlReplacer, pattern) {
-        const targetAttr       = pattern.targetAttr;
+        const targetAttr       = pattern.targetAttr || 'target';
         const storedTargetAttr = DomProcessor.getStoredAttrName(targetAttr);
         const processed        = this.adapter.hasAttr(el, storedTargetAttr);
 
@@ -502,7 +492,7 @@ export default class DomProcessor {
                     const isIframe   = elTagName === 'iframe' || elTagName === 'frame';
                     const isScript   = elTagName === 'script';
                     const isAnchor   = elTagName === 'a';
-                    const targetAttr = pattern.targetAttr ? pattern.targetAttr : 'target';
+                    const targetAttr = pattern.targetAttr || 'target';
                     const target     = this.adapter.getAttr(el, targetAttr);
 
                     // NOTE: Elements with target=_parent shouldn’t be processed on the server,because we don't

--- a/src/processing/dom/index.js
+++ b/src/processing/dom/index.js
@@ -48,11 +48,11 @@ export default class DomProcessor {
     }
 
     static isTagWithTargetAttr (tagName) {
-        return TARGET_ATTR_TAGS['target'].indexOf(tagName) !== -1;
+        return TARGET_ATTR_TAGS['target'].indexOf(tagName) > -1;
     }
 
     static isTagWithFormTargetAttr (tagName) {
-        return TARGET_ATTR_TAGS['formtarget'].indexOf(tagName) !== -1;
+        return TARGET_ATTR_TAGS['formtarget'].indexOf(tagName) > -1;
     }
 
     static isTagWithIntegrityAttr (tagName) {
@@ -270,7 +270,7 @@ export default class DomProcessor {
         const tagName = this.adapter.getTagName(el);
 
         for (const targetAttr of TARGET_ATTRS) {
-            if (TARGET_ATTR_TAGS[targetAttr].indexOf(tagName) !== -1)
+            if (TARGET_ATTR_TAGS[targetAttr].indexOf(tagName) > -1)
                 return targetAttr;
         }
 

--- a/src/processing/dom/parse5-dom-adapter.js
+++ b/src/processing/dom/parse5-dom-adapter.js
@@ -105,4 +105,8 @@ export default class Parse5DomAdapter extends BaseDomAdapter {
     sameOriginCheck (location, checkedUrl) {
         return urlUtils.sameOriginCheck(location, checkedUrl);
     }
+
+    isExistingTarget () {
+        return false;
+    }
 }

--- a/test/client/data/dom-processor/iframe-with-nonproceed-on-server-tags.html
+++ b/test/client/data/dom-processor/iframe-with-nonproceed-on-server-tags.html
@@ -16,8 +16,15 @@
     });
 </script>
 <a id="processed-anchor" target="_parent" href="http://localhost/anchor-action.html">link</a>
-<form id="processed-form" target="_parent" action="http://localhost/form-action.html"></form>
+<form id="tst-form" target="_blank" action="http://localhost/form-action.html"></form>
+<form id="processed-form" target="_parent" action="http://localhost/form-action.html">
+    <input id="processed-input" formaction="http://localhost/input-formAction.html" formtarget="_parent">
+    <button id="processed-button" formaction="http://localhost/button-formAction.html" formtarget="_parent"></button>
+</form>
 <a id="non-processed-anchor" target="_self" href="http://localhost/anchor-action.html">link</a>
-<form id="non-processed-form" action="http://localhost/form-action.html"></form>
+<form id="non-processed-form" action="http://localhost/form-action.html">
+    <input id="non-processed-input" formaction="http://localhost/input-formAction.html">
+    <button id="non-processed-button" formaction="http://localhost/button-formAction.html"></button>
+</form>
 </body>
 </html>

--- a/test/client/fixtures/sandbox/fetch-test.js
+++ b/test/client/fixtures/sandbox/fetch-test.js
@@ -217,7 +217,12 @@ if (window.fetch) {
                         return response.json();
                     })
                     .then(function (headers) {
-                        strictEqual('omit', headers[xhrHeaders.fetchRequestCredentials]);
+                        // NOTE: The Fetch API's Request.credentials property now defaults to "same-origin" per the latest
+                        // revision of the specification. https://developer.mozilla.org/en-US/Firefox/Releases/61
+                        if (browserUtils.isFirefox && browserUtils.version > 60)
+                            strictEqual(headers[xhrHeaders.fetchRequestCredentials], 'same-origin');
+                        else
+                            strictEqual(headers[xhrHeaders.fetchRequestCredentials], 'omit');
                     });
             });
 
@@ -234,7 +239,12 @@ if (window.fetch) {
                         return response.json();
                     })
                     .then(function (headers) {
-                        strictEqual('omit', headers[xhrHeaders.fetchRequestCredentials]);
+                        // NOTE: The Fetch API's Request.credentials property now defaults to "same-origin" per the latest
+                        // revision of the specification. https://developer.mozilla.org/en-US/Firefox/Releases/61
+                        if (browserUtils.isFirefox && browserUtils.version > 60)
+                            strictEqual(headers[xhrHeaders.fetchRequestCredentials], 'same-origin');
+                        else
+                            strictEqual(headers[xhrHeaders.fetchRequestCredentials], 'omit');
                     });
             });
 

--- a/test/client/fixtures/sandbox/fetch-test.js
+++ b/test/client/fixtures/sandbox/fetch-test.js
@@ -217,12 +217,7 @@ if (window.fetch) {
                         return response.json();
                     })
                     .then(function (headers) {
-                        // NOTE: The Fetch API's Request.credentials property now defaults to "same-origin" per the latest
-                        // revision of the specification. https://developer.mozilla.org/en-US/Firefox/Releases/61
-                        if (browserUtils.isFirefox && browserUtils.version > 60)
-                            strictEqual(headers[xhrHeaders.fetchRequestCredentials], 'same-origin');
-                        else
-                            strictEqual(headers[xhrHeaders.fetchRequestCredentials], 'omit');
+                        strictEqual('omit', headers[xhrHeaders.fetchRequestCredentials]);
                     });
             });
 
@@ -239,12 +234,7 @@ if (window.fetch) {
                         return response.json();
                     })
                     .then(function (headers) {
-                        // NOTE: The Fetch API's Request.credentials property now defaults to "same-origin" per the latest
-                        // revision of the specification. https://developer.mozilla.org/en-US/Firefox/Releases/61
-                        if (browserUtils.isFirefox && browserUtils.version > 60)
-                            strictEqual(headers[xhrHeaders.fetchRequestCredentials], 'same-origin');
-                        else
-                            strictEqual(headers[xhrHeaders.fetchRequestCredentials], 'omit');
+                        strictEqual('omit', headers[xhrHeaders.fetchRequestCredentials]);
                     });
             });
 

--- a/test/client/fixtures/sandbox/iframe-flag-test.js
+++ b/test/client/fixtures/sandbox/iframe-flag-test.js
@@ -62,7 +62,7 @@ var tagFormTargetAttr = {
 function testIframeFlagViaFormTarget (doc, iframeFlagResults) {
     var url                   = 'https://example.com/';
     var hasIframeFlagByTarget = function (tagName, targetValue) {
-        return tagName === 'base' ? false : iframeFlagResults[targetValue];
+        return iframeFlagResults[targetValue];
     };
 
     Object.keys(tagFormTargetAttr).forEach(function (tagName) {
@@ -279,6 +279,62 @@ test('assign a "formaction" attribute to elements with the "formtarget" attribut
                 _blank:        false,
                 _self:         false,
                 _parent:       false,
+                _top:          false,
+                window_name:   true,
+                unknow_window: false
+            });
+            /* eslint-enable camelcase */
+        });
+});
+
+test('assign a "formaction" attribute to elements with the "formtarget" attribute in iframe', function () {
+    // NOTE: Firefox doesn't raise the 'load' event for double-nested iframes without src
+    var src          = browserUtils.isFirefox ? 'javascript:"<html><body></body></html>"' : '';
+    var parentIframe = null;
+
+    return createTestIframe({ src: src })
+        .then(function (iframe) {
+            parentIframe = iframe;
+
+            return createTestIframe({ name: 'window_name' }, iframe.contentDocument.body);
+        })
+        .then(function () {
+            /* eslint-disable camelcase */
+            testIframeFlagViaFormTarget(parentIframe.contentDocument, {
+                _blank:        false,
+                _self:         true,
+                _parent:       false,
+                _top:          false,
+                window_name:   true,
+                unknow_window: false
+            });
+            /* eslint-enable camelcase */
+        });
+});
+
+test('assign a "formaction" attribute to elements with the "formtarget" attribute in embedded iframe', function () {
+    // NOTE: Firefox doesn't raise the 'load' event for double-nested iframes without src
+    var src            = browserUtils.isFirefox ? 'javascript:"<html><body></body></html>"' : '';
+    var embeddedIframe = null;
+
+    return createTestIframe({ src: src })
+        .then(function (iframe) {
+            return createTestIframe(null, iframe.contentDocument.body);
+        })
+        .then(function (iframe) {
+            embeddedIframe = iframe;
+
+            return createTestIframe({
+                src:  getSameDomainPageUrl('../../data/iframe/simple-iframe.html'),
+                name: 'window_name'
+            }, embeddedIframe.contentDocument.body);
+        })
+        .then(function () {
+            /* eslint-disable camelcase */
+            testIframeFlagViaFormTarget(embeddedIframe.contentDocument, {
+                _blank:        false,
+                _self:         true,
+                _parent:       true,
                 _top:          false,
                 window_name:   true,
                 unknow_window: false

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -160,47 +160,45 @@ if (!browserUtils.isIE || browserUtils.version > 9) {
     });
 }
 
-if (!browserUtils.isIE || browserUtils.version > 9) {
-    test('set and remove "formtarget" attribute on form child element with existing "formaction" attribute', function () {
-        var iframe = document.createElement('iframe');
-        var form   = document.createElement('form');
-        var input  = document.createElement('input');
-        var button = document.createElement('button');
+test('set and remove "formtarget" attribute on form child element with existing "formaction" attribute', function () {
+    var iframe = document.createElement('iframe');
+    var form   = document.createElement('form');
+    var input  = document.createElement('input');
+    var button = document.createElement('button');
 
-        iframe.id   = 'test' + Date.now();
-        iframe.name = 'iframe-name';
-        input.type  = 'submit';
-        button.type = 'submit';
+    iframe.id   = 'test' + Date.now();
+    iframe.name = 'iframe-name';
+    input.type  = 'submit';
+    button.type = 'submit';
 
-        form.appendChild(input);
-        form.appendChild(button);
+    form.appendChild(input);
+    form.appendChild(button);
 
-        document.body.appendChild(iframe);
-        document.body.appendChild(form);
+    document.body.appendChild(iframe);
+    document.body.appendChild(form);
 
-        nativeMethods.setAttribute.call(form, 'action', urlUtils.getProxyUrl('./action.html', { resourceType: 'f' }));
-        form.setAttribute('target', '_self');
+    nativeMethods.setAttribute.call(form, 'action', urlUtils.getProxyUrl('./action.html', { resourceType: 'f' }));
+    form.setAttribute('target', '_self');
 
-        input.setAttribute('formaction', './input.html');
-        input.setAttribute('formtarget', 'iframe-name');
-        button.setAttribute('formaction', './input.html');
-        button.setAttribute('formtarget', 'iframe-name');
+    input.setAttribute('formaction', './input.html');
+    input.setAttribute('formtarget', 'iframe-name');
+    button.setAttribute('formaction', './input.html');
+    button.setAttribute('formtarget', 'iframe-name');
 
-        strictEqual(urlUtils.parseProxyUrl(nativeMethods.inputFormActionGetter.call(input)).resourceType, 'if');
-        strictEqual(urlUtils.parseProxyUrl(nativeMethods.buttonFormActionGetter.call(button)).resourceType, 'if');
-        strictEqual(urlUtils.parseProxyUrl(nativeMethods.formActionGetter.call(form)).resourceType, 'f');
+    strictEqual(urlUtils.parseProxyUrl(nativeMethods.inputFormActionGetter.call(input)).resourceType, 'if');
+    strictEqual(urlUtils.parseProxyUrl(nativeMethods.buttonFormActionGetter.call(button)).resourceType, 'if');
+    strictEqual(urlUtils.parseProxyUrl(nativeMethods.formActionGetter.call(form)).resourceType, 'f');
 
-        input.removeAttribute('formtarget');
-        button.removeAttribute('formtarget');
+    input.removeAttribute('formtarget');
+    button.removeAttribute('formtarget');
 
-        strictEqual(urlUtils.parseProxyUrl(nativeMethods.inputFormActionGetter.call(input)).resourceType, 'f');
-        strictEqual(urlUtils.parseProxyUrl(nativeMethods.buttonFormActionGetter.call(button)).resourceType, 'f');
-        strictEqual(urlUtils.parseProxyUrl(nativeMethods.formActionGetter.call(form)).resourceType, 'f');
+    strictEqual(urlUtils.parseProxyUrl(nativeMethods.inputFormActionGetter.call(input)).resourceType, 'f');
+    strictEqual(urlUtils.parseProxyUrl(nativeMethods.buttonFormActionGetter.call(button)).resourceType, 'f');
+    strictEqual(urlUtils.parseProxyUrl(nativeMethods.formActionGetter.call(form)).resourceType, 'f');
 
-        iframe.parentNode.removeChild(iframe);
-        form.parentNode.removeChild(form);
-    });
-}
+    iframe.parentNode.removeChild(iframe);
+    form.parentNode.removeChild(form);
+});
 
 test('script src', function () {
     var storedSessionId = settings.get().sessionId;

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -160,6 +160,48 @@ if (!browserUtils.isIE || browserUtils.version > 9) {
     });
 }
 
+if (!browserUtils.isIE || browserUtils.version > 9) {
+    test('set and remove "formtarget" attribute on form child element with existing "formaction" attribute', function () {
+        var iframe = document.createElement('iframe');
+        var form   = document.createElement('form');
+        var input  = document.createElement('input');
+        var button = document.createElement('button');
+
+        iframe.id   = 'test' + Date.now();
+        iframe.name = 'iframe-name';
+        input.type  = 'submit';
+        button.type = 'submit';
+
+        form.appendChild(input);
+        form.appendChild(button);
+
+        document.body.appendChild(iframe);
+        document.body.appendChild(form);
+
+        nativeMethods.setAttribute.call(form, 'action', urlUtils.getProxyUrl('./action.html', { resourceType: 'f' }));
+        form.setAttribute('target', '_self');
+
+        input.setAttribute('formaction', './input.html');
+        input.setAttribute('formtarget', 'iframe-name');
+        button.setAttribute('formaction', './input.html');
+        button.setAttribute('formtarget', 'iframe-name');
+
+        strictEqual(urlUtils.parseProxyUrl(nativeMethods.inputFormActionGetter.call(input)).resourceType, 'if');
+        strictEqual(urlUtils.parseProxyUrl(nativeMethods.buttonFormActionGetter.call(button)).resourceType, 'if');
+        strictEqual(urlUtils.parseProxyUrl(nativeMethods.formActionGetter.call(form)).resourceType, 'f');
+
+        input.removeAttribute('formtarget');
+        button.removeAttribute('formtarget');
+
+        strictEqual(urlUtils.parseProxyUrl(nativeMethods.inputFormActionGetter.call(input)).resourceType, 'f');
+        strictEqual(urlUtils.parseProxyUrl(nativeMethods.buttonFormActionGetter.call(button)).resourceType, 'f');
+        strictEqual(urlUtils.parseProxyUrl(nativeMethods.formActionGetter.call(form)).resourceType, 'f');
+
+        iframe.parentNode.removeChild(iframe);
+        form.parentNode.removeChild(form);
+    });
+}
+
 test('script src', function () {
     var storedSessionId = settings.get().sessionId;
 

--- a/test/client/fixtures/sandbox/node/dom-processor-test.js
+++ b/test/client/fixtures/sandbox/node/dom-processor-test.js
@@ -193,22 +193,6 @@ test('javascript protocol', function () {
     strictEqual(nativeMethods.getAttribute.call(anchor, DomProcessor.getStoredAttrName('href')), attrValue);
 });
 
-test('anchor with target attribute', function () {
-    var anchor   = nativeMethods.createElement.call(document, 'a');
-    var testUrl  = 'http://url.com/';
-    var proxyUrl = urlUtils.getProxyUrl(testUrl, { resourceType: 'i' });
-
-    nativeMethods.setAttribute.call(anchor, 'href', testUrl);
-    nativeMethods.setAttribute.call(anchor, 'target', 'iframeName');
-
-    domProcessor.processElement(anchor, function (url, resourceType) {
-        return urlUtils.getProxyUrl(url, { resourceType: resourceType });
-    });
-
-    strictEqual(nativeMethods.getAttribute.call(anchor, 'href'), proxyUrl);
-    strictEqual(nativeMethods.getAttribute.call(anchor, DomProcessor.getStoredAttrName('href')), testUrl);
-});
-
 test('autocomplete attribute', function () {
     var input1 = nativeMethods.createElement.call(document, 'input');
     var input2 = nativeMethods.createElement.call(document, 'input');

--- a/test/client/fixtures/sandbox/node/dom-processor-test.js
+++ b/test/client/fixtures/sandbox/node/dom-processor-test.js
@@ -627,23 +627,35 @@ test('should reprocess tags that doesn\'t processed on server side (GH-838)', fu
 
     return createTestIframe({ src: src })
         .then(function (iframe) {
-            var processedAnchor     = iframe.contentDocument.querySelector('#processed-anchor');
-            var processedForm       = iframe.contentDocument.querySelector('#processed-form');
-            var processedAnchorHref = nativeMethods.anchorHrefGetter.call(processedAnchor);
-            var processedFormAction = nativeMethods.formActionGetter.call(processedForm);
+            var processedAnchor           = iframe.contentDocument.querySelector('#processed-anchor');
+            var processedForm             = iframe.contentDocument.querySelector('#processed-form');
+            var processedInput            = iframe.contentDocument.querySelector('#processed-input');
+            var processedButton           = iframe.contentDocument.querySelector('#processed-button');
+            var processedAnchorHref       = nativeMethods.anchorHrefGetter.call(processedAnchor);
+            var processedFormAction       = nativeMethods.formActionGetter.call(processedForm);
+            var processedInputFormAction  = nativeMethods.inputFormActionGetter.call(processedInput);
+            var processedButtonFormAction = nativeMethods.buttonFormActionGetter.call(processedButton);
 
             strictEqual(processedAnchorHref, urlUtils.getProxyUrl('http://localhost/anchor-action.html'));
             strictEqual(processedFormAction, urlUtils.getProxyUrl('http://localhost/form-action.html', { resourceType: 'f' }));
+            strictEqual(processedInputFormAction, urlUtils.getProxyUrl('http://localhost/input-formAction.html', { resourceType: 'f' }));
+            strictEqual(processedButtonFormAction, urlUtils.getProxyUrl('http://localhost/button-formAction.html', { resourceType: 'f' }));
 
             // NOTE: These tags shouldn't be reprocessed on the client side
             // because they are already processed on the server
-            var nonProcessedAnchor     = iframe.contentDocument.querySelector('#non-processed-anchor');
-            var nonProcessedForm       = iframe.contentDocument.querySelector('#non-processed-form');
-            var nonProcessedAnchorHref = nativeMethods.anchorHrefGetter.call(nonProcessedAnchor);
-            var nonProcessedFormAction = nonProcessedForm.action;
+            var nonProcessedAnchor           = iframe.contentDocument.querySelector('#non-processed-anchor');
+            var nonProcessedForm             = iframe.contentDocument.querySelector('#non-processed-form');
+            var nonProcessedInput            = iframe.contentDocument.querySelector('#non-processed-input');
+            var nonProcessedButton           = iframe.contentDocument.querySelector('#non-processed-button');
+            var nonProcessedAnchorHref       = nativeMethods.anchorHrefGetter.call(nonProcessedAnchor);
+            var nonProcessedFormAction       = nonProcessedForm.action;
+            var nonProcessedInputFormAction  = nonProcessedInput.formAction;
+            var nonProcessedButtonFormAction = nonProcessedButton.formAction;
 
             strictEqual(nonProcessedAnchorHref, 'http://localhost/anchor-action.html');
             strictEqual(nonProcessedFormAction, 'http://localhost/form-action.html');
+            strictEqual(nonProcessedInputFormAction, 'http://localhost/input-formAction.html');
+            strictEqual(nonProcessedButtonFormAction, 'http://localhost/button-formAction.html');
         });
 });
 

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -1,7 +1,7 @@
 var urlUtils = hammerhead.get('./utils/url');
 
-var nativeMethods    = hammerhead.nativeMethods;
-var browserUtils     = hammerhead.utils.browser;
+var nativeMethods = hammerhead.nativeMethods;
+var browserUtils  = hammerhead.utils.browser;
 
 test('window.onerror setter/getter', function () {
     var storedOnErrorHandler = window.onerror;
@@ -307,6 +307,14 @@ test('an overridden "target" attribute getter should return the same value as or
     strictEqual(nativeMethods.areaTargetGetter.call(area), area.target);
     strictEqual(nativeMethods.baseTargetGetter.call(base), base.target);
     strictEqual(nativeMethods.formTargetGetter.call(form), form.target);
+});
+
+test('an overridden "formtarget" attribute getter should return the same value as origin getter (attribute value is not defined)', function () {
+    var input  = document.createElement('input');
+    var button = document.createElement('button');
+
+    strictEqual(nativeMethods.inputFormTargetGetter.call(input), input.formTarget);
+    strictEqual(nativeMethods.buttonFormTargetGetter.call(button), button.formTarget);
 });
 
 module('regression');

--- a/test/client/fixtures/target-attr-test.js
+++ b/test/client/fixtures/target-attr-test.js
@@ -211,31 +211,23 @@ test('setAttribute', function () {
 
     document.body.appendChild(form);
 
-    input.type  = 'submit';
-    button.type = 'submit';
-
     function testFormtargetAttr (el, real, primary) {
         el.setAttribute('formtarget', primary);
 
         checkElementFormTarget(el, real, primary);
     }
 
-    form.appendChild(input);
-    form.appendChild(button);
+    [input, button].forEach(function (el) {
+        el.type = 'submit';
+        form.appendChild(el);
 
-    testFormtargetAttr(input, '_top', '_blank');
-    testFormtargetAttr(input, '_parent', '_parent');
-    testFormtargetAttr(input, '_self', '_self');
-    testFormtargetAttr(input, '_top', '_top');
-    testFormtargetAttr(input, 'window_name', 'window_name');
-    testFormtargetAttr(input, '_top', 'unknown_window');
-
-    testFormtargetAttr(button, '_top', '_blank');
-    testFormtargetAttr(button, '_parent', '_parent');
-    testFormtargetAttr(button, '_self', '_self');
-    testFormtargetAttr(button, '_top', '_top');
-    testFormtargetAttr(button, 'window_name', 'window_name');
-    testFormtargetAttr(button, '_top', 'unknown_window');
+        testFormtargetAttr(el, '_top', '_blank');
+        testFormtargetAttr(el, '_parent', '_parent');
+        testFormtargetAttr(el, '_self', '_self');
+        testFormtargetAttr(el, '_top', '_top');
+        testFormtargetAttr(el, 'window_name', 'window_name');
+        testFormtargetAttr(el, '_top', 'unknown_window');
+    });
 
     document.body.removeChild(form);
 });

--- a/test/client/fixtures/target-attr-test.js
+++ b/test/client/fixtures/target-attr-test.js
@@ -190,7 +190,7 @@ test('process html', function () {
 
     function checkTag (formTargetCase, tagName) {
         form.innerHTML = '<' + tagName + ' type="submit" formaction="http://input.formaction.com/" formtarget=' +
-                         formTargetCase.primary + (tagName === 'button' ? '></button>' : '>');
+                         formTargetCase.primary + '>';
 
         checkElementFormTarget(form.firstChild, formTargetCase.real, formTargetCase.primary);
         strictEqual(urlUtils.parseProxyUrl(nativeMethods.getAttribute.call(form.firstChild, 'formaction')).resourceType, formTargetCase.resourceType);

--- a/test/client/fixtures/target-attr-test.js
+++ b/test/client/fixtures/target-attr-test.js
@@ -174,7 +174,7 @@ test('all possible elements', function () {
 
 module('"formtarget" attribute');
 
-test('process html, correct resource type in "formaction" attribute', function () {
+test('process html', function () {
     var form = document.createElement('form');
 
     document.body.appendChild(form);

--- a/test/client/fixtures/target-attr-test.js
+++ b/test/client/fixtures/target-attr-test.js
@@ -21,16 +21,29 @@ function createTestedLink () {
 }
 
 function checkElementTarget (el, real, primary) {
-    if (el.tagName === 'anchor')
+    var tagName = el.tagName.toLowerCase();
+
+    if (tagName === 'a')
         strictEqual(nativeMethods.anchorTargetGetter.call(el), real);
-    else if (el.tagName === 'area')
+    else if (tagName === 'area')
         strictEqual(nativeMethods.areaTargetGetter.call(el), real);
-    else if (el.tagName === 'base')
+    else if (tagName === 'base')
         strictEqual(nativeMethods.baseTargetGetter.call(el), real);
-    else if (el.tagName === 'form')
+    else if (tagName === 'form')
         strictEqual(nativeMethods.formTargetGetter.call(el), real);
 
     strictEqual(el.getAttribute('target'), primary);
+}
+
+function checkElementFormTarget (el, real, primary) {
+    var tagName = el.tagName.toLowerCase();
+
+    if (tagName === 'input')
+        strictEqual(nativeMethods.inputFormTargetGetter.call(el), real);
+    else if (tagName === 'button')
+        strictEqual(nativeMethods.buttonFormTargetGetter.call(el), real);
+
+    strictEqual(el.getAttribute('formtarget'), primary);
 }
 
 function provokeTargetCalculation (link) {
@@ -156,6 +169,110 @@ test('all possible elements', function () {
         provokeTargetCalculation(el);
         checkElementTarget(el, '', null);
     }
+});
+
+
+module('"formtarget" attribute');
+
+test('process html', function () {
+    var form = document.createElement('form');
+
+    document.body.appendChild(form);
+
+    form.innerHTML = '<input type="submit" formtarget="_blank">' +
+                     '<input type="submit" formtarget="_parent">' +
+                     '<input type="submit" formtarget="_self">' +
+                     '<input type="submit" formtarget="_top">' +
+                     '<input type="submit" formtarget="unknown_window">' +
+                     '<input type="submit" formtarget="window_name">' +
+                     '<button type="submit" formtarget="_blank"></button>' +
+                     '<button type="submit" formtarget="_parent"></button>' +
+                     '<button type="submit" formtarget="_self"></button>' +
+                     '<button type="submit" formtarget="_top"></button>' +
+                     '<button type="submit" formtarget="unknown_window"></button>' +
+                     '<button type="submit" formtarget="window_name"></button>';
+
+    var children = form.children;
+
+    checkElementFormTarget(children[0], '_top', '_blank');
+    checkElementFormTarget(children[1], '_parent', '_parent');
+    checkElementFormTarget(children[2], '_self', '_self');
+    checkElementFormTarget(children[3], '_top', '_top');
+    checkElementFormTarget(children[4], 'unknown_window', 'unknown_window');
+    checkElementFormTarget(children[5], 'window_name', 'window_name');
+
+    checkElementFormTarget(children[6], '_top', '_blank');
+    checkElementFormTarget(children[7], '_parent', '_parent');
+    checkElementFormTarget(children[8], '_self', '_self');
+    checkElementFormTarget(children[9], '_top', '_top');
+    checkElementFormTarget(children[10], 'unknown_window', 'unknown_window');
+    checkElementFormTarget(children[11], 'window_name', 'window_name');
+
+    document.body.removeChild(form);
+});
+
+test('setAttribute', function () {
+    var form   = document.createElement('form');
+    var input  = document.createElement('input');
+    var button = document.createElement('button');
+
+    document.body.appendChild(form);
+
+    input.type  = 'submit';
+    button.type = 'submit';
+
+    function testFormtargetAttr (el, real, primary) {
+        el.setAttribute('formtarget', primary);
+
+        checkElementFormTarget(el, real, primary);
+    }
+
+    form.appendChild(input);
+    form.appendChild(button);
+
+    testFormtargetAttr(input, '_top', '_blank');
+    testFormtargetAttr(input, '_parent', '_parent');
+    testFormtargetAttr(input, '_self', '_self');
+    testFormtargetAttr(input, '_top', '_top');
+    testFormtargetAttr(input, 'window_name', 'window_name');
+    testFormtargetAttr(input, '_top', 'unknown_window');
+
+    testFormtargetAttr(button, '_top', '_blank');
+    testFormtargetAttr(button, '_parent', '_parent');
+    testFormtargetAttr(button, '_self', '_self');
+    testFormtargetAttr(button, '_top', '_top');
+    testFormtargetAttr(button, 'window_name', 'window_name');
+    testFormtargetAttr(button, '_top', 'unknown_window');
+
+    document.body.removeChild(form);
+});
+
+test('removeAttribute, hasAttribute', function () {
+    var form   = document.createElement('form');
+    var input  = document.createElement('input');
+    var button = document.createElement('button');
+
+    document.body.appendChild(form);
+
+    input.type  = 'submit';
+    button.type = 'submit';
+
+    input.setAttribute('formtarget', '_self');
+    button.setAttribute('formtarget', '_self');
+
+    ok(input.hasAttribute('formtarget'));
+    ok(button.hasAttribute('formtarget'));
+
+    input.removeAttribute('formtarget');
+    button.removeAttribute('formtarget');
+
+    checkElementFormTarget(input, '', null);
+    checkElementFormTarget(button, '', null);
+
+    ok(!input.hasAttribute('formtarget'));
+    ok(!button.hasAttribute('formtarget'));
+
+    document.body.removeChild(form);
 });
 
 


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1513
### References:
https://github.com/DevExpress/testcafe-hammerhead/issues/1670
### Changes
1. Override `formtarget` attribute.
2. Add `formaction` change logic for an element with an `formtarget` attribute
3. Fix `<a>` `tagName` in test/client/fixtures/target-attr-test.js
4. Remove 'anchor with target attribute' test from test/client/fixtures/sandbox/node/dom-processor-test.js

### Remove 'anchor with target attribute' test form test/client/fixtures/sandbox/node/dom-processor-test.js
```diff
- test('anchor with target attribute', function () {
-     var anchor   = nativeMethods.createElement.call(document, 'a');
-     var testUrl  = 'http://url.com/';
-     var proxyUrl = urlUtils.getProxyUrl(testUrl, { resourceType: 'i' });
-
-     nativeMethods.setAttribute.call(anchor, 'href', testUrl);
-     nativeMethods.setAttribute.call(anchor, 'target', 'iframeName');
-
-     domProcessor.processElement(anchor, function (url, resourceType) {
-         return urlUtils.getProxyUrl(url, { resourceType: resourceType });
-     });
-
-     strictEqual(nativeMethods.getAttribute.call(anchor, 'href'), proxyUrl);
-     strictEqual(nativeMethods.getAttribute.call(anchor, DomProcessor.getStoredAttrName('href')), testUrl);
- });
```
Now, we don't have the `i` iframe flag in this case. See `_processUrlAttrs` -> `getElementResourceType` -> `_isOpenLinkInIframe`

### Notes
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button:
> `formtarget`
If the button is a submit button, this attribute is a name or keyword indicating where to display the response that is received after submitting the form. This is a name of, or keyword for, a browsing context (for example, tab, window, or inline frame). If this attribute is specified, it overrides the target attribute of the button's form owner. The following keywords have special meanings:
> - _self: Load the response into the same browsing context as the current one. This value is the default if the attribute is not specified.
> - _blank: Load the response into a new unnamed browsing context.
> - _parent: Load the response into the parent browsing context of the current one. If there is no parent, this option behaves the same way as _self.
> - _top: Load the response into the top-level browsing context (that is, the browsing context that is an ancestor of the current one, and has no parent). If there is no parent, this option behaves the same way as _self.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input:
> `formtarget`
If the input element is a submit button or image, this attribute is a name or keyword indicating where to display the response that is received after submitting the form. This is a name of, or keyword for, a browsing context (e.g. tab, window, or inline frame). If this attribute is specified, it overrides the target attribute of the elements's form owner. The following keywords have special meanings:
> - _self: Load the response into the same browsing context as the current one. This value is the default if the attribute is not specified.
> - _blank: Load the response into a new unnamed browsing context.
> - _parent: Load the response into the parent browsing context of the current one. If there is no parent, this option behaves the same way as _self.
> - _top: Load the response into the top-level browsing context (i.e. the browsing context that is an ancestor of the current one, and has no parent). If there is no parent, this option behaves the same way as _self.

