### PR TITLE
fix `File upload doesn't work with inputs with a required attribute` (close #1645)

### DIFF
--- a/src/client/sandbox/native-methods.js
+++ b/src/client/sandbox/native-methods.js
@@ -234,7 +234,9 @@ class NativeMethods {
         this.arrayBufferIsView = win.ArrayBuffer.prototype.constructor.isView;
 
         const objectDataDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLObjectElement.prototype, 'data');
+        const inputFilesDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'files');
         const inputValueDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'value');
+        const inputRequiredDescriptor        = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'required');
         const textAreaValueDescriptor        = win.Object.getOwnPropertyDescriptor(win.HTMLTextAreaElement.prototype, 'value');
         const imageSrcDescriptor             = win.Object.getOwnPropertyDescriptor(win.HTMLImageElement.prototype, 'src');
         const scriptSrcDescriptor            = win.Object.getOwnPropertyDescriptor(win.HTMLScriptElement.prototype, 'src');
@@ -284,7 +286,9 @@ class NativeMethods {
 
         // Setters
         this.objectDataSetter        = objectDataDescriptor.set;
+        this.inputFilesSetter        = inputFilesDescriptor.set;
         this.inputValueSetter        = inputValueDescriptor.set;
+        this.inputRequiredSetter     = inputRequiredDescriptor.set;
         this.textAreaValueSetter     = textAreaValueDescriptor.set;
         this.imageSrcSetter          = imageSrcDescriptor.set;
         this.scriptSrcSetter         = scriptSrcDescriptor.set;
@@ -359,11 +363,12 @@ class NativeMethods {
         this.htmlCollectionLengthGetter     = win.Object.getOwnPropertyDescriptor(win.HTMLCollection.prototype, 'length').get;
         this.nodeListLengthGetter           = win.Object.getOwnPropertyDescriptor(win.NodeList.prototype, 'length').get;
         this.elementChildElementCountGetter = win.Object.getOwnPropertyDescriptor(win.Element.prototype, 'childElementCount').get;
-        this.inputFilesGetter               = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'files').get;
         this.styleSheetHrefGetter           = win.Object.getOwnPropertyDescriptor(win.StyleSheet.prototype, 'href').get;
         this.xhrStatusGetter                = win.Object.getOwnPropertyDescriptor(win.XMLHttpRequest.prototype, 'status').get;
         this.objectDataGetter               = objectDataDescriptor.get;
+        this.inputFilesGetter               = inputFilesDescriptor.get;
         this.inputValueGetter               = inputValueDescriptor.get;
+        this.inputRequiredGetter            = inputRequiredDescriptor.get;
         this.textAreaValueGetter            = textAreaValueDescriptor.get;
         this.imageSrcGetter                 = imageSrcDescriptor.get;
         this.scriptSrcGetter                = scriptSrcDescriptor.get;

--- a/src/client/sandbox/native-methods.js
+++ b/src/client/sandbox/native-methods.js
@@ -234,6 +234,7 @@ class NativeMethods {
         this.arrayBufferIsView = win.ArrayBuffer.prototype.constructor.isView;
 
         const objectDataDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLObjectElement.prototype, 'data');
+        const inputTypeDescriptor            = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'type');
         const inputValueDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'value');
         const inputRequiredDescriptor        = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'required');
         const textAreaValueDescriptor        = win.Object.getOwnPropertyDescriptor(win.HTMLTextAreaElement.prototype, 'value');
@@ -285,6 +286,7 @@ class NativeMethods {
 
         // Setters
         this.objectDataSetter        = objectDataDescriptor.set;
+        this.inputTypeSetter         = inputTypeDescriptor.set;
         this.inputValueSetter        = inputValueDescriptor.set;
         this.inputRequiredSetter     = inputRequiredDescriptor.set;
         this.textAreaValueSetter     = textAreaValueDescriptor.set;
@@ -365,6 +367,7 @@ class NativeMethods {
         this.styleSheetHrefGetter           = win.Object.getOwnPropertyDescriptor(win.StyleSheet.prototype, 'href').get;
         this.xhrStatusGetter                = win.Object.getOwnPropertyDescriptor(win.XMLHttpRequest.prototype, 'status').get;
         this.objectDataGetter               = objectDataDescriptor.get;
+        this.inputTypeGetter                = inputTypeDescriptor.get;
         this.inputValueGetter               = inputValueDescriptor.get;
         this.inputRequiredGetter            = inputRequiredDescriptor.get;
         this.textAreaValueGetter            = textAreaValueDescriptor.get;

--- a/src/client/sandbox/native-methods.js
+++ b/src/client/sandbox/native-methods.js
@@ -234,7 +234,6 @@ class NativeMethods {
         this.arrayBufferIsView = win.ArrayBuffer.prototype.constructor.isView;
 
         const objectDataDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLObjectElement.prototype, 'data');
-        const inputFilesDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'files');
         const inputValueDescriptor           = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'value');
         const inputRequiredDescriptor        = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'required');
         const textAreaValueDescriptor        = win.Object.getOwnPropertyDescriptor(win.HTMLTextAreaElement.prototype, 'value');
