### PR TITLE
fix `fetch.toString() prints full function code instead of function fetch() { [native code] }` (close #1662)

### DIFF
--- a/src/client/sandbox/fetch.js
+++ b/src/client/sandbox/fetch.js
@@ -131,6 +131,10 @@ export default class FetchSandbox extends SandboxBase {
                 });
         };
 
+        const fetchToString = nativeMethods.fetch.toString();
+
+        window.fetch.toString = () => fetchToString;
+
         overrideDescriptor(window.Response.prototype, 'type', {
             getter: function () {
                 return FetchSandbox._getResponseType(this);

--- a/test/client/fixtures/sandbox/fetch-test.js
+++ b/test/client/fixtures/sandbox/fetch-test.js
@@ -7,6 +7,10 @@ var browserUtils  = hammerhead.utils.browser;
 var Promise       = hammerhead.Promise;
 
 if (window.fetch) {
+    test('fetch.toString (GH-1662)', function () {
+        strictEqual(fetch.toString(), nativeMethods.fetch.toString());
+    });
+
     test('global fetch - redirect request to proxy', function () {
         return fetch('/xhr-test/100')
             .then(function (response) {


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1662

localForage/src/utils/isIndexedDBValid.js
https://github.com/localForage/localForage/blob/55db1ef633af28abe98ea0baf68fa1c24566f282/src/utils/isIndexedDBValid.js#L20-L22