### PR TITLE
fix `Bug: Chrome gets stuck in middle of pageload`

### DIFF
--- a/src/client/sandbox/native-methods.js
+++ b/src/client/sandbox/native-methods.js
@@ -248,6 +248,7 @@ class NativeMethods {
         const anchorHrefDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLAnchorElement.prototype, 'href');
         const linkHrefDescriptor             = win.Object.getOwnPropertyDescriptor(win.HTMLLinkElement.prototype, 'href');
         const linkIntegrityDescriptor        = win.Object.getOwnPropertyDescriptor(win.HTMLLinkElement.prototype, 'integrity');
+        const linkRelDescriptor              = win.Object.getOwnPropertyDescriptor(win.HTMLLinkElement.prototype, 'rel');
         const areaHrefDescriptor             = win.Object.getOwnPropertyDescriptor(win.HTMLAreaElement.prototype, 'href');
         const baseHrefDescriptor             = win.Object.getOwnPropertyDescriptor(win.HTMLBaseElement.prototype, 'href');
         const anchorHostDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLAnchorElement.prototype, 'host');
@@ -295,6 +296,7 @@ class NativeMethods {
         this.iframeSrcSetter         = iframeSrcDescriptor.set;
         this.anchorHrefSetter        = anchorHrefDescriptor.set;
         this.linkHrefSetter          = linkHrefDescriptor.set;
+        this.linkRelSetter           = linkRelDescriptor.set;
         this.areaHrefSetter          = areaHrefDescriptor.set;
         this.baseHrefSetter          = baseHrefDescriptor.set;
         this.anchorHostSetter        = anchorHostDescriptor.set;
@@ -373,6 +375,7 @@ class NativeMethods {
         this.iframeSrcGetter                = iframeSrcDescriptor.get;
         this.anchorHrefGetter               = anchorHrefDescriptor.get;
         this.linkHrefGetter                 = linkHrefDescriptor.get;
+        this.linkRelGetter                  = linkRelDescriptor.get;
         this.areaHrefGetter                 = areaHrefDescriptor.get;
         this.baseHrefGetter                 = baseHrefDescriptor.get;
         this.anchorHostGetter               = anchorHostDescriptor.get;

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -15,6 +15,7 @@ import { isValidEventListener, stopPropagation } from '../../utils/event';
 import { processHtml } from '../../utils/html';
 import { getNativeQuerySelector, getNativeQuerySelectorAll } from '../../utils/query-selector';
 import { HASH_RE } from '../../../utils/url';
+import trim from '../../../utils/string-trim';
 import * as windowsStorage from '../windows-storage';
 import { refreshAttributesWrapper } from './attributes';
 import ShadowUI from '../shadow-ui';
@@ -261,15 +262,15 @@ export default class ElementSandbox extends SandboxBase {
         }
 
         else if (!isNs && loweredAttr === 'rel' && tagName === 'link') {
+            const formatedValue = trim(value.toLowerCase());
             const storedRelAttr = DomProcessor.getStoredAttrName(attr);
 
-            if (value === 'prefetch') {
+            if (formatedValue === 'prefetch') {
                 nativeMethods.removeAttribute.call(el, attr);
-
-                return setAttrMeth.apply(el, [storedRelAttr, value]);
+                args[0] = storedRelAttr;
             }
-
-            nativeMethods.removeAttribute.call(el, storedRelAttr);
+            else
+                nativeMethods.removeAttribute.call(el, storedRelAttr);
         }
 
         const result = setAttrMeth.apply(el, args);

--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -796,6 +796,8 @@ export default class WindowSandbox extends SandboxBase {
             this._overrideAttrDescriptors('integrity', [window.HTMLLinkElement]);
         }
 
+        this._overrideAttrDescriptors('rel', [window.HTMLLinkElement]);
+
         overrideDescriptor(window.HTMLIFrameElement.prototype, 'sandbox', {
             getter: function () {
                 let domTokenList = this[SANDBOX_DOM_TOKEN_LIST];

--- a/src/processing/dom/index.js
+++ b/src/processing/dom/index.js
@@ -7,6 +7,7 @@ import SHADOW_UI_CLASSNAME from '../../shadow-ui/class-name';
 import { isScriptProcessed, processScript } from '../script';
 import styleProcessor from '../../processing/style';
 import * as urlUtils from '../../utils/url';
+import trim from '../../utils/string-trim';
 import { XML_NAMESPACE } from './namespaces';
 import { URL_ATTR_TAGS, URL_ATTRS, TARGET_ATTR_TAGS, TARGET_ATTRS } from './attributes';
 
@@ -27,7 +28,7 @@ const SVG_XLINK_HREF_TAGS = [
 const INTEGRITY_ATTR_TAGS = ['script', 'link'];
 
 // eslint-disable-next-line hammerhead/proto-methods
-const IFRAME_FLAG_TAGS = TARGET_ATTR_TAGS['target'].filter(tagName => tagName !== 'base').concat(TARGET_ATTR_TAGS['formtarget']);
+const IFRAME_FLAG_TAGS = TARGET_ATTR_TAGS.target.filter(tagName => tagName !== 'base').concat(TARGET_ATTR_TAGS.formtarget);
 
 const ELEMENT_PROCESSED = 'hammerhead|element-processed';
 
@@ -48,11 +49,11 @@ export default class DomProcessor {
     }
 
     static isTagWithTargetAttr (tagName) {
-        return tagName && TARGET_ATTR_TAGS['target'].indexOf(tagName) > -1;
+        return tagName && TARGET_ATTR_TAGS.target.indexOf(tagName) > -1;
     }
 
     static isTagWithFormTargetAttr (tagName) {
-        return tagName && TARGET_ATTR_TAGS['formtarget'].indexOf(tagName) > -1;
+        return tagName && TARGET_ATTR_TAGS.formtarget.indexOf(tagName) > -1;
     }
 
     static isTagWithIntegrityAttr (tagName) {
@@ -345,16 +346,17 @@ export default class DomProcessor {
     _processRelPrefetch (el, urlReplacer, pattern) {
         const storedRelAttr = DomProcessor.getStoredAttrName(pattern.relAttr);
         const processed     = this.adapter.hasAttr(el, storedRelAttr) && !this.adapter.hasAttr(el, pattern.relAttr);
-        let attrValue       = this.adapter.getAttr(el, processed ? storedRelAttr : pattern.relAttr);
+        const attrValue     = this.adapter.getAttr(el, processed ? storedRelAttr : pattern.relAttr);
 
-        // NOTE: Value may have whitespace.
-        attrValue = attrValue && attrValue.replace(/\s/g, '');
+        if (attrValue) {
+            const formatedValue = trim(attrValue.toLowerCase());
 
-        if (attrValue === 'prefetch') {
-            this.adapter.setAttr(el, storedRelAttr, attrValue);
+            if (formatedValue === 'prefetch') {
+                this.adapter.setAttr(el, storedRelAttr, attrValue);
 
-            if (!processed)
-                this.adapter.removeAttr(el, pattern.relAttr);
+                if (!processed)
+                    this.adapter.removeAttr(el, pattern.relAttr);
+            }
         }
     }
 

--- a/src/request-pipeline/header-transforms.js
+++ b/src/request-pipeline/header-transforms.js
@@ -196,7 +196,14 @@ const responseTransforms = {
 
     'referrer-policy': () => 'unsafe-url',
 
-    'refresh': (src, ctx) => transformRefreshHeader(src, ctx)
+    'refresh': (src, ctx) => transformRefreshHeader(src, ctx),
+
+    'link': src => {
+        if (/[;\s]rel=prefetch/i.test(src))
+            return void 0;
+
+        return src;
+    }
 };
 
 // Transformation routine

--- a/src/request-pipeline/header-transforms.js
+++ b/src/request-pipeline/header-transforms.js
@@ -199,7 +199,7 @@ const responseTransforms = {
     'refresh': (src, ctx) => transformRefreshHeader(src, ctx),
 
     'link': src => {
-        if (/[;\s]rel=prefetch/i.test(src))
+        if (/[;\s]rel=\s*prefetch/i.test(src))
             return void 0;
 
         return src;

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -652,52 +652,52 @@ module('"rel" attribute');
 
 test('process html', function () {
     var relAttrCases = [
-        { valueToSet: 'prefetch', hasRelAttr: false, hasStoredRel: true },
-        { valueToSet: '  prEFEtch ', hasRelAttr: false, hasStoredRel: true },
-        { valueToSet: 'autor', hasRelAttr: true, hasStoredRel: false },
-        { valueToSet: 'dns-prefetch', hasRelAttr: true, hasStoredRel: false },
-        { valueToSet: 'help', hasRelAttr: true, hasStoredRel: false },
-        { valueToSet: 'icon', hasRelAttr: true, hasStoredRel: false },
-        { valueToSet: 'license', hasRelAttr: true, hasStoredRel: false },
-        { valueToSet: 'next', hasRelAttr: true, hasStoredRel: false },
-        { valueToSet: 'pingback', hasRelAttr: true, hasStoredRel: false },
-        { valueToSet: 'preconnect', hasRelAttr: true, hasStoredRel: false },
-        { valueToSet: 'preload', hasRelAttr: true, hasStoredRel: false },
-        { valueToSet: 'prev', hasRelAttr: true, hasStoredRel: false },
-        { valueToSet: 'search', hasRelAttr: true, hasStoredRel: false },
-        { valueToSet: 'stylesheet', hasRelAttr: true, hasStoredRel: false }
+        { relValue: 'prefetch', hasRelAttr: false, hasStoredRelAttr: true },
+        { relValue: '  prEFEtch ', hasRelAttr: false, hasStoredRelAttr: true },
+        { relValue: 'autor', hasRelAttr: true, hasStoredRelAttr: false },
+        { relValue: 'dns-prefetch', hasRelAttr: true, hasStoredRelAttr: false },
+        { relValue: 'help', hasRelAttr: true, hasStoredRelAttr: false },
+        { relValue: 'icon', hasRelAttr: true, hasStoredRelAttr: false },
+        { relValue: 'license', hasRelAttr: true, hasStoredRelAttr: false },
+        { relValue: 'next', hasRelAttr: true, hasStoredRelAttr: false },
+        { relValue: 'pingback', hasRelAttr: true, hasStoredRelAttr: false },
+        { relValue: 'preconnect', hasRelAttr: true, hasStoredRelAttr: false },
+        { relValue: 'preload', hasRelAttr: true, hasStoredRelAttr: false },
+        { relValue: 'prev', hasRelAttr: true, hasStoredRelAttr: false },
+        { relValue: 'search', hasRelAttr: true, hasStoredRelAttr: false },
+        { relValue: 'stylesheet', hasRelAttr: true, hasStoredRelAttr: false }
     ];
 
     relAttrCases.forEach(function (relAttrCase) {
         var link = nativeMethods.createElement.call(document, 'link');
 
-        nativeMethods.linkRelSetter.call(link, relAttrCase.valueToSet);
+        nativeMethods.linkRelSetter.call(link, relAttrCase.relValue);
 
         domProcessor.processElement(link);
 
         strictEqual(nativeMethods.elementOuterHTMLGetter.call(link),
-            '<link' + (relAttrCase.hasRelAttr ? ' rel="' + relAttrCase.valueToSet + '"' : '')
-            + (relAttrCase.hasStoredRel ? ' rel-hammerhead-stored-value="' + relAttrCase.valueToSet + '"' : '') + '>',
-            relAttrCase.valueToSet);
+            '<link' + (relAttrCase.hasRelAttr ? ' rel="' + relAttrCase.relValue + '"' : '')
+            + (relAttrCase.hasStoredRelAttr ? ' rel-hammerhead-stored-value="' + relAttrCase.relValue + '"' : '') + '>',
+            relAttrCase.relValue);
     });
 });
 
 test('setAttribute', function () {
     var relAttrCases = [
-        { valueToSet: 'prefetch', nativeGetAttrExpected: null },
-        { valueToSet: '  prEFEtch ', nativeGetAttrExpected: null },
-        { valueToSet: 'autor', nativeGetAttrExpected: 'autor' },
-        { valueToSet: 'dns-prefetch', nativeGetAttrExpected: 'dns-prefetch' },
-        { valueToSet: 'help', nativeGetAttrExpected: 'help' },
-        { valueToSet: 'icon', nativeGetAttrExpected: 'icon' },
-        { valueToSet: 'license', nativeGetAttrExpected: 'license' },
-        { valueToSet: 'next', nativeGetAttrExpected: 'next' },
-        { valueToSet: 'pingback', nativeGetAttrExpected: 'pingback' },
-        { valueToSet: 'preconnect', nativeGetAttrExpected: 'preconnect' },
-        { valueToSet: 'preload', nativeGetAttrExpected: 'preload' },
-        { valueToSet: 'prev', nativeGetAttrExpected: 'prev' },
-        { valueToSet: 'search', nativeGetAttrExpected: 'search' },
-        { valueToSet: 'stylesheet', nativeGetAttrExpected: 'stylesheet' }
+        { relValue: 'prefetch', nativeGetAttrExpected: null },
+        { relValue: '  prEFEtch ', nativeGetAttrExpected: null },
+        { relValue: 'autor', nativeGetAttrExpected: 'autor' },
+        { relValue: 'dns-prefetch', nativeGetAttrExpected: 'dns-prefetch' },
+        { relValue: 'help', nativeGetAttrExpected: 'help' },
+        { relValue: 'icon', nativeGetAttrExpected: 'icon' },
+        { relValue: 'license', nativeGetAttrExpected: 'license' },
+        { relValue: 'next', nativeGetAttrExpected: 'next' },
+        { relValue: 'pingback', nativeGetAttrExpected: 'pingback' },
+        { relValue: 'preconnect', nativeGetAttrExpected: 'preconnect' },
+        { relValue: 'preload', nativeGetAttrExpected: 'preload' },
+        { relValue: 'prev', nativeGetAttrExpected: 'prev' },
+        { relValue: 'search', nativeGetAttrExpected: 'search' },
+        { relValue: 'stylesheet', nativeGetAttrExpected: 'stylesheet' }
     ];
 
     var link = nativeMethods.createElement.call(document, 'link');
@@ -705,9 +705,9 @@ test('setAttribute', function () {
     document.body.appendChild(link);
 
     relAttrCases.forEach(function (relAttrCase) {
-        link.setAttribute('rel', relAttrCase.valueToSet);
-        strictEqual(nativeMethods.getAttribute.call(link, 'rel'), relAttrCase.nativeGetAttrExpected, relAttrCase.valueToSet);
-        strictEqual(link.getAttribute('rel'), relAttrCase.valueToSet, relAttrCase.valueToSet);
+        link.setAttribute('rel', relAttrCase.relValue);
+        strictEqual(nativeMethods.getAttribute.call(link, 'rel'), relAttrCase.nativeGetAttrExpected, relAttrCase.relValue);
+        strictEqual(link.getAttribute('rel'), relAttrCase.relValue, relAttrCase.relValue);
     });
 
     link.parentNode.removeChild(link);
@@ -718,19 +718,15 @@ test('hasAttribute, removeAttribute', function () {
 
     document.body.appendChild(link);
 
-    ok(!link.hasAttribute('rel'));
+    ok(!link.hasAttribute('rel'), 'nonexistent rel attribute');
 
-    link.setAttribute('rel', 'prefetch');
-    ok(link.hasAttribute('rel'));
+    ['prefetch', '  prEFEtch ', 'autor'].forEach(function (relValue) {
+        link.setAttribute('rel', relValue);
+        ok(link.hasAttribute('rel'), relValue);
 
-    link.removeAttribute('rel');
-    ok(!link.hasAttribute('rel'));
-
-    link.setAttribute('rel', '  prEFEtch ');
-    ok(link.hasAttribute('rel'));
-
-    link.removeAttribute('rel');
-    ok(!link.hasAttribute('rel'));
+        link.removeAttribute('rel');
+        ok(!link.hasAttribute('rel'), 'nonexistent rel attribute');
+    });
 
     link.parentNode.removeChild(link);
 });
@@ -740,11 +736,11 @@ test('"rel" property', function () {
 
     document.body.appendChild(link);
 
-    function checkRelAttr (valueToSet, nativeGetAttrExpected) {
-        link.rel = valueToSet;
+    function checkRelAttr (relValue, nativeGetAttrExpected) {
+        link.rel = relValue;
 
-        strictEqual(link.rel, valueToSet, valueToSet);
-        strictEqual(nativeMethods.getAttribute.call(link, 'rel'), nativeGetAttrExpected, valueToSet);
+        strictEqual(link.rel, relValue, relValue);
+        strictEqual(nativeMethods.getAttribute.call(link, 'rel'), nativeGetAttrExpected, relValue);
     }
 
     checkRelAttr('prefetch', null);

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -647,6 +647,111 @@ if (window.Node.prototype.hasOwnProperty('attributes')) {
     });
 }
 
+
+module('"rel" attribute');
+
+test('process html', function () {
+    var relAttrCases = [
+        { valueToSet: 'prefetch', hasRelAttr: false, hasStoredRel: true },
+        { valueToSet: 'autor', hasRelAttr: true, hasStoredRel: false },
+        { valueToSet: 'dns-prefetch', hasRelAttr: true, hasStoredRel: false },
+        { valueToSet: 'help', hasRelAttr: true, hasStoredRel: false },
+        { valueToSet: 'icon', hasRelAttr: true, hasStoredRel: false },
+        { valueToSet: 'license', hasRelAttr: true, hasStoredRel: false },
+        { valueToSet: 'next', hasRelAttr: true, hasStoredRel: false },
+        { valueToSet: 'pingback', hasRelAttr: true, hasStoredRel: false },
+        { valueToSet: 'preconnect', hasRelAttr: true, hasStoredRel: false },
+        { valueToSet: 'preload', hasRelAttr: true, hasStoredRel: false },
+        { valueToSet: 'prev', hasRelAttr: true, hasStoredRel: false },
+        { valueToSet: 'search', hasRelAttr: true, hasStoredRel: false },
+        { valueToSet: 'stylesheet', hasRelAttr: true, hasStoredRel: false }
+    ];
+
+    relAttrCases.forEach(function (relAttrCase) {
+        var link = nativeMethods.createElement.call(document, 'link');
+
+        nativeMethods.linkRelSetter.call(link, relAttrCase.valueToSet);
+
+        domProcessor.processElement(link);
+
+        strictEqual(nativeMethods.elementOuterHTMLGetter.call(link),
+            '<link' + (relAttrCase.hasRelAttr ? ' rel="' + relAttrCase.valueToSet + '"' : '')
+            + (relAttrCase.hasStoredRel ? ' rel-hammerhead-stored-value="' + relAttrCase.valueToSet + '"' : '') + '>',
+            relAttrCase.valueToSet);
+    });
+});
+
+test('setAttribute', function () {
+    var relAttrCases = [
+        { valueToSet: 'prefetch', nativeGetAttrExpected: null },
+        { valueToSet: 'autor', nativeGetAttrExpected: 'autor' },
+        { valueToSet: 'dns-prefetch', nativeGetAttrExpected: 'dns-prefetch' },
+        { valueToSet: 'help', nativeGetAttrExpected: 'help' },
+        { valueToSet: 'icon', nativeGetAttrExpected: 'icon' },
+        { valueToSet: 'license', nativeGetAttrExpected: 'license' },
+        { valueToSet: 'next', nativeGetAttrExpected: 'next' },
+        { valueToSet: 'pingback', nativeGetAttrExpected: 'pingback' },
+        { valueToSet: 'preconnect', nativeGetAttrExpected: 'preconnect' },
+        { valueToSet: 'preload', nativeGetAttrExpected: 'preload' },
+        { valueToSet: 'prev', nativeGetAttrExpected: 'prev' },
+        { valueToSet: 'search', nativeGetAttrExpected: 'search' },
+        { valueToSet: 'stylesheet', nativeGetAttrExpected: 'stylesheet' }
+    ];
+
+    var link = nativeMethods.createElement.call(document, 'link');
+
+    document.body.appendChild(link);
+
+    relAttrCases.forEach(function (relAttrCase) {
+        link.setAttribute('rel', relAttrCase.valueToSet);
+        strictEqual(nativeMethods.getAttribute.call(link, 'rel'), relAttrCase.nativeGetAttrExpected, relAttrCase.valueToSet);
+        strictEqual(link.getAttribute('rel'), relAttrCase.valueToSet, relAttrCase.valueToSet);
+    });
+
+    link.parentNode.removeChild(link);
+});
+
+test('hasAttribute, removeAttribute', function () {
+    var link = nativeMethods.createElement.call(document, 'link');
+
+    document.body.appendChild(link);
+
+    ok(!link.hasAttribute('rel'));
+
+    link.setAttribute('rel', 'prefetch');
+    ok(link.hasAttribute('rel'));
+
+    link.removeAttribute('rel');
+    ok(!link.hasAttribute('rel'));
+
+    link.setAttribute('rel', 'autor');
+    ok(link.hasAttribute('rel'));
+
+    link.removeAttribute('rel');
+    ok(!link.hasAttribute('rel'));
+
+    link.parentNode.removeChild(link);
+});
+
+test('"rel" property', function () {
+    var link = nativeMethods.createElement.call(document, 'link');
+
+    document.body.appendChild(link);
+
+    function checkRelAttr (valueToSet, nativeGetAttrExpected) {
+        link.rel = valueToSet;
+
+        strictEqual(link.rel, valueToSet, valueToSet);
+        strictEqual(nativeMethods.getAttribute.call(link, 'rel'), nativeGetAttrExpected, valueToSet);
+    }
+
+    checkRelAttr('prefetch', null);
+    checkRelAttr('autor', 'autor');
+
+    link.parentNode.removeChild(link);
+});
+
+
 module('regression');
 
 test('setting function to the link.href attribute value (T230764)', function () {

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -653,6 +653,7 @@ module('"rel" attribute');
 test('process html', function () {
     var relAttrCases = [
         { valueToSet: 'prefetch', hasRelAttr: false, hasStoredRel: true },
+        { valueToSet: '  prEFEtch ', hasRelAttr: false, hasStoredRel: true },
         { valueToSet: 'autor', hasRelAttr: true, hasStoredRel: false },
         { valueToSet: 'dns-prefetch', hasRelAttr: true, hasStoredRel: false },
         { valueToSet: 'help', hasRelAttr: true, hasStoredRel: false },
@@ -684,6 +685,7 @@ test('process html', function () {
 test('setAttribute', function () {
     var relAttrCases = [
         { valueToSet: 'prefetch', nativeGetAttrExpected: null },
+        { valueToSet: '  prEFEtch ', nativeGetAttrExpected: null },
         { valueToSet: 'autor', nativeGetAttrExpected: 'autor' },
         { valueToSet: 'dns-prefetch', nativeGetAttrExpected: 'dns-prefetch' },
         { valueToSet: 'help', nativeGetAttrExpected: 'help' },
@@ -724,7 +726,7 @@ test('hasAttribute, removeAttribute', function () {
     link.removeAttribute('rel');
     ok(!link.hasAttribute('rel'));
 
-    link.setAttribute('rel', 'autor');
+    link.setAttribute('rel', '  prEFEtch ');
     ok(link.hasAttribute('rel'));
 
     link.removeAttribute('rel');
@@ -746,6 +748,7 @@ test('"rel" property', function () {
     }
 
     checkRelAttr('prefetch', null);
+    checkRelAttr('  prEFEtch ', null);
     checkRelAttr('autor', 'autor');
 
     link.parentNode.removeChild(link);

--- a/test/server/data/page/expected-https.html
+++ b/test/server/data/page/expected-https.html
@@ -2,6 +2,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=7">
     <link id="stylesheet" rel="stylesheet" type="text/css" href="https://127.0.0.1:1836/sessionId/http://stylesheet.url" crossorigin="anonymous" href-hammerhead-stored-value="http://stylesheet.url" integrity-hammerhead-stored-value="sha384-Li9vy3DqF8tnTXuiaAJuML3ky+er10rcgNR/VqsVpcw+ThHmYcwiB1pbOxEbzJr7">
+    <link href="https://127.0.0.1:1836/sessionId/http://prefetch.url" href-hammerhead-stored-value="http://prefetch.url" rel-hammerhead-stored-value="prefetch">
     <script type="text/javascript" src="https://127.0.0.1:1836/sessionId!s!utf-8/http://link.url" crossorigin="anonymous" src-hammerhead-stored-value="http://link.url" integrity-hammerhead-stored-value="sha384-Li9vy3DqF8tnTXuiaAJuML3ky+er10rcgNR/VqsVpcw+ThHmYcwiB1pbOxEbzJr7"></script>
     <script type="text/javascript" charset="utf-16be" src="https://127.0.0.1:1836/sessionId!s!utf-16be/http://link.url" src-hammerhead-stored-value="http://link.url"></script>
     <meta http-equiv="Refresh" content="0;URL=https://127.0.0.1:1836/sessionId/http://link.url/">

--- a/test/server/data/page/expected.html
+++ b/test/server/data/page/expected.html
@@ -2,6 +2,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=7">
     <link id="stylesheet" rel="stylesheet" type="text/css" href="http://127.0.0.1:1836/sessionId/http://stylesheet.url" crossorigin="anonymous" href-hammerhead-stored-value="http://stylesheet.url" integrity-hammerhead-stored-value="sha384-Li9vy3DqF8tnTXuiaAJuML3ky+er10rcgNR/VqsVpcw+ThHmYcwiB1pbOxEbzJr7">
+    <link href="http://127.0.0.1:1836/sessionId/http://prefetch.url" href-hammerhead-stored-value="http://prefetch.url" rel-hammerhead-stored-value="prefetch">
     <script type="text/javascript" src="http://127.0.0.1:1836/sessionId!s!utf-8/http://link.url" crossorigin="anonymous" src-hammerhead-stored-value="http://link.url" integrity-hammerhead-stored-value="sha384-Li9vy3DqF8tnTXuiaAJuML3ky+er10rcgNR/VqsVpcw+ThHmYcwiB1pbOxEbzJr7"></script>
     <script type="text/javascript" charset="utf-16be" src="http://127.0.0.1:1836/sessionId!s!utf-16be/http://link.url" src-hammerhead-stored-value="http://link.url"></script>
     <meta http-equiv="Refresh" content="0;URL=http://127.0.0.1:1836/sessionId/http://link.url/">

--- a/test/server/data/page/src.html
+++ b/test/server/data/page/src.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=7" />
     <link id="stylesheet" rel="stylesheet" type="text/css" href="http://stylesheet.url" integrity="sha384-Li9vy3DqF8tnTXuiaAJuML3ky+er10rcgNR/VqsVpcw+ThHmYcwiB1pbOxEbzJr7" crossorigin="anonymous">
+    <link rel="prefetch" href="http://prefetch.url">
     <script type="text/javascript" src="http://link.url" integrity="sha384-Li9vy3DqF8tnTXuiaAJuML3ky+er10rcgNR/VqsVpcw+ThHmYcwiB1pbOxEbzJr7" crossorigin="anonymous"></script>
     <script type="text/javascript" charset="utf-16be" src="http://link.url"></script>
     <meta http-equiv="Refresh" content="0;URL=http://link.url/">


### PR DESCRIPTION
https://github.com/DevExpress/testcafe/issues/2528

### Changes
1. Override `rel` attribute of `HTMLLinkElement`.
2. Omit HTTP `Link:` header from response.
3. Fix `isTagWithTargetAttr`, `isTagWithFormTargetAttr` and `isTagWithIntegrityAttr` (add `tagName` check).
4. Refactor const `TARGET_ATTR_TAGS['target']` to `TARGET_ATTR_TAGS.target`


### rel="prefetch" tags
https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types:
`<link>`
`<a>` (Unimplemented), `<area>` (Unimplemented)

### Notes:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ:
> The browser looks for either an HTML `<link>` or an HTTP `Link: header` with a relation type of either `next` or `prefetch`
