### PR TITLE
fix `The overridden "removeEventListener" function does not support the "options" object` (close #1737)

### DIFF
--- a/src/client/sandbox/event/listeners.js
+++ b/src/client/sandbox/event/listeners.js
@@ -88,7 +88,7 @@ export default class Listeners extends EventEmitter {
         if (optionalParam && typeof optionalParam === 'boolean')
             return optionalParam;
         else if (optionalParam && typeof optionalParam === 'object')
-            return optionalParam.capture || false;
+            return !!optionalParam.capture;
 
         return false;
     }

--- a/src/client/sandbox/event/listeners.js
+++ b/src/client/sandbox/event/listeners.js
@@ -84,6 +84,15 @@ export default class Listeners extends EventEmitter {
         return true;
     }
 
+    static _getUseCaptureParam (optionalParam) {
+        if (optionalParam && typeof optionalParam === 'boolean')
+            return optionalParam;
+        else if (optionalParam && typeof optionalParam === 'object')
+            return optionalParam.capture || false;
+
+        return false;
+    }
+
     _createEventHandler () {
         const listeners = this;
 
@@ -136,7 +145,7 @@ export default class Listeners extends EventEmitter {
             addEventListener: function (...args) {
                 const type                   = args[0];
                 const listener               = args[1];
-                const useCapture             = args[2];
+                const useCapture             = Listeners._getUseCaptureParam(args[2]);
                 const eventListeningInfo     = listeningCtx.getEventCtx(el, type);
                 const nativeAddEventListener = Listeners._getNativeAddEventListener(el);
 
@@ -165,7 +174,7 @@ export default class Listeners extends EventEmitter {
             removeEventListener: function (...args) {
                 const type                      = args[0];
                 const listener                  = args[1];
-                const useCapture                = args[2];
+                const useCapture                = Listeners._getUseCaptureParam(args[2]);
                 const nativeRemoveEventListener = Listeners._getNativeRemoveEventListener(el);
                 const eventCtx                  = listeningCtx.getEventCtx(el, type);
 
@@ -189,12 +198,15 @@ export default class Listeners extends EventEmitter {
         const nativeRemoveEventListener = (() => doc.body.removeEventListener)();
 
         return {
-            addEventListener: function (type, listener, useCapture) {
+            addEventListener: function (...args) {
+                const type                  = args[0];
+                const listener              = args[1];
+                const useCapture            = Listeners._getUseCaptureParam(args[2]);
                 const docEventListeningInfo = listeningCtx.getEventCtx(doc, type);
                 const eventListeningInfo    = listeningCtx.getEventCtx(this, type);
 
                 if (!docEventListeningInfo || !isValidEventListener(listener))
-                    return nativeAddEventListener.call(this, type, listener, useCapture);
+                    return nativeAddEventListener.apply(this, args);
 
                 // NOTE: T233158
                 const isDifferentHandler = Listeners._isDifferentHandler(eventListeningInfo.outerHandlers, listener, useCapture);
@@ -217,7 +229,11 @@ export default class Listeners extends EventEmitter {
                 return res;
             },
 
-            removeEventListener: function (type, listener, useCapture) {
+            removeEventListener: function (...args) {
+                const type       = args[0];
+                const listener   = args[1];
+                const useCapture = Listeners._getUseCaptureParam(args[2]);
+
                 const eventListeningInfo = listeningCtx.getEventCtx(this, type);
 
                 if (!eventListeningInfo || !isValidEventListener(listener))

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -25,7 +25,7 @@ test('remove event listener in the context of optional parameters ("options" obj
         ok(false);
     }
 
-    var paramsCases = [
+    var testCases = [
         { addEventListener: [unexpectedClickHandler], removeEventListener: [unexpectedClickHandler] },
         { addEventListener: [unexpectedClickHandler, true], removeEventListener: [unexpectedClickHandler, true] },
         { addEventListener: [unexpectedClickHandler], removeEventListener: [unexpectedClickHandler, false] },
@@ -35,7 +35,7 @@ test('remove event listener in the context of optional parameters ("options" obj
 
     // NOTE: IE11 doesn't support 'options.capture' option
     if (!browserUtils.isIE11) {
-        paramsCases = paramsCases.concat([
+        testCases = testCases.concat([
             { addEventListener: [unexpectedClickHandler, { capture: false }], removeEventListener: [unexpectedClickHandler] },
             { addEventListener: [unexpectedClickHandler], removeEventListener: [unexpectedClickHandler, { capture: false }] },
             { addEventListener: [expectedClickHandler, { capture: true }], removeEventListener: [expectedClickHandler, false] },
@@ -44,14 +44,17 @@ test('remove event listener in the context of optional parameters ("options" obj
     }
 
     function checkEventListenerRemoving (el) {
-        paramsCases.forEach(function (paramsCase) {
-            el.addEventListener.apply(el, ['click'].concat(paramsCase.addEventListener));
-            el.removeEventListener.apply(el, ['click'].concat(paramsCase.removeEventListener));
+        testCases.forEach(function (testCase) {
+            var addEventListenerArgs    = ['click'].concat(testCase.addEventListener);
+            var removeEventListenerArgs = ['click'].concat(testCase.removeEventListener);
+
+            el.addEventListener.apply(el, addEventListenerArgs);
+            el.removeEventListener.apply(el, removeEventListenerArgs);
 
             el.click();
 
-            if (paramsCase.addEventListener[0] === expectedClickHandler)
-                el.removeEventListener.apply(el, ['click'].concat(paramsCase.addEventListener));
+            if (testCase.addEventListener[0] === expectedClickHandler)
+                el.removeEventListener.apply(el, addEventListenerArgs);
         });
     }
 

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -51,6 +51,55 @@ test('document.addEventListener (Q532574)', function () {
     strictEqual(docClickRaisedCount, 1);
 });
 
+test('add/remove event listeners in the context of optional parameters ("options" object or "useCapture") (GH-1737)', function () {
+    expect(browserUtils.isIE11 ? 0 : 4);
+
+    function expectedClickHandler () {
+        ok(true);
+    }
+
+    function unexpectedClickHandler () {
+        ok(false);
+    }
+
+    var paramsCases = [
+        { addEventListener: [unexpectedClickHandler], removeEventListener: [unexpectedClickHandler] },
+        { addEventListener: [unexpectedClickHandler, true], removeEventListener: [unexpectedClickHandler, true] },
+        { addEventListener: [unexpectedClickHandler], removeEventListener: [unexpectedClickHandler, false] },
+        { addEventListener: [unexpectedClickHandler, false], removeEventListener: [unexpectedClickHandler] },
+        { addEventListener: [unexpectedClickHandler, { capture: false }], removeEventListener: [unexpectedClickHandler, { capture: false }] }
+    ];
+
+    if (!browserUtils.isIE11) {
+        paramsCases = paramsCases.concat([
+            { addEventListener: [unexpectedClickHandler, { capture: false }], removeEventListener: [unexpectedClickHandler] },
+            { addEventListener: [unexpectedClickHandler], removeEventListener: [unexpectedClickHandler, { capture: false }] },
+            { addEventListener: [expectedClickHandler, { capture: true }], removeEventListener: [expectedClickHandler, false] },
+            { addEventListener: [expectedClickHandler, false], removeEventListener: [expectedClickHandler, { capture: true }] }
+        ]);
+    }
+
+    function test (el) {
+        paramsCases.forEach(function (paramsCase) {
+            el.addEventListener.apply(el, ['click'].concat(paramsCase.addEventListener));
+            el.removeEventListener.apply(el, ['click'].concat(paramsCase.removeEventListener));
+
+            el.click();
+
+            if (paramsCase.addEventListener[0] === expectedClickHandler)
+                el.removeEventListener.apply(el, ['click'].concat(paramsCase.addEventListener));
+        });
+    }
+
+    var divEl = document.body.appendChild(document.createElement('div'));
+
+    listeners.initElementListening(document, ['click']);
+    listeners.initElementListening(divEl, ['click']);
+
+    test(document.body);
+    test(divEl);
+});
+
 test('firing and dispatching the events created in different ways (Q532574)', function () {
     var $div                      = $('<div>').appendTo('body');
     var div                       = $div[0];


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1737

### Changes
1. Add `options.capture` option support in `addEventListener` and `removeEventListener` (`_createElementOverridedMethods`, `_createDocumentBodyOverridedMethods`).

### Notes
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener