### PR TITLE
fix `Worker, Blob, etc objects `toString` function should returns 'function ...() { [native code] }'` (close #1683)

### DIFF
--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -367,6 +367,7 @@ export default class WindowSandbox extends SandboxBase {
                 return new nativeMethods.FontFace(family, source, descriptors);
             };
             window.FontFace.prototype = nativeMethods.FontFace.prototype;
+            window.FontFace.toString  = () => nativeMethods.FontFace.toString();
         }
 
         if (window.Worker) {
@@ -385,6 +386,7 @@ export default class WindowSandbox extends SandboxBase {
                     : new nativeMethods.Worker(scriptURL, options);
             };
             window.Worker.prototype = nativeMethods.Worker.prototype;
+            window.Worker.toString  = () => nativeMethods.Worker.toString();
         }
 
         if (window.Blob) {
@@ -407,6 +409,7 @@ export default class WindowSandbox extends SandboxBase {
                 return arguments.length === 1 ? new nativeMethods.Blob(array) : new nativeMethods.Blob(array, opts);
             };
             window.Blob.prototype = nativeMethods.Blob.prototype;
+            window.Blob.toString  = () => nativeMethods.Blob.toString();
         }
 
         if (window.EventSource) {
@@ -426,6 +429,7 @@ export default class WindowSandbox extends SandboxBase {
             window.EventSource.CONNECTING = nativeMethods.EventSource.CONNECTING;
             window.EventSource.OPEN       = nativeMethods.EventSource.OPEN;
             window.EventSource.CLOSED     = nativeMethods.EventSource.CLOSED;
+            window.EventSource.toString   = () => nativeMethods.EventSource.toString();
         }
 
         if (window.MutationObserver) {
@@ -446,6 +450,7 @@ export default class WindowSandbox extends SandboxBase {
             };
 
             window.MutationObserver.prototype = nativeMethods.MutationObserver.prototype;
+            window.MutationObserver.toString  = () => nativeMethods.MutationObserver.toString();
         }
 
         if (nativeMethods.registerServiceWorker) {
@@ -504,6 +509,7 @@ export default class WindowSandbox extends SandboxBase {
             return image;
         };
         window.Image.prototype = nativeMethods.Image.prototype;
+        window.Image.toString  = () => nativeMethods.Image.toString();
 
         const FunctionWrapper = function (...args) {
             const functionBodyArgIndex = args.length - 1;
@@ -627,6 +633,8 @@ export default class WindowSandbox extends SandboxBase {
                     }
                 });
             }
+
+            window.WebSocket.toString = () => nativeMethods.WebSocket.toString();
         }
 
         overrideDescriptor(window.MessageEvent.prototype, 'origin', {

--- a/src/client/sandbox/storages/index.js
+++ b/src/client/sandbox/storages/index.js
@@ -91,6 +91,8 @@ export default class StorageSandbox extends SandboxBase {
 
             return event;
         };
+
+        window.StorageEvent.toString = () => nativeMethods.StorageEvent.toString();
     }
 
     clear () {

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -119,14 +119,21 @@ test('native methods are properly initialized in an iframe without src (GH-279)'
             var iframeHammerhead       = iframeWindow['%hammerhead%'];
             var nativeCreateElement    = iframeHammerhead.sandbox.nativeMethods.createElement.toString();
             var nativeAppendChild      = iframeHammerhead.sandbox.nativeMethods.appendChild.toString();
-            var nativeImage            = iframeHammerhead.sandbox.nativeMethods.Image.toString();
             var overridedCreateElement = iframeDocument.createElement.toString();
             var overridedAppendChild   = iframeDocument.createElement('div').appendChild.toString();
-            var overridedImage         = iframeWindow.Image.toString();
 
             ok(nativeCreateElement !== overridedCreateElement);
             ok(nativeAppendChild !== overridedAppendChild);
-            ok(nativeImage !== overridedImage);
+
+            var nativeImage     = new iframeHammerhead.sandbox.nativeMethods.Image(10, 10);
+            var overridedImage  = new iframeWindow.Image(10, 10);
+            var nativeSrcGetter = iframeHammerhead.sandbox.nativeMethods.imageSrcGetter;
+            var imageSrc        = 'test.jpg';
+
+            nativeImage.src    = imageSrc;
+            overridedImage.src = imageSrc;
+
+            ok(nativeSrcGetter.call(nativeImage) !== nativeSrcGetter.call(overridedImage));
         });
 });
 

