### PR TITLE
Fix `A client's url resolving mechanism works wrong` (close #1701)

### DIFF
--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -132,7 +132,7 @@ export default class WindowSandbox extends SandboxBase {
             return '';
 
         else if (HASH_RE.test(attrValue))
-            return destLocation.withHash(attrValue);
+            return urlResolver.resolve(attrValue, currentDocument);
 
         else if (!isValidUrl(attrValue))
             return urlResolver.resolve(attrValue, currentDocument);

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -363,7 +363,7 @@ export function ensureTrailingSlash (srcUrl, processedUrl) {
 
     if (srcUrlEndsWithTrailingSlash && !processedUrlEndsWithTrailingSlash)
         processedUrl += '/';
-    else if (!srcUrlEndsWithTrailingSlash && processedUrlEndsWithTrailingSlash)
+    else if (srcUrl && !srcUrlEndsWithTrailingSlash && processedUrlEndsWithTrailingSlash)
         processedUrl = processedUrl.replace(TRAILING_SLASH_RE, '');
 
     return processedUrl;

--- a/test/client/before-test.js
+++ b/test/client/before-test.js
@@ -17,7 +17,7 @@
     var iframeSandbox  = hammerhead.sandbox.iframe;
     var cookieSandbox  = hammerhead.sandbox.cookie;
 
-    destLocation.forceLocation('http://localhost/sessionId/https://example.com');
+    destLocation.forceLocation('http://localhost/sessionId/https://example.com/');
 
     var iframeTaskScriptTempate = [
         'window["%hammerhead%"].get("./utils/destination-location").forceLocation("{{{location}}}");',

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -1074,19 +1074,49 @@ test('Url resolving in an instance of document.implementation (GH-1673)', functi
 
     anchorEl.href = '';
 
-    strictEqual(anchorEl.href, 'https://example.com');
+    strictEqual(anchorEl.href, 'https://example.com/');
 
     implementation.head.appendChild(baseEl);
+
+    baseEl.href   = 'https://example.com';
+    anchorEl.href = '';
+
+    strictEqual(anchorEl.href, 'https://example.com/');
+
+    baseEl.href   = 'https://example.com/';
+    anchorEl.href = '';
+
+    strictEqual(anchorEl.href, 'https://example.com/');
 
     baseEl.href   = 'https://example.com/some/path/';
     anchorEl.href = '';
 
-    strictEqual(anchorEl.href, 'https://example.com/some/path');
+    strictEqual(anchorEl.href, 'https://example.com/some/path/');
 
     baseEl.href   = 'http://localhost:1993/some/';
     anchorEl.href = 'page.html';
 
     strictEqual(anchorEl.href, 'http://localhost:1993/some/page.html');
+
+    baseEl.href   = 'http://example.com/some';
+    anchorEl.href = '';
+
+    strictEqual(anchorEl.href, browserUtils.isIE11 ? 'http://example.com/' : 'http://example.com/some');
+
+    baseEl.href   = 'http://example.com/some';
+    anchorEl.href = 'page.html';
+
+    strictEqual(anchorEl.href, 'http://example.com/page.html');
+
+    baseEl.href   = 'https://example.com/some';
+    anchorEl.href = '#hash';
+
+    strictEqual(anchorEl.href, 'https://example.com/some#hash');
+
+    baseEl.href   = 'https://example.com/page.html';
+    anchorEl.href = '';
+
+    strictEqual(anchorEl.href, browserUtils.isIE11 ? 'https://example.com/' : 'https://example.com/page.html');
 });
 
 test('The overridden "createHTMLDocument" method should has right context (GH-1722)', function () {

--- a/test/client/fixtures/sandbox/node/methods-test.js
+++ b/test/client/fixtures/sandbox/node/methods-test.js
@@ -508,7 +508,7 @@ test('link.href with an empty value must return root site url (Q519748)', functi
     anchor.href = '';
     document.body.appendChild(anchor);
 
-    strictEqual(anchor.href, 'https://example.com');
+    strictEqual(anchor.href, 'https://example.com/');
 
     document.body.removeChild(anchor);
 });

--- a/test/client/fixtures/sandbox/storages-test.js
+++ b/test/client/fixtures/sandbox/storages-test.js
@@ -288,7 +288,7 @@ test('event firing in all same host windows except current', function () {
             strictEqual(topStorageEventArgs[0].key, 'key1');
             strictEqual(topStorageEventArgs[0].oldValue, isIE ? '' : null);
             strictEqual(topStorageEventArgs[0].newValue, 'value1');
-            strictEqual(topStorageEventArgs[0].url, 'https://example.com');
+            strictEqual(topStorageEventArgs[0].url, 'https://example.com/');
             strictEqual(topStorageEventArgs[0].storageArea, iframe.contentWindow.localStorage);
 
             localStorage.key2 = 'value2';
@@ -302,7 +302,7 @@ test('event firing in all same host windows except current', function () {
             strictEqual(iframeStorageEventArgs[0].key, 'key2');
             strictEqual(iframeStorageEventArgs[0].oldValue, isIE ? '' : null);
             strictEqual(iframeStorageEventArgs[0].newValue, 'value2');
-            strictEqual(iframeStorageEventArgs[0].url, 'https://example.com');
+            strictEqual(iframeStorageEventArgs[0].url, 'https://example.com/');
             strictEqual(iframeStorageEventArgs[0].storageArea, localStorage);
 
             window.removeEventListener('storage', topWindowHandler);
@@ -315,7 +315,7 @@ test('event argument parameters', function () {
         strictEqual(e.key, key);
         strictEqual(e.oldValue, oldValue);
         strictEqual(e.newValue, newValue);
-        strictEqual(e.url, 'https://example.com');
+        strictEqual(e.url, 'https://example.com/');
         strictEqual(e.storageArea, iframeStorageSandbox);
     };
 


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1701

### Changes
1. Fix `srcUrl = ''` case (`ensureTrailingSlash`).
2. Fix `HASH_RE` case (`_getUrlAttr`).
3. Set location with trailing slash (`forceLocation`, test/client/before-test.js), fix tests.


### `<a>`-`<base>`native behavior example
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <title>title</title>
    <base href="https://example.com/page.html">
</head>
<body>
    <a href=""></a>
    <script>
        var anchor = document.querySelector('a');
        var base   = document.querySelector('base');


        console.log('base.href = \'\', anchor.href = \'\'');
        base.href = '';
        var href = '';

        anchor.href = href;

        console.log('base.href   = ' + base.href);
        console.log('anchor.href = ' + anchor.href);
        console.log('----------------');


        console.log('base.href = https://example.com/some/path/, anchor.href = \'\'');
        base.href = 'https://example.com/some/path/';
        anchor.href = href;

        console.log('base.href   = ' + base.href);
        console.log('anchor.href = ' + anchor.href);
        console.log('----------------');


        console.log('base.href = https://example.com/some, anchor.href = \'\'');
        base.href = 'https://example.com/some';
        anchor.href = href;

        console.log('base.href   = ' + base.href);
        console.log('anchor.href = ' + anchor.href);
        console.log('----------------');


        console.log('base.href = https://example.com, anchor.href = \'\'');
        base.href = 'https://example.com';
        anchor.href = href;

        console.log('base.href   = ' + base.href);
        console.log('anchor.href = ' + anchor.href);
        console.log('----------------');


        console.log('base.href = https://example.com/, anchor.href = \'\'');
        base.href = 'https://example.com/';
        anchor.href = href;

        console.log('base.href   = ' + base.href);
        console.log('anchor.href = ' + anchor.href);
        console.log('----------------');


        href = '#hash';
        console.log('base.href = https://example.com/some, anchor.href = \'\'');
        base.href = 'https://example.com/some';
        anchor.href = href;

        console.log('base.href   = ' + base.href);
        console.log('anchor.href = ' + anchor.href);
        console.log('----------------');


        href = 'page.html';
        console.log('base.href = https://example.com/some, anchor.href = page.html');
        base.href = 'https://example.com/some';
        anchor.href = href;

        console.log('base.href   = ' + base.href);
        console.log('anchor.href = ' + anchor.href);
        console.log('----------------');


        href = '';
        console.log('base.href = https://example.com/page.html, anchor.href = \'\'');
        base.href = 'https://example.com/page.html';
        anchor.href = href;

        console.log('base.href   = ' + base.href);
        console.log('anchor.href = ' + anchor.href);
        console.log('----------------');


        href = 'another-page.html';
        console.log('base.href = https://example.com/page.html, anchor.href = another-page.html');
        base.href = 'https://example.com/page.html';
        anchor.href = href;

        console.log('base.href   = ' + base.href);
        console.log('anchor.href = ' + anchor.href);
        console.log('----------------');
    </script>
</body>
</html>
```
