### PR TITLE
fix `The DOM received by using DOMParser.parseFromString should not contains self-removing scripts` (close #1619)

### DIFF
--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -1004,10 +1004,21 @@ export default class WindowSandbox extends SandboxBase {
 
         if (window.DOMParser) {
             window.DOMParser.prototype.parseFromString = function (...args) {
-                if (args.length > 1 && typeof args[0] === 'string' && args[1] === 'text/html')
-                    args[0] = processHtml(args[0]);
+                const str  = args[0];
+                const type = args[1];
+                let processedHtml;
 
-                return nativeMethods.DOMParserParseFromString.apply(this, args);
+                if (args.length > 1 && typeof str === 'string' && type === 'text/html') {
+                    processedHtml = processHtml(str);
+                    args[0]       = processedHtml;
+                }
+
+                const document = nativeMethods.DOMParserParseFromString.apply(this, args);
+
+                if (processedHtml)
+                    ShadowUI.removeSelfRemovingScripts(document);
+
+                return document;
             };
         }
 


### PR DESCRIPTION
### Todo
- [x] ~~use _partial_ `cleanUpHtml` in `DOMParser.parseFromString` after `processHtml(str);`?~~ No
- [x] Test: move `'<!DOCTYPE html>'` to separate `isIE` case?
- [x] check `let processedHtml;` without initial value (reference: `_onTargetChanged` -> `let urlAttr;`)

https://github.com/DevExpress/testcafe-hammerhead/issues/1619

### Changes
1. Add `removeSelfRemovingScripts` to `DOMParser.parseFromString` (`arg[0]` (html string) processed case).