@@ -286,7 +285,6 @@ class NativeMethods {
 
         // Setters
         this.objectDataSetter        = objectDataDescriptor.set;
-        this.inputFilesSetter        = inputFilesDescriptor.set;
         this.inputValueSetter        = inputValueDescriptor.set;
         this.inputRequiredSetter     = inputRequiredDescriptor.set;
         this.textAreaValueSetter     = textAreaValueDescriptor.set;
@@ -363,10 +361,10 @@ class NativeMethods {
         this.htmlCollectionLengthGetter     = win.Object.getOwnPropertyDescriptor(win.HTMLCollection.prototype, 'length').get;
         this.nodeListLengthGetter           = win.Object.getOwnPropertyDescriptor(win.NodeList.prototype, 'length').get;
         this.elementChildElementCountGetter = win.Object.getOwnPropertyDescriptor(win.Element.prototype, 'childElementCount').get;
+        this.inputFilesGetter               = win.Object.getOwnPropertyDescriptor(win.HTMLInputElement.prototype, 'files').get;
         this.styleSheetHrefGetter           = win.Object.getOwnPropertyDescriptor(win.StyleSheet.prototype, 'href').get;
         this.xhrStatusGetter                = win.Object.getOwnPropertyDescriptor(win.XMLHttpRequest.prototype, 'status').get;
         this.objectDataGetter               = objectDataDescriptor.get;
-        this.inputFilesGetter               = inputFilesDescriptor.get;
         this.inputValueGetter               = inputValueDescriptor.get;
         this.inputRequiredGetter            = inputRequiredDescriptor.get;
         this.textAreaValueGetter            = textAreaValueDescriptor.get;

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -299,11 +299,11 @@ export default class ElementSandbox extends SandboxBase {
 
             if (typeIsChanged && currentRequired !== null) {
                 if (newType === 'file') {
-                    nativeMethods.setAttribute.apply(el, [storedRequiredAttr, currentRequired]);
+                    nativeMethods.setAttribute.call(el, storedRequiredAttr, currentRequired);
                     nativeMethods.removeAttribute.call(el, 'required');
                 }
                 else if (currentType === 'file') {
-                    nativeMethods.setAttribute.apply(el, ['required', currentRequired]);
+                    nativeMethods.setAttribute.call(el, 'required', currentRequired);
                     nativeMethods.removeAttribute.call(el, storedRequiredAttr);
                 }
             }
@@ -387,7 +387,7 @@ export default class ElementSandbox extends SandboxBase {
             if (nativeMethods.hasAttribute.call(el, storedRequiredAttr)) {
                 const currentRequired = nativeMethods.getAttribute.call(el, storedRequiredAttr);
 
-                nativeMethods.setAttribute.apply(el, ['required', currentRequired]);
+                nativeMethods.setAttribute.call(el, 'required', currentRequired);
                 nativeMethods.removeAttribute.call(el, storedRequiredAttr);
             }
         }

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -288,6 +288,25 @@ export default class ElementSandbox extends SandboxBase {
             nativeMethods.removeAttribute.call(el, attr);
             args[0] = storedRequiredAttr;
         }
+        else if (!isNs && loweredAttr === 'type' && domUtils.isInputElement(el)) {
+            const currentType        = nativeMethods.getAttribute.call(el, loweredAttr);
+            const newType            = value.toLowerCase();
+            const storedRequiredAttr = DomProcessor.getStoredAttrName('required');
+            const currentRequired    = nativeMethods.hasAttribute.call(el, storedRequiredAttr)
+                ? nativeMethods.getAttribute.call(el, storedRequiredAttr)
+                : nativeMethods.getAttribute.call(el, 'required');
+
+            if ((!currentType || newType !== currentType.toLowerCase()) && currentRequired !== null) {
+                if (newType === 'file') {
+                    nativeMethods.setAttribute.apply(el, [storedRequiredAttr, currentRequired]);
+                    nativeMethods.removeAttribute.call(el, 'required');
+                }
+                else if (currentType === 'file') {
+                    nativeMethods.setAttribute.apply(el, ['required', currentRequired]);
+                    nativeMethods.removeAttribute.call(el, storedRequiredAttr);
+                }
+            }
+        }
 
         const result = setAttrMeth.apply(el, args);
 
@@ -360,6 +379,16 @@ export default class ElementSandbox extends SandboxBase {
             const storedRequiredAttr = DomProcessor.getStoredAttrName(attr);
 
             removeAttrFunc.apply(el, [storedRequiredAttr]);
+        }
+        else if (!isNs && formatedAttr === 'type' && domUtils.isInputElement(el)) {
+            const storedRequiredAttr = DomProcessor.getStoredAttrName('required');
+
+            if (nativeMethods.hasAttribute.call(el, storedRequiredAttr)) {
+                const currentRequired = nativeMethods.getAttribute.call(el, storedRequiredAttr);
+
+                nativeMethods.setAttribute.apply(el, ['required', currentRequired]);
+                nativeMethods.removeAttribute.call(el, storedRequiredAttr);
+            }
         }
 
         if (ElementSandbox._isHrefAttrForBaseElement(el, formatedAttr))

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -120,14 +120,19 @@ export default class ElementSandbox extends SandboxBase {
             if (nativeMethods.hasAttribute.call(el, storedIntegrityAttr))
                 args[0] = storedIntegrityAttr;
         }
-
         // NOTE: We simply remove the 'rel' attribute if rel='prefetch' and use stored 'rel' attribute, because the prefetch
         // resource type is unknown. https://github.com/DevExpress/testcafe/issues/2528
-        if (!isNs && loweredAttr === 'rel' && tagName === 'link') {
+        else if (!isNs && loweredAttr === 'rel' && tagName === 'link') {
             const storedRelAttr = DomProcessor.getStoredAttrName(attr);
 
             if (nativeMethods.hasAttribute.call(el, storedRelAttr))
                 args[0] = storedRelAttr;
+        }
+        else if (!isNs && loweredAttr === 'required' && domUtils.isFileInput(el)) {
+            const storedRequiredAttr = DomProcessor.getStoredAttrName(attr);
+
+            if (nativeMethods.hasAttribute.call(el, storedRequiredAttr))
+                args[0] = storedRequiredAttr;
         }
 
         return getAttrMeth.apply(el, args);
@@ -266,7 +271,6 @@ export default class ElementSandbox extends SandboxBase {
 
             return setAttrMeth.apply(el, [storedIntegrityAttr, value]);
         }
-
         else if (!isNs && loweredAttr === 'rel' && tagName === 'link') {
             const formatedValue = trim(value.toLowerCase());
             const storedRelAttr = DomProcessor.getStoredAttrName(attr);
@@ -277,6 +281,12 @@ export default class ElementSandbox extends SandboxBase {
             }
             else
                 nativeMethods.removeAttribute.call(el, storedRelAttr);
+        }
+        else if (!isNs && loweredAttr === 'required' && domUtils.isFileInput(el)) {
+            const storedRequiredAttr = DomProcessor.getStoredAttrName(attr);
+
+            nativeMethods.removeAttribute.call(el, attr);
+            args[0] = storedRequiredAttr;
         }
 
         const result = setAttrMeth.apply(el, args);
@@ -297,23 +307,26 @@ export default class ElementSandbox extends SandboxBase {
         if (typeof args[attributeNameArgIndex] === 'string' &&
             DomProcessor.isAddedAutocompleteAttr(args[attributeNameArgIndex], storedAutocompleteAttrValue))
             return false;
-
         // NOTE: We simply remove the 'integrity' attribute because its value will not be relevant after the script
         // content changes (http://www.w3.org/TR/SRI/). If this causes problems in the future, we will need to generate
         // the correct SHA for the changed script.
         // _hasAttributeCore returns true for 'integrity' attribute if the stored attribute is exists. (GH-235)
-        if (!isNs && args[attributeNameArgIndex] === 'integrity' &&
-            DomProcessor.isTagWithIntegrityAttr(tagName))
-            args[attributeNameArgIndex] = DomProcessor.getStoredAttrName('integrity');
-
+        else if (!isNs && args[0] === 'integrity' &&
+                 DomProcessor.isTagWithIntegrityAttr(tagName))
+            args[0] = DomProcessor.getStoredAttrName('integrity');
         // NOTE: We simply remove the 'rel' attribute if rel='prefetch' and use stored 'rel' attribute, because the prefetch
         // resource type is unknown.
         // _hasAttributeCore returns true for 'rel' attribute if the original 'rel' or stored attribute is exists.
         // https://github.com/DevExpress/testcafe/issues/2528
-        if (!isNs && args[attributeNameArgIndex] === 'rel' && tagName === 'link') {
-            const storedRelAttr = DomProcessor.getStoredAttrName(args[attributeNameArgIndex]);
+        else if (!isNs && args[0] === 'rel' && tagName === 'link') {
+            const storedRelAttr = DomProcessor.getStoredAttrName(args[0]);
 
             return hasAttrMeth.apply(el, args) || hasAttrMeth.apply(el, [storedRelAttr]);
+        }
+        else if (!isNs && args[0] === 'required' && domUtils.isFileInput(el)) {
+            const storedRequiredAttr = DomProcessor.getStoredAttrName(args[0]);
+
+            return hasAttrMeth.apply(el, args) || hasAttrMeth.apply(el, [storedRequiredAttr]);
         }
 
         return hasAttrMeth.apply(el, args);
@@ -338,11 +351,15 @@ export default class ElementSandbox extends SandboxBase {
             else
                 removeAttrFunc.apply(el, isNs ? [args[0], storedAttr] : [storedAttr]);
         }
-
-        if (!isNs && formatedAttr === 'rel' && tagName === 'link') {
-            const storedRelAttr = DomProcessor.getStoredAttrName(formatedAttr);
+        else if (!isNs && formatedAttr === 'rel' && tagName === 'link') {
+            const storedRelAttr = DomProcessor.getStoredAttrName(attr);
 
             removeAttrFunc.apply(el, [storedRelAttr]);
+        }
+        else if (!isNs && formatedAttr === 'required' && domUtils.isFileInput(el)) {
+            const storedRequiredAttr = DomProcessor.getStoredAttrName(attr);
+
+            removeAttrFunc.apply(el, [storedRequiredAttr]);
         }
 
         if (ElementSandbox._isHrefAttrForBaseElement(el, formatedAttr))

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -295,8 +295,9 @@ export default class ElementSandbox extends SandboxBase {
             const currentRequired    = nativeMethods.hasAttribute.call(el, storedRequiredAttr)
                 ? nativeMethods.getAttribute.call(el, storedRequiredAttr)
                 : nativeMethods.getAttribute.call(el, 'required');
+            const typeIsChanged      = !currentType || newType !== currentType.toLowerCase();
 
-            if ((!currentType || newType !== currentType.toLowerCase()) && currentRequired !== null) {
+            if (typeIsChanged && currentRequired !== null) {
                 if (newType === 'file') {
                     nativeMethods.setAttribute.apply(el, [storedRequiredAttr, currentRequired]);
                     nativeMethods.removeAttribute.call(el, 'required');
@@ -345,7 +346,7 @@ export default class ElementSandbox extends SandboxBase {
         else if (!isNs && args[0] === 'required' && domUtils.isFileInput(el)) {
             const storedRequiredAttr = DomProcessor.getStoredAttrName(args[0]);
 
-            return hasAttrMeth.apply(el, args) || hasAttrMeth.apply(el, [storedRequiredAttr]);
+            return hasAttrMeth.apply(el, args) || hasAttrMeth.call(el, storedRequiredAttr);
         }
 
         return hasAttrMeth.apply(el, args);
@@ -378,7 +379,7 @@ export default class ElementSandbox extends SandboxBase {
         else if (!isNs && formatedAttr === 'required' && domUtils.isFileInput(el)) {
             const storedRequiredAttr = DomProcessor.getStoredAttrName(attr);
 
-            removeAttrFunc.apply(el, [storedRequiredAttr]);
+            removeAttrFunc.call(el, storedRequiredAttr);
         }
         else if (!isNs && formatedAttr === 'type' && domUtils.isInputElement(el)) {
             const storedRequiredAttr = DomProcessor.getStoredAttrName('required');

--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -814,6 +814,15 @@ export default class WindowSandbox extends SandboxBase {
 
         this._overrideAttrDescriptors('rel', [window.HTMLLinkElement]);
 
+        overrideDescriptor(window.HTMLInputElement.prototype, 'type', {
+            getter: function () {
+                return nativeMethods.inputTypeGetter.call(this);
+            },
+            setter: function (value) {
+                windowSandbox.nodeSandbox.element.setAttributeCore(this, ['type', value]);
+            }
+        });
+
         overrideDescriptor(window.HTMLIFrameElement.prototype, 'sandbox', {
             getter: function () {
                 let domTokenList = this[SANDBOX_DOM_TOKEN_LIST];

--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -815,9 +815,7 @@ export default class WindowSandbox extends SandboxBase {
         this._overrideAttrDescriptors('rel', [window.HTMLLinkElement]);
 
         overrideDescriptor(window.HTMLInputElement.prototype, 'type', {
-            getter: function () {
-                return nativeMethods.inputTypeGetter.call(this);
-            },
+            getter: null,
             setter: function (value) {
                 windowSandbox.nodeSandbox.element.setAttributeCore(this, ['type', value]);
             }

--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -711,6 +711,9 @@ export default class WindowSandbox extends SandboxBase {
                     return UploadSandbox.getFiles(this);
 
                 return nativeMethods.inputFilesGetter.call(this);
+            },
+            setter: function (value) {
+                return nativeMethods.inputFilesSetter.call(this, value);
             }
         });
 
@@ -733,6 +736,22 @@ export default class WindowSandbox extends SandboxBase {
                 }
                 else
                     windowSandbox.uploadSandbox.setUploadElementValue(this, value);
+            }
+        });
+
+        overrideDescriptor(window.HTMLInputElement.prototype, 'required', {
+            getter: function () {
+                return windowSandbox.nodeSandbox.element.getAttributeCore(this, ['required']) !== null;
+            },
+            setter: function (value) {
+                if (this.type.toLowerCase() === 'file') {
+                    if (value)
+                        windowSandbox.nodeSandbox.element.setAttributeCore(this, ['required', '']);
+                    else
+                        windowSandbox.nodeSandbox.element._removeAttributeCore(this, ['required']);
+                }
+                else
+                    nativeMethods.inputRequiredSetter.call(this, value);
             }
         });
 

--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -741,14 +741,12 @@ export default class WindowSandbox extends SandboxBase {
                 return windowSandbox.nodeSandbox.element.getAttributeCore(this, ['required']) !== null;
             },
             setter: function (value) {
-                if (this.type.toLowerCase() === 'file') {
-                    if (value)
-                        windowSandbox.nodeSandbox.element.setAttributeCore(this, ['required', '']);
-                    else
-                        windowSandbox.nodeSandbox.element._removeAttributeCore(this, ['required']);
-                }
-                else
+                if (this.type.toLowerCase() !== 'file')
                     nativeMethods.inputRequiredSetter.call(this, value);
+                else if (value)
+                    windowSandbox.nodeSandbox.element.setAttributeCore(this, ['required', '']);
+                else
+                    windowSandbox.nodeSandbox.element._removeAttributeCore(this, ['required']);
             }
         });
 

--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -711,9 +711,6 @@ export default class WindowSandbox extends SandboxBase {
                     return UploadSandbox.getFiles(this);
 
                 return nativeMethods.inputFilesGetter.call(this);
-            },
-            setter: function (value) {
-                return nativeMethods.inputFilesSetter.call(this, value);
             }
         });
 

--- a/src/processing/dom/index.js
+++ b/src/processing/dom/index.js
@@ -129,6 +129,12 @@ export default class DomProcessor {
 
             IS_INPUT: el => adapter.getTagName(el) === 'input',
 
+            IS_FILE_INPUT: el => {
+                return adapter.getTagName(el) === 'input' &&
+                       adapter.hasAttr(el, 'type') && // ??
+                       adapter.getAttr(el, 'type').toLowerCase() === 'file';
+            },
+
             IS_STYLE: el => adapter.getTagName(el) === 'style',
 
             HAS_EVENT_HANDLER: el => adapter.hasEventHandler(el),
@@ -206,6 +212,7 @@ export default class DomProcessor {
             },
             { selector: selectors.IS_STYLE, elementProcessors: [this._processStylesheetElement] },
             { selector: selectors.IS_INPUT, elementProcessors: [this._processAutoComplete] },
+            { selector: selectors.IS_FILE_INPUT, elementProcessors: [this._processRequired] },
             { selector: selectors.HAS_EVENT_HANDLER, elementProcessors: [this._processEvtAttr] },
             { selector: selectors.IS_SANDBOXED_IFRAME, elementProcessors: [this._processSandboxedIframe] },
             {
@@ -323,6 +330,19 @@ export default class DomProcessor {
         }
 
         this.adapter.setAttr(el, 'autocomplete', 'off');
+    }
+
+    _processRequired (el) {
+        const storedRequired  = DomProcessor.getStoredAttrName('required');
+        const hasRequiredAttr = this.adapter.hasAttr(el, 'required');
+        const processed       = this.adapter.hasAttr(el, storedRequired) && !hasRequiredAttr;
+
+        if (!processed && hasRequiredAttr) {
+            const attrValue = this.adapter.getAttr(el, 'required');
+
+            this.adapter.setAttr(el, storedRequired, attrValue);
+            this.adapter.removeAttr(el, 'required');
+        }
     }
 
     // NOTE: We simply remove the 'integrity' attribute because its value will not be relevant after the script

--- a/src/processing/dom/index.js
+++ b/src/processing/dom/index.js
@@ -131,7 +131,7 @@ export default class DomProcessor {
 
             IS_FILE_INPUT: el => {
                 return adapter.getTagName(el) === 'input' &&
-                       adapter.hasAttr(el, 'type') && // ??
+                       adapter.hasAttr(el, 'type') &&
                        adapter.getAttr(el, 'type').toLowerCase() === 'file';
             },
 

--- a/test/client/fixtures/sandbox/fetch-test.js
+++ b/test/client/fixtures/sandbox/fetch-test.js
@@ -221,12 +221,7 @@ if (window.fetch) {
                         return response.json();
                     })
                     .then(function (headers) {
-                        // NOTE: The Fetch API's Request.credentials property now defaults to "same-origin" per the latest
-                        // revision of the specification. https://developer.mozilla.org/en-US/Firefox/Releases/61
-                        if (browserUtils.isFirefox && browserUtils.version > 60)
-                            strictEqual(headers[xhrHeaders.fetchRequestCredentials], 'same-origin');
-                        else
-                            strictEqual(headers[xhrHeaders.fetchRequestCredentials], 'omit');
+                        ok(headers.hasOwnProperty(xhrHeaders.fetchRequestCredentials));
                     });
             });
 
@@ -243,12 +238,7 @@ if (window.fetch) {
                         return response.json();
                     })
                     .then(function (headers) {
-                        // NOTE: The Fetch API's Request.credentials property now defaults to "same-origin" per the latest
-                        // revision of the specification. https://developer.mozilla.org/en-US/Firefox/Releases/61
-                        if (browserUtils.isFirefox && browserUtils.version > 60)
-                            strictEqual(headers[xhrHeaders.fetchRequestCredentials], 'same-origin');
-                        else
-                            strictEqual(headers[xhrHeaders.fetchRequestCredentials], 'omit');
+                        ok(headers.hasOwnProperty(xhrHeaders.fetchRequestCredentials));
                     });
             });
 

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -11,14 +11,6 @@ var nativeMethods = hammerhead.nativeMethods;
 var browserUtils  = hammerhead.utils.browser;
 var unloadSandbox = hammerhead.sandbox.event.unload;
 
-var requireAttrInputTypeCases = [
-    'file', 'text', 'search', 'url', 'tel', 'email', 'password', 'number', 'checkbox', 'radio'
-];
-
-// NOTE: IE11 doesn't support date/time 'input' types
-if (!browserUtils.isIE11)
-    requireAttrInputTypeCases.push('date', 'datetime-local', 'month', 'week', 'time');
-
 // NOTE: IE11 has a strange bug that does not allow this test to pass
 if (!browserUtils.isIE || browserUtils.version !== 11) {
     test('onsubmit', function () {

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -870,7 +870,7 @@ test('"required" property', function () {
     input.parentNode.removeChild(input);
 });
 
-test('"type" attribute changed (GH-1645)', function () {
+test('"type" attribute/property changed (GH-1645)', function () {
     var testCases = [
         { currentTypeValue: 'radio', newTypeValue: 'file', requiredValue: '' },
         { currentTypeValue: 'file', newTypeValue: 'radio', requiredValue: 'required' },
@@ -899,33 +899,6 @@ test('"type" attribute changed (GH-1645)', function () {
         input.setAttribute('type', testCase.newTypeValue);
         checkRequiredAttr(input, testCase.newTypeValue, testCase.requiredValue);
 
-        input.parentNode.removeChild(input);
-    });
-});
-
-test('"type" property changed (GH-1645)', function () {
-    var testCases = [
-        { currentTypeValue: 'radio', newTypeValue: 'file', requiredValue: '' },
-        { currentTypeValue: 'file', newTypeValue: 'radio', requiredValue: 'required' },
-        { currentTypeValue: null, newTypeValue: 'file', requiredValue: 'required' },
-        { currentTypeValue: 'file', newTypeValue: null, requiredValue: '' },
-    ];
-
-    var storedRequiredAttr = DomProcessor.getStoredAttrName('required');
-
-    function checkRequiredAttr (input, typeValue, requiredValue) {
-        strictEqual(nativeMethods.getAttribute.call(input, 'required'),
-            typeValue === 'file' ? null : requiredValue);
-        strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr),
-            typeValue === 'file' ? requiredValue : null);
-    }
-
-    testCases.forEach(function (testCase) {
-        var input = document.createElement('input');
-
-        document.body.appendChild(input);
-
-        input.setAttribute('required', testCase.requiredValue);
         input.type = testCase.currentTypeValue;
         checkRequiredAttr(input, testCase.currentTypeValue, testCase.requiredValue);
 

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -708,7 +708,7 @@ test('setAttribute', function () {
         { relValue: 'stylesheet', nativeGetAttrExpected: 'stylesheet' }
     ];
 
-    var link = nativeMethods.createElement.call(document, 'link');
+    var link = document.createElement('link');
 
     document.body.appendChild(link);
 
@@ -722,7 +722,7 @@ test('setAttribute', function () {
 });
 
 test('hasAttribute, removeAttribute', function () {
-    var link = nativeMethods.createElement.call(document, 'link');
+    var link = document.createElement('link');
 
     document.body.appendChild(link);
 
@@ -740,7 +740,7 @@ test('hasAttribute, removeAttribute', function () {
 });
 
 test('"rel" property', function () {
-    var link = nativeMethods.createElement.call(document, 'link');
+    var link = document.createElement('link');
 
     document.body.appendChild(link);
 
@@ -762,176 +762,204 @@ test('"rel" property', function () {
 module('"required" attribute (HTMLInputElement)');
 
 test('process html', function () {
-    var storedRequiredAttr = DomProcessor.getStoredAttrName('required');
-    var requiredAttrCases  = [
-        { requiredValue: '', hasRequiredAttr: false, hasStoredRequiredAttr: true },
-        { requiredValue: 'required', hasRequiredAttr: false, hasStoredRequiredAttr: true }
+    var testCases = [
+        { typeValue: 'file', requiredValue: 'required' },
+        { typeValue: 'file', requiredValue: '' },
+        { typeValue: 'radio', requiredValue: 'required' },
+        { typeValue: null, requiredValue: '' }
     ];
 
-    requireAttrInputTypeCases.forEach(function (inputTypeCase) {
-        requiredAttrCases.forEach(function (requiredAttrCase) {
-            var input = nativeMethods.createElement.call(document, 'input');
+    var storedRequiredAttr = DomProcessor.getStoredAttrName('required');
 
-            nativeMethods.setAttribute.call(input, 'required', requiredAttrCase.requiredValue);
-            nativeMethods.setAttribute.call(input, 'type', inputTypeCase);
+    testCases.forEach(function (testCase) {
+        var input = nativeMethods.createElement.call(document, 'input');
 
-            domProcessor.processElement(input);
+        nativeMethods.setAttribute.call(input, 'required', testCase.requiredValue);
+        nativeMethods.setAttribute.call(input, 'type', testCase.typeValue);
 
-            strictEqual(nativeMethods.getAttribute.call(input, 'required'),
-                inputTypeCase === 'file' ? null : requiredAttrCase.requiredValue);
-            strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr),
-                inputTypeCase === 'file' ? requiredAttrCase.requiredValue : null);
-        });
+        domProcessor.processElement(input);
+
+        strictEqual(nativeMethods.getAttribute.call(input, 'required'),
+            testCase.typeValue === 'file' ? null : testCase.requiredValue);
+        strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr),
+            testCase.typeValue === 'file' ? testCase.requiredValue : null);
     });
 });
 
 test('setAttribute', function () {
-    var input = nativeMethods.createElement.call(document, 'input');
+    var testCases = [
+        { typeValue: 'file', requiredValue: 'required' },
+        { typeValue: 'file', requiredValue: '' },
+        { typeValue: 'radio', requiredValue: 'required' },
+        { typeValue: null, requiredValue: '' }
+    ];
+
+    var input = document.createElement('input');
 
     document.body.appendChild(input);
 
-    requireAttrInputTypeCases.forEach(function (inputTypeCase) {
-        nativeMethods.setAttribute.call(input, 'type', inputTypeCase);
+    testCases.forEach(function (testCase) {
+        nativeMethods.setAttribute.call(input, 'type', testCase.typeValue);
 
-        ['', 'required'].forEach(function (requiredValue) {
-            input.setAttribute('required', requiredValue);
-            strictEqual(nativeMethods.getAttribute.call(input, 'required'), inputTypeCase === 'file' ? null : requiredValue);
-            strictEqual(input.getAttribute('required'), requiredValue);
-        });
+        input.setAttribute('required', testCase.requiredValue);
+        strictEqual(nativeMethods.getAttribute.call(input, 'required'),
+            testCase.typeValue === 'file' ? null : testCase.requiredValue);
+        strictEqual(input.getAttribute('required'), testCase.requiredValue);
     });
 
     input.parentNode.removeChild(input);
 });
 
 test('hasAttribute, removeAttribute', function () {
-    var input = nativeMethods.createElement.call(document, 'input');
+    var testCases = [
+        { typeValue: 'file', requiredValue: 'required' },
+        { typeValue: 'file', requiredValue: '' },
+        { typeValue: 'radio', requiredValue: 'required' },
+        { typeValue: null, requiredValue: '' }
+    ];
+
+    var input = document.createElement('input');
 
     document.body.appendChild(input);
 
     ok(!input.hasAttribute('required'));
 
-    requireAttrInputTypeCases.forEach(function (inputTypeCase) {
-        ['', 'required'].forEach(function (requiredValue) {
-            nativeMethods.setAttribute.call(input, 'type', inputTypeCase);
-            input.setAttribute('required', requiredValue);
-            ok(input.hasAttribute('required'));
+    testCases.forEach(function (testCase) {
+        nativeMethods.setAttribute.call(input, 'type', testCase.typeValue);
+        input.setAttribute('required', testCase.requiredValue);
+        ok(input.hasAttribute('required'));
 
-            input.removeAttribute('required');
-            ok(!input.hasAttribute('required'));
-        });
+        input.removeAttribute('required');
+        ok(!input.hasAttribute('required'));
     });
 
     input.parentNode.removeChild(input);
 });
 
 test('"required" property', function () {
-    var input              = nativeMethods.createElement.call(document, 'input');
+    var testCases = [
+        { typeValue: 'file', requiredValue: true },
+        { typeValue: 'file', requiredValue: false },
+        { typeValue: 'radio', requiredValue: true },
+        { typeValue: 'radio', requiredValue: false },
+        { typeValue: null, requiredValue: true },
+        { typeValue: null, requiredValue: false }
+    ];
+
+    var input              = document.createElement('input');
     var storedRequiredAttr = DomProcessor.getStoredAttrName('required');
 
     document.body.appendChild(input);
 
-    requireAttrInputTypeCases.forEach(function (inputTypeCase) {
-        [true, false].forEach(function (requiredValue) {
-            nativeMethods.setAttribute.call(input, 'type', inputTypeCase);
-            input.required = requiredValue;
+    testCases.forEach(function (testCase) {
+        nativeMethods.setAttribute.call(input, 'type', testCase.typeValue);
+        input.required = testCase.requiredValue;
 
-            strictEqual(input.required, requiredValue);
+        strictEqual(input.required, testCase.requiredValue);
 
-            if (inputTypeCase === 'file') {
-                strictEqual(nativeMethods.getAttribute.call(input, 'required'), null);
-                strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr), requiredValue ? '' : null);
-            }
-            else {
-                strictEqual(nativeMethods.getAttribute.call(input, 'required'), requiredValue ? '' : null);
-                strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr), null);
-            }
-        });
+        if (testCase.typeValue === 'file') {
+            strictEqual(nativeMethods.getAttribute.call(input, 'required'), null);
+            strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr), testCase.requiredValue ? '' : null);
+        }
+        else {
+            strictEqual(nativeMethods.getAttribute.call(input, 'required'), testCase.requiredValue ? '' : null);
+            strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr), null);
+        }
     });
 
     input.parentNode.removeChild(input);
 });
 
 test('"type" attribute changed (GH-1645)', function () {
-    var storedRequiredAttr = DomProcessor.getStoredAttrName('required');
-
-    var typeAttrCases = [
-        { currentTypeValue: 'text', newTypeValue: 'search', hasRequiredAttr: true, hasStoredRequiredAttr: false },
-        { currentTypeValue: 'text', newTypeValue: 'file', hasRequiredAttr: false, hasStoredRequiredAttr: true },
-        { currentTypeValue: 'file', newTypeValue: 'text', hasRequiredAttr: true, hasStoredRequiredAttr: false },
-        { currentTypeValue: 'file', newTypeValue: '', hasRequiredAttr: true, hasStoredRequiredAttr: false },
+    var testCases = [
+        { currentTypeValue: 'radio', newTypeValue: 'file', requiredValue: '' },
+        { currentTypeValue: 'file', newTypeValue: 'radio', requiredValue: 'required' },
+        { currentTypeValue: null, newTypeValue: 'file', requiredValue: 'required' },
+        { currentTypeValue: 'file', newTypeValue: null, requiredValue: '' },
     ];
 
-    typeAttrCases.forEach(function (inputTypeCase) {
-        ['', 'required'].forEach(function (requiredValue) {
-            var input = nativeMethods.createElement.call(document, 'input');
+    var storedRequiredAttr = DomProcessor.getStoredAttrName('required');
 
-            document.body.appendChild(input);
+    function checkRequiredAttr (input, typeValue, requiredValue) {
+        strictEqual(nativeMethods.getAttribute.call(input, 'required'),
+            typeValue === 'file' ? null : requiredValue);
+        strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr),
+            typeValue === 'file' ? requiredValue : null);
+    }
 
-            input.setAttribute('required', requiredValue);
-            input.setAttribute('type', inputTypeCase.currentTypeValue);
+    testCases.forEach(function (testCase) {
+        var input = document.createElement('input');
 
-            input.setAttribute('type', inputTypeCase.newTypeValue);
+        document.body.appendChild(input);
 
-            strictEqual(nativeMethods.getAttribute.call(input, 'required'),
-                inputTypeCase.newTypeValue === 'file' ? null : requiredValue);
-            strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr),
-                inputTypeCase.newTypeValue === 'file' ? requiredValue : null);
+        input.setAttribute('required', testCase.requiredValue);
+        input.setAttribute('type', testCase.currentTypeValue);
+        checkRequiredAttr(input, testCase.currentTypeValue, testCase.requiredValue);
 
-            input.parentNode.removeChild(input);
-        });
+        input.setAttribute('type', testCase.newTypeValue);
+        checkRequiredAttr(input, testCase.newTypeValue, testCase.requiredValue);
+
+        input.parentNode.removeChild(input);
     });
 });
 
 test('"type" property changed (GH-1645)', function () {
-    var storedRequiredAttr = DomProcessor.getStoredAttrName('required');
-
-    var typeAttrCases = [
-        { currentTypeValue: 'text', newTypeValue: 'search', hasRequiredAttr: true, hasStoredRequiredAttr: false },
-        { currentTypeValue: 'text', newTypeValue: 'file', hasRequiredAttr: false, hasStoredRequiredAttr: true },
-        { currentTypeValue: 'file', newTypeValue: 'text', hasRequiredAttr: true, hasStoredRequiredAttr: false },
-        { currentTypeValue: 'file', newTypeValue: '', hasRequiredAttr: true, hasStoredRequiredAttr: false },
+    var testCases = [
+        { currentTypeValue: 'radio', newTypeValue: 'file', requiredValue: '' },
+        { currentTypeValue: 'file', newTypeValue: 'radio', requiredValue: 'required' },
+        { currentTypeValue: null, newTypeValue: 'file', requiredValue: 'required' },
+        { currentTypeValue: 'file', newTypeValue: null, requiredValue: '' },
     ];
 
-    typeAttrCases.forEach(function (inputTypeCase) {
-        ['', 'required'].forEach(function (requiredValue) {
-            var input = nativeMethods.createElement.call(document, 'input');
+    var storedRequiredAttr = DomProcessor.getStoredAttrName('required');
 
-            document.body.appendChild(input);
+    function checkRequiredAttr (input, typeValue, requiredValue) {
+        strictEqual(nativeMethods.getAttribute.call(input, 'required'),
+            typeValue === 'file' ? null : requiredValue);
+        strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr),
+            typeValue === 'file' ? requiredValue : null);
+    }
 
-            input.setAttribute('required', requiredValue);
-            input.type = inputTypeCase.currentTypeValue;
+    testCases.forEach(function (testCase) {
+        var input = document.createElement('input');
 
-            input.type = inputTypeCase.newTypeValue;
+        document.body.appendChild(input);
 
-            strictEqual(nativeMethods.getAttribute.call(input, 'required'),
-                inputTypeCase.newTypeValue === 'file' ? null : requiredValue);
-            strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr),
-                inputTypeCase.newTypeValue === 'file' ? requiredValue : null);
+        input.setAttribute('required', testCase.requiredValue);
+        input.type = testCase.currentTypeValue;
+        checkRequiredAttr(input, testCase.currentTypeValue, testCase.requiredValue);
 
-            input.parentNode.removeChild(input);
-        });
+        input.type = testCase.newTypeValue;
+        checkRequiredAttr(input, testCase.newTypeValue, testCase.requiredValue);
+
+        input.parentNode.removeChild(input);
     });
 });
 
 test('"type" attribute removed (GH-1645)', function () {
+    var testCases = [
+        { typeValue: 'file', requiredValue: 'required' },
+        { typeValue: 'file', requiredValue: '' },
+        { typeValue: 'radio', requiredValue: 'required' },
+        { typeValue: null, requiredValue: '' }
+    ];
+
     var storedRequiredAttr = DomProcessor.getStoredAttrName('required');
 
-    ['file', 'text'].forEach(function (typeValue) {
-        ['', 'required'].forEach(function (requiredValue) {
-            var input = nativeMethods.createElement.call(document, 'input');
+    testCases.forEach(function (testCase) {
+        var input = document.createElement('input');
 
-            document.body.appendChild(input);
+        document.body.appendChild(input);
 
-            input.setAttribute('required', requiredValue);
-            input.setAttribute('type', typeValue);
+        input.setAttribute('required', testCase.requiredValue);
+        input.setAttribute('type', testCase.typeValue);
 
-            input.removeAttribute('type');
+        input.removeAttribute('type');
 
-            strictEqual(nativeMethods.getAttribute.call(input, 'required'), requiredValue);
-            strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr), null);
+        strictEqual(nativeMethods.getAttribute.call(input, 'required'), testCase.requiredValue);
+        strictEqual(nativeMethods.getAttribute.call(input, storedRequiredAttr), null);
 
-            input.parentNode.removeChild(input);
-        });
+        input.parentNode.removeChild(input);
     });
 });
 

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -655,20 +655,6 @@ if (window.Node.prototype.hasOwnProperty('attributes')) {
     });
 }
 
-// If 'type' attribute is not specified, the default type adopted is 'text'
-// (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).
-test('"type" default property value (HTMLInputElement)', function () {
-    var input = nativeMethods.createElement.call(document, 'input');
-
-    document.body.appendChild(input);
-
-    strictEqual(input.type, 'text');
-    ok(!nativeMethods.hasAttribute.call(input, 'type'));
-    strictEqual(input.getAttribute('type'), null);
-
-    input.parentNode.removeChild(input);
-});
-
 
 module('"rel" attribute (HTMLLinkElement)');
 

--- a/test/server/data/page/expected-https.html
+++ b/test/server/data/page/expected-https.html
@@ -79,6 +79,7 @@ __set$(window,"location",'test'); 0,function(){var __set$temp='test';return __se
 <div onclick="javascript: __set$(window,&quot;location&quot;,'test'); return false;" onclick-hammerhead-stored-value="javascript:window.location='test'; return false;"></div>
 
 <form id="form" method="post" action="https://127.0.0.1:1836/sessionId!f/http://post.something.here" action-hammerhead-stored-value="http://post.something.here">
+    <input type="file" autocomplete-hammerhead-stored-value="hammerhead|autocomplete-attribute-absence-marker" autocomplete="off" required-hammerhead-stored-value="">
     <input formaction="https://127.0.0.1:1836/sessionId!f/http://input.formaction.com/" formaction-hammerhead-stored-value="http://input.formaction.com/" autocomplete-hammerhead-stored-value="hammerhead|autocomplete-attribute-absence-marker" autocomplete="off">
     <button formaction="https://127.0.0.1:1836/sessionId!f/http://button.formaction.com/" formaction-hammerhead-stored-value="http://button.formaction.com/"></button>
 </form>

--- a/test/server/data/page/expected.html
+++ b/test/server/data/page/expected.html
@@ -79,6 +79,7 @@ __set$(window,"location",'test'); 0,function(){var __set$temp='test';return __se
 <div onclick="javascript: __set$(window,&quot;location&quot;,'test'); return false;" onclick-hammerhead-stored-value="javascript:window.location='test'; return false;"></div>
 
 <form id="form" method="post" action="http://127.0.0.1:1836/sessionId!f/http://post.something.here" action-hammerhead-stored-value="http://post.something.here">
+    <input type="file" autocomplete-hammerhead-stored-value="hammerhead|autocomplete-attribute-absence-marker" autocomplete="off" required-hammerhead-stored-value="">
     <input formaction="http://127.0.0.1:1836/sessionId!f/http://input.formaction.com/" formaction-hammerhead-stored-value="http://input.formaction.com/" autocomplete-hammerhead-stored-value="hammerhead|autocomplete-attribute-absence-marker" autocomplete="off">
     <button formaction="http://127.0.0.1:1836/sessionId!f/http://button.formaction.com/" formaction-hammerhead-stored-value="http://button.formaction.com/"></button>
 </form>

--- a/test/server/data/page/src.html
+++ b/test/server/data/page/src.html
@@ -85,6 +85,7 @@
 <div onclick="javascript:window.location='test'; return false;"></div>
 
 <form id="form" method="post" action="http://post.something.here">
+    <input type="file" required>
     <input formaction="http://input.formaction.com/" />
     <button formaction="http://button.formaction.com/"></button>
 </form>


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1645

### Changes
1. Override `HTMLInputElement.required` attribute.
2. Override  `HTMLInputElement.type` attribute.
3. Fix default credential fetch tests: 'headers is object', 'headers is window.Headers' (test/client/fixtures/sandbox/fetch-test.js)

### `required` attribute `input` types
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input:
**'file'**, 'text', 'search', 'url', 'tel', 'email', 'password', 'date', 'datetime-local', 'month', 'week', 'time', 'number', 'checkbox', 'radio'

### Notes
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types:
> How an `<input>` works varies considerably depending on the value of its type attribute, hence the different types are covered in their own separate reference pages. **If this attributes is not specified, the default type adopted is `text`**.