### PR TITLE
fix `"Can't execute code from a freed script" error when testing Sencha ExtJS applications in IE11`

### DIFF
--- a/src/client/utils/html.js
+++ b/src/client/utils/html.js
@@ -15,6 +15,8 @@ import createSelfRemovingScript from '../../utils/create-self-removing-script';
 
 const FAKE_TAG_NAME_PREFIX    = 'hh_fake_tag_name_';
 const FAKE_DOCTYPE_TAG_NAME   = 'hh_fake_doctype';
+const FAKE_HEAD_TAG_NAME      = `${FAKE_TAG_NAME_PREFIX}head`;
+const FAKE_BODY_TAG_NAME      = `${FAKE_TAG_NAME_PREFIX}body`;
 const FAKE_ATTR_WITH_TAG_NAME = 'hh_fake_attr';
 
 const FAKE_TAG_NAME_RE   = new RegExp('(<\\/?)' + FAKE_TAG_NAME_PREFIX, 'ig');
@@ -56,7 +58,7 @@ const STORED_ATTRS_SELECTOR = (() => {
 
 const SHADOW_UI_ELEMENTS_SELECTOR                    = `[class*="${SHADOW_UI_CLASSNAME.postfix}"]`;
 const HOVER_AND_FOCUS_PSEUDO_CLASS_ELEMENTS_SELECTOR = `[${INTERNAL_ATTRS.hoverPseudoClass}],[${INTERNAL_ATTRS.focusPseudoClass}]`;
-const FAKE_ELEMENTS_SELECTOR                         = `${FAKE_TAG_NAME_PREFIX}head, ${FAKE_TAG_NAME_PREFIX}body`;
+const FAKE_ELEMENTS_SELECTOR                         = `${FAKE_HEAD_TAG_NAME}, ${FAKE_BODY_TAG_NAME}`;
 
 export const INIT_SCRIPT_FOR_IFRAME_TEMPLATE = createSelfRemovingScript(`
     var parentHammerhead = null;
@@ -229,9 +231,9 @@ export function processHtml (html, { parentTag, prepareDom, processedContext } =
 
             const elTagName = getTagName(child);
 
-            if (elTagName === `${FAKE_TAG_NAME_PREFIX}head` || elTagName === `${FAKE_TAG_NAME_PREFIX}body`)
+            if (elTagName === FAKE_HEAD_TAG_NAME || elTagName === FAKE_BODY_TAG_NAME)
                 htmlElements.push(child);
-            else if (elTagName === `${FAKE_DOCTYPE_TAG_NAME}`)
+            else if (elTagName === FAKE_DOCTYPE_TAG_NAME)
                 doctypeElement = child;
         }
 

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -317,3 +317,22 @@ test('self-removing script shouldn\'t throw an error (GH-TC-2469)', function () 
     iframeDocument.write('<html><head></head><body></body></html>');
     iframeDocument.close();
 });
+
+test('write "doctype" markup without head and body tags (https://github.com/DevExpress/testcafe/issues/2639)', function () {
+    var iframe = document.createElement('iframe');
+
+    expect(0);
+
+    iframe.id = 'test' + Date.now();
+    document.body.appendChild(iframe);
+
+    try {
+        iframe.contentDocument.write('<!DOCTYPE html><div>x</div>');
+    }
+    catch (e) {
+        ok(false, e);
+    }
+
+    iframe.contentDocument.close();
+    iframe.parentNode.removeChild(iframe);
+});

--- a/test/client/fixtures/sandbox/node/document-write-test.js
+++ b/test/client/fixtures/sandbox/node/document-write-test.js
@@ -115,6 +115,20 @@ function testWriteln () {
     testHTML();
 }
 
+test('write "doctype" markup without head and body tags (https://github.com/DevExpress/testcafe/issues/2639)', function () {
+    nativeIframeForWrite    = nativeMethods.createElement.call(document, 'iframe');
+    nativeIframeForWrite.id = 'test' + Date.now();
+    nativeMethods.appendChild.call(document.body, nativeIframeForWrite);
+
+    processedIframeForWrite    = document.createElement('iframe');
+    processedIframeForWrite.id = 'test' + Date.now();
+    document.body.appendChild(processedIframeForWrite);
+
+    testWrite('<!DOCTYPE html><div>x</div>');
+
+    processedIframeForWrite.parentNode.removeChild(processedIframeForWrite);
+});
+
 test('write incomplete tags', function () {
     return createWriteTestIframes()
         .then(function () {

--- a/test/client/fixtures/sandbox/node/document-write-test.js
+++ b/test/client/fixtures/sandbox/node/document-write-test.js
@@ -115,20 +115,6 @@ function testWriteln () {
     testHTML();
 }
 
-test('write "doctype" markup without head and body tags (https://github.com/DevExpress/testcafe/issues/2639)', function () {
-    nativeIframeForWrite    = nativeMethods.createElement.call(document, 'iframe');
-    nativeIframeForWrite.id = 'test' + Date.now();
-    nativeMethods.appendChild.call(document.body, nativeIframeForWrite);
-
-    processedIframeForWrite    = document.createElement('iframe');
-    processedIframeForWrite.id = 'test' + Date.now();
-    document.body.appendChild(processedIframeForWrite);
-
-    testWrite('<!DOCTYPE html><div>x</div>');
-
-    processedIframeForWrite.parentNode.removeChild(processedIframeForWrite);
-});
-
 test('write incomplete tags', function () {
     return createWriteTestIframes()
         .then(function () {

--- a/test/client/fixtures/utils/html-test.js
+++ b/test/client/fixtures/utils/html-test.js
@@ -8,6 +8,7 @@ var urlResolver    = hammerhead.get('./utils/url-resolver');
 
 var nativeMethods = hammerhead.nativeMethods;
 var shadowUI      = hammerhead.sandbox.shadowUI;
+var browserUtils  = hammerhead.utils.browser;
 
 module('clean up html');
 
@@ -344,3 +345,12 @@ test('should not throw an error if the innerHTML property is defined on Node.pro
         delete Node.prototype.innerHTML;
     }
 });
+
+if (browserUtils.isIE) {
+    test('must add init script for iframe template after doctype declaration if the markup does not have head and body tags (https://github.com/DevExpress/testcafe/issues/2639)', function () {
+        var htmlSrc      = '<!doctype html><div>x</div>';
+        var htmlExpected = '<!doctype html>' + htmlUtils.INIT_SCRIPT_FOR_IFRAME_TEMPLATE + '<div>x</div>';
+
+        strictEqual(htmlUtils.processHtml(htmlSrc), htmlExpected);
+    });
+}


### PR DESCRIPTION
https://github.com/DevExpress/testcafe/issues/2639

### Changes
1. Fix "doctype" markup write case without both `<head>` and `<body>` tags.
2. Refactor `INIT_SCRIPT_FOR_IFRAME_TEMPLATE` adding to `head`/`body` elements.

### Reproducing reference
http://examples.sencha.com/extjs/6.6.0/examples/admin-dashboard/
app.js `getScrollingElement` function:
```js
if (c === undefined) {
    a = document.createElement('iframe');
    a.style.height = '1px';
    document.body.appendChild(a);
    b = a.contentWindow.document;
    b.write('<!DOCTYPE html><div style="height:9999em">x</div>');
    b.close();
    c = b.documentElement.scrollHeight > b.body.scrollHeight;
    a.parentNode.removeChild(a);
    this.$standardScrollElement = c
}
```