### PR TITLE
Notify request hooks for cors validation failed

### DIFF
--- a/src/request-pipeline/context.js
+++ b/src/request-pipeline/context.js
@@ -267,9 +267,6 @@ export default class RequestPipelineContext {
     isKeepSameOriginPolicy () {
         const isNotModifiedAjaxRequest = (this.isXhr || this.isFetch) && !this.contentInfo.isNotModified;
 
-        if (isNotModifiedAjaxRequest)
-            return checkSameOriginPolicy(this);
-
-        return true;
+        return isNotModifiedAjaxRequest ? checkSameOriginPolicy(this) : true;
     }
 }

--- a/src/request-pipeline/context.js
+++ b/src/request-pipeline/context.js
@@ -3,6 +3,7 @@ import Charset from '../processing/encoding/charset';
 import * as urlUtils from '../utils/url';
 import * as contentTypeUtils from '../utils/content-type';
 import genearateUniqueId from '../utils/generate-unique-id';
+import { check as checkSameOriginPolicy } from './xhr/same-origin-policy';
 
 const REDIRECT_STATUS_CODES = [301, 302, 303, 307, 308];
 
@@ -261,5 +262,14 @@ export default class RequestPipelineContext {
             resourceType,
             charset
         });
+    }
+
+    isKeepSameOriginPolicy () {
+        const isNotModifiedAjaxRequest = (this.isXhr || this.isFetch) && !this.contentInfo.isNotModified;
+
+        if (isNotModifiedAjaxRequest)
+            return checkSameOriginPolicy(this);
+
+        return true;
     }
 }

--- a/src/request-pipeline/context.js
+++ b/src/request-pipeline/context.js
@@ -265,8 +265,9 @@ export default class RequestPipelineContext {
     }
 
     isKeepSameOriginPolicy () {
-        const isNotModifiedAjaxRequest = (this.isXhr || this.isFetch) && !this.contentInfo.isNotModified;
+        const isAjaxRequest          = this.isXhr || this.isFetch;
+        const shouldPerformCORSCheck = isAjaxRequest && !this.contentInfo.isNotModified;
 
-        return isNotModifiedAjaxRequest ? checkSameOriginPolicy(this) : true;
+        return shouldPerformCORSCheck ? checkSameOriginPolicy(this) : true;
     }
 }

--- a/src/request-pipeline/index.js
+++ b/src/request-pipeline/index.js
@@ -67,10 +67,10 @@ const stages = {
                 const configureResponseEvent = new ConfigureResponseEvent(rule, ConfigureResponseEventOptions.DEFAULT);
 
                 ctx.session.callRequestEventCallback(REQUEST_EVENT_NAMES.onConfigureResponse, rule, configureResponseEvent);
-
                 callOnResponseEventCallbackForFailedSameOriginCheck(ctx, rule, configureResponseEvent);
             });
             ctx.closeWithError(SAME_ORIGIN_CHECK_FAILED_STATUS_CODE);
+
             return;
         }
 