--- a/test/client/fixtures/sandbox/node/classes-test.js
+++ b/test/client/fixtures/sandbox/node/classes-test.js
@@ -23,6 +23,36 @@ if (window.PerformanceNavigationTiming) {
     });
 }
 
+test('refreshed classes "toString" method', function () {
+    var refreshedClassCases = [
+        { name: 'Window', storedName: 'windowClass' },
+        { name: 'Document', storedName: 'documentClass' },
+        { name: 'Location', storedName: 'locationClass' },
+        { name: 'Element', storedName: 'elementClass' },
+        { name: 'SVGElement', storedName: 'svgElementClass' },
+        { name: 'Worker', storedName: 'Worker' },
+        { name: 'ArrayBuffer', storedName: 'ArrayBuffer' },
+        { name: 'Uint8Array', storedName: 'Uint8Array' },
+        { name: 'DataView', storedName: 'DataView' },
+        { name: 'Blob', storedName: 'Blob' },
+        { name: 'XMLHttpRequest', storedName: 'XMLHttpRequest' },
+        { name: 'Image', storedName: 'Image' },
+        { name: 'Function', storedName: 'Function' },
+        { name: 'FontFace', storedName: 'FontFace' },
+        { name: 'StorageEvent', storedName: 'StorageEvent' },
+        { name: 'MutationObserver', storedName: 'MutationObserver' },
+        { name: 'EventSource', storedName: 'EventSource' },
+        { name: 'WebSocket', storedName: 'WebSocket' }
+    ];
+
+    refreshedClassCases.forEach(function (refreshedClassCase) {
+        var windowClass = window[refreshedClassCase.name];
+
+        if (windowClass)
+            strictEqual(windowClass.toString(), nativeMethods[refreshedClassCase.storedName].toString(), refreshedClassCase.name);
+    });
+});
+
 test('window.Blob([data], { type: "" }) should return correct result for `ArrayBuffer`, `Uint8Array` and `DataView` data types (GH-1599)', function () {
     var bmpExample = {
         signature: [0x42, 0x4D]

--- a/test/client/fixtures/sandbox/node/classes-test.js
+++ b/test/client/fixtures/sandbox/node/classes-test.js
@@ -42,7 +42,12 @@ test('refreshed classes "toString" method', function () {
         { name: 'StorageEvent', storedName: 'StorageEvent' },
         { name: 'MutationObserver', storedName: 'MutationObserver' },
         { name: 'EventSource', storedName: 'EventSource' },
-        { name: 'WebSocket', storedName: 'WebSocket' }
+        { name: 'WebSocket', storedName: 'WebSocket' },
+        { name: 'Proxy', storedName: 'Proxy' },
+        { name: 'DataTransfer', storedName: 'DataTransfer' },
+        { name: 'DataTransferItemList', storedName: 'DataTransferItemList' },
+        { name: 'DataTransferItem', storedName: 'DataTransferItem' },
+        { name: 'FileList', storedName: 'FileList' }
     ];
 
     refreshedClassCases.forEach(function (refreshedClassCase) {

--- a/test/client/fixtures/sandbox/node/classes-test.js
+++ b/test/client/fixtures/sandbox/node/classes-test.js
@@ -24,37 +24,35 @@ if (window.PerformanceNavigationTiming) {
 }
 
 test('refreshed classes "toString" method', function () {
-    var refreshedClassCases = [
-        { name: 'Window', storedName: 'windowClass' },
-        { name: 'Document', storedName: 'documentClass' },
-        { name: 'Location', storedName: 'locationClass' },
-        { name: 'Element', storedName: 'elementClass' },
-        { name: 'SVGElement', storedName: 'svgElementClass' },
-        { name: 'Worker', storedName: 'Worker' },
-        { name: 'ArrayBuffer', storedName: 'ArrayBuffer' },
-        { name: 'Uint8Array', storedName: 'Uint8Array' },
-        { name: 'DataView', storedName: 'DataView' },
-        { name: 'Blob', storedName: 'Blob' },
-        { name: 'XMLHttpRequest', storedName: 'XMLHttpRequest' },
-        { name: 'Image', storedName: 'Image' },
-        { name: 'Function', storedName: 'Function' },
-        { name: 'FontFace', storedName: 'FontFace' },
-        { name: 'StorageEvent', storedName: 'StorageEvent' },
-        { name: 'MutationObserver', storedName: 'MutationObserver' },
-        { name: 'EventSource', storedName: 'EventSource' },
-        { name: 'WebSocket', storedName: 'WebSocket' },
-        { name: 'Proxy', storedName: 'Proxy' },
-        { name: 'DataTransfer', storedName: 'DataTransfer' },
-        { name: 'DataTransferItemList', storedName: 'DataTransferItemList' },
-        { name: 'DataTransferItem', storedName: 'DataTransferItem' },
-        { name: 'FileList', storedName: 'FileList' }
+    var testCases = [
+        { refreshedClass: window.Window, storedClass: nativeMethods.windowClass },
+        { refreshedClass: window.Document, storedClass: nativeMethods.documentClass },
+        { refreshedClass: window.Location, storedClass: nativeMethods.locationClass },
+        { refreshedClass: window.Element, storedClass: nativeMethods.elementClass },
+        { refreshedClass: window.SVGElement, storedClass: nativeMethods.svgElementClass },
+        { refreshedClass: window.Worker, storedClass: nativeMethods.Worker },
+        { refreshedClass: window.ArrayBuffer, storedClass: nativeMethods.ArrayBuffer },
+        { refreshedClass: window.Uint8Array, storedClass: nativeMethods.Uint8Array },
+        { refreshedClass: window.DataView, storedClass: nativeMethods.DataView },
+        { refreshedClass: window.Blob, storedClass: nativeMethods.Blob },
+        { refreshedClass: window.XMLHttpRequest, storedClass: nativeMethods.XMLHttpRequest },
+        { refreshedClass: window.Image, storedClass: nativeMethods.Image },
+        { refreshedClass: window.Function, storedClass: nativeMethods.Function },
+        { refreshedClass: window.StorageEvent, storedClass: nativeMethods.StorageEvent },
+        { refreshedClass: window.MutationObserver, storedClass: nativeMethods.MutationObserver },
+        { refreshedClass: window.WebSocket, storedClass: nativeMethods.WebSocket },
+        { refreshedClass: window.DataTransfer, storedClass: nativeMethods.DataTransfer },
+        { refreshedClass: window.FileList, storedClass: nativeMethods.FileList },
+        { refreshedClass: window.FontFace, storedClass: nativeMethods.FontFace },
+        { refreshedClass: window.EventSource, storedClass: nativeMethods.EventSource },
+        { refreshedClass: window.Proxy, storedClass: nativeMethods.Proxy },
+        { refreshedClass: window.DataTransferItemList, storedClass: nativeMethods.DataTransferItemList },
+        { refreshedClass: window.DataTransferItem, storedClass: nativeMethods.DataTransferItem }
     ];
 
-    refreshedClassCases.forEach(function (refreshedClassCase) {
-        var windowClass = window[refreshedClassCase.name];
-
-        if (windowClass)
-            strictEqual(windowClass.toString(), nativeMethods[refreshedClassCase.storedName].toString(), refreshedClassCase.name);
+    testCases.forEach(function (testCase) {
+        if (testCase.refreshedClass)
+            strictEqual(testCase.refreshedClass.toString(), testCase.storedClass.toString());
     });
 });
 


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1683

### Changes
1. Add native `toString` to refreshed classes (`Worker`, `Blob`, `Image`, `FontFace`, `StorageEvent`, `MutationObserver`, `EventSource`, `WebSocket`)