@@ -275,7 +275,7 @@ function callOnResponseEventCallbackWithCollectedBody (ctx, rule, configureOpts)
 }
 
 function callOnResponseEventCallbackForFailedSameOriginCheck (ctx, rule, configureOpts) {
-    const responseInfo  = requestEventInfo.createResponseInfo(ctx);
+    const responseInfo = requestEventInfo.createResponseInfo(ctx);
 
     responseInfo.statusCode = SAME_ORIGIN_CHECK_FAILED_STATUS_CODE;
 

--- a/src/request-pipeline/request-hooks/request-filter-rule.js
+++ b/src/request-pipeline/request-hooks/request-filter-rule.js
@@ -1,4 +1,4 @@
-import { isRegExp } from 'lodash';
+import { isRegExp, isString } from 'lodash';
 import { ensureOriginTrailingSlash } from '../../utils/url';
 
 const DEFAULT_OPTIONS = {
@@ -8,6 +8,8 @@ const DEFAULT_OPTIONS = {
 };
 
 const MATCH_ANY_REQUEST_REG_EX = /.*/;
+
+const CORS_VALIDATION_FAILED_MSG_PREFIX = 'CORS validation failed for a request specified as ';
 
 export default class RequestFilterRule {
     constructor (options) {
@@ -79,6 +81,28 @@ export default class RequestFilterRule {
         return !!this.options.call(this, requestInfo);
     }
 
+    _stringifyFunctionOptions () {
+        return `${CORS_VALIDATION_FAILED_MSG_PREFIX}{ <predicate> }`;
+    }
+
+    _stringifyObjectOptions () {
+        const stringifiedOptions = [
+            { name: 'url', value: this.options.url },
+            { name: 'method', value: this.options.method },
+            { name: 'isAjax', value: this.options.isAjax }
+        ];
+
+        const msg = stringifiedOptions.filter(option => !!option.value)
+            .map(option => {
+                const stringifiedOptionValue = isString(option.value) ? `"${option.value}"` : option.value;
+
+                return `${option.name}: ${stringifiedOptionValue}`;
+            })
+            .join(', ');
+
+        return `${CORS_VALIDATION_FAILED_MSG_PREFIX}{ ${msg} }`;
+    }
+
     match (requestInfo) {
         if (typeof this.options === 'function')
             return this._matchUsingFunctionOptions(requestInfo);
@@ -88,5 +112,12 @@ export default class RequestFilterRule {
 
     static get ANY () {
         return new RequestFilterRule(MATCH_ANY_REQUEST_REG_EX);
+    }
+
+    toString () {
+        if (typeof this.options === 'function')
+            return this._stringifyFunctionOptions();
+
+        return this._stringifyObjectOptions();
     }
 }

--- a/src/request-pipeline/request-hooks/request-filter-rule.js
+++ b/src/request-pipeline/request-hooks/request-filter-rule.js
@@ -115,9 +115,8 @@ export default class RequestFilterRule {
     }
 
     toString () {
-        if (typeof this.options === 'function')
-            return this._stringifyFunctionOptions();
+        const isFunctionOptions = typeof this.options === 'function';
 
-        return this._stringifyObjectOptions();
+        return isFunctionOptions ? this._stringifyFunctionOptions() : this._stringifyObjectOptions();
     }
 }

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -370,7 +370,7 @@ export function ensureTrailingSlash (srcUrl, processedUrl) {
 }
 
 export function isSpecialPage (url) {
-    return SPECIAL_PAGES.includes(url);
+    return SPECIAL_PAGES.indexOf(url) !== -1;
 }
 
 export function isRelativeUrl (url) {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -370,7 +370,7 @@ export function ensureTrailingSlash (srcUrl, processedUrl) {
 }
 
 export function isSpecialPage (url) {
-    return SPECIAL_PAGES.indexOf(url) !== -1;
+    return SPECIAL_PAGES.includes(url);
 }
 
 export function isRelativeUrl (url) {

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -2148,11 +2148,26 @@ describe('Proxy', () => {
             });
 
             it('Ajax request', () => {
+                let requestEventIsRaised          = false;
+                let configureResponseEventIsRaised = false;
+                let responseEventIsRaised          = false;
+
                 const rule = new RequestFilterRule('http://127.0.0.1:2000/page/plain-text');
 
                 session.addRequestEventListeners(rule, {
                     onRequest: e => {
                         expect(e.isAjax).to.be.true;
+
+                        requestEventIsRaised = true;
+                    },
+
+                    onConfigureResponse: () => {
+                        configureResponseEventIsRaised = true;
+                    },
+
+                    onResponse: e => {
+                        expect(e.statusCode).eql(SAME_ORIGIN_CHECK_FAILED_STATUS_CODE);
+                        responseEventIsRaised = true;
                     }
                 });
 
@@ -2168,6 +2183,9 @@ describe('Proxy', () => {
                 return request(options)
                     .then(res => {
                         expect(res.statusCode).eql(SAME_ORIGIN_CHECK_FAILED_STATUS_CODE);
+                        expect(requestEventIsRaised).to.be.true;
+                        expect(configureResponseEventIsRaised).to.be.true;
+                        expect(responseEventIsRaised).to.be.true;
 
                         session.removeRequestEventListeners(rule);
                     });
@@ -2289,6 +2307,8 @@ describe('Proxy', () => {
                         session.removeRequestEventListeners(rule);
                     });
             });
+
+
         });
 
         it('Should allow to set request options', () => {

--- a/test/server/request-hook-test.js
+++ b/test/server/request-hook-test.js
@@ -139,21 +139,25 @@ describe('RequestFilterRule', () => {
         expect(hook.options.url).eql('http://example.com');
         expect(hook.options.method).to.be.undefined;
         expect(hook.options.isAjax).to.be.undefined;
+        expect(hook.toString()).contains('{ url: "http://example.com" }');
 
         hook = new RequestFilterRule(/example.com/);
         expect(hook.options.url).eql(/example.com/);
         expect(hook.options.method).to.be.undefined;
         expect(hook.options.isAjax).to.be.undefined;
+        expect(hook.toString()).contains('{ url: /example.com/ }');
 
         hook = new RequestFilterRule({ url: 'http://example.com', method: 'GET', isAjax: false });
         expect(hook.options.url).eql('http://example.com');
         expect(hook.options.method).eql('get');
         expect(hook.options.isAjax).eql(false);
+        expect(hook.toString()).contains('{ url: "http://example.com", method: "get" }');
 
         const filterFn = () => false;
 
         hook = new RequestFilterRule(filterFn);
         expect(hook.options).eql(filterFn);
+        expect(hook.toString()).contains('{ <predicate> }');
     });
 
     it('Match', () => {


### PR DESCRIPTION
@LavrovArtem 

Changes:
* add `RequestFilterRule.toString` method
* notify request hooks about cors validation failed requests