### PR TITLE
fix `node v4 switch` (part of #190)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "semver": "5.5.0",
     "tough-cookie": "2.3.3",
     "tunnel-agent": "0.6.0",
-    "webauth": "^1.1.0",
-    "yakaa": "1.0.1"
+    "webauth": "^1.1.0"
   },
   "devDependencies": {
     "babel-core": "^6.4.0",

--- a/src/request-pipeline/destination-request/agent.js
+++ b/src/request-pipeline/destination-request/agent.js
@@ -3,9 +3,6 @@ import https from 'https';
 import LRUCache from 'lru-cache';
 import tunnel from 'tunnel-agent';
 
-const httpAgent  = http.Agent;
-const httpsAgent = https.Agent;
-
 // Const
 const SSL3_HOST_CACHE_SIZE = 1000;
 
@@ -22,18 +19,18 @@ const ssl3HostCache = new LRUCache({ max: SSL3_HOST_CACHE_SIZE });
 const agents = {
     [TYPE.SSL3]: {
         instance:       null,
-        Ctor:           httpsAgent,
+        Ctor:           https.Agent,
         secureProtocol: 'SSLv3_method'
     },
 
     [TYPE.TLS]: {
         instance: null,
-        Ctor:     httpsAgent
+        Ctor:     https.Agent
     },
 
     [TYPE.HTTP]: {
         instance: null,
-        Ctor:     httpAgent
+        Ctor:     http.Agent
     }
 };
 

--- a/src/request-pipeline/destination-request/agent.js
+++ b/src/request-pipeline/destination-request/agent.js
@@ -1,6 +1,10 @@
-import Agent from 'yakaa';
+import http from 'http';
+import https from 'https';
 import LRUCache from 'lru-cache';
 import tunnel from 'tunnel-agent';
+
+const httpAgent  = http.Agent;
+const httpsAgent = https.Agent;
 
 // Const
 const SSL3_HOST_CACHE_SIZE = 1000;
@@ -15,23 +19,21 @@ const TYPE = {
 // Static
 const ssl3HostCache = new LRUCache({ max: SSL3_HOST_CACHE_SIZE });
 
-// NOTE: We need an agent with proper keep-alive behavior. Such an agent has landed in Node 0.12. Since we
-// still support Node 0.10, we will use a third-party agent that is the extraction of Node 0.12 Agent code.
 const agents = {
     [TYPE.SSL3]: {
         instance:       null,
-        Ctor:           Agent.SSL,
+        Ctor:           httpsAgent,
         secureProtocol: 'SSLv3_method'
     },
 
     [TYPE.TLS]: {
         instance: null,
-        Ctor:     Agent.SSL
+        Ctor:     httpsAgent
     },
 
     [TYPE.HTTP]: {
         instance: null,
-        Ctor:     Agent
+        Ctor:     httpAgent
     }
 };
 

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -30,7 +30,6 @@ const requestAgent                         = require('../../lib/request-pipeline
 const scriptHeader                         = require('../../lib/processing/script/header');
 const resourceProcessor                    = require('../../lib/processing/resources/');
 const urlUtils                             = require('../../lib/utils/url');
-const semver                               = require('semver');
 
 const EMPTY_PAGE_MARKUP = '<html></html>';
 const TEST_OBJ          = {
@@ -3276,104 +3275,99 @@ describe('Proxy', () => {
             ]);
         });
 
-        // NOTE: 'yakka' module does not keep alive socket in node 9.3 and higher.
-        // It leads to a slowdown proxy. We will remove this condition after getting rid of 'yakka'.
-        // After dropping node 0.10, 0.12 support,  we can use a standard agent from 'http/https' module.
-        if (semver.lt(process.version, '9.3.0')) {
-            it('Should close a proxy connection if a connection to destination server hang up (GH-1384)', () => {
-                const agent        = new http.Agent({
-                    keepAlive:      true,
-                    keepAliveMsecs: 10000
-                });
-                let mainPageSocket = null;
-                let reqOptions     = null;
-                let error          = null;
+        it('Should close a proxy connection if a connection to destination server hang up (GH-1384)', () => {
+            const agent        = new http.Agent({
+                keepAlive:      true,
+                keepAliveMsecs: 10000
+            });
+            let mainPageSocket = null;
+            let reqOptions     = null;
+            let error          = null;
 
-                const server = net.createServer(socket => {
-                    socket.on('data', data => {
-                        const url = data.toString().match(/GET ([\s\S]+) HTTP/)[1];
+            const server = net.createServer(socket => {
+                socket.on('data', data => {
+                    const url = data.toString().match(/GET ([\s\S]+) HTTP/)[1];
 
-                        if (url === '/') {
-                            mainPageSocket = socket;
+                    if (url === '/') {
+                        mainPageSocket = socket;
 
-                            socket.setKeepAlive(true, 10000);
+                        socket.setKeepAlive(true, 10000);
+                        socket.write([
+                            'HTTP/1.1 302 Object Moved',
+                            'Location: /redirect',
+                            'Content-Length: 0',
+                            '',
+                            ''
+                        ].join('\r\n'));
+                    }
+                    else if (url === '/redirect') {
+                        if (mainPageSocket) {
+                            expect(mainPageSocket).eql(socket);
+                            mainPageSocket.end();
+
+                            mainPageSocket = null;
+                        }
+                        else {
                             socket.write([
-                                'HTTP/1.1 302 Object Moved',
-                                'Location: /redirect',
-                                'Content-Length: 0',
+                                'HTTP/1.1 200 Ok',
+                                'Content-Length: 5',
                                 '',
-                                ''
+                                'Hello'
                             ].join('\r\n'));
                         }
-                        else if (url === '/redirect') {
-                            if (mainPageSocket) {
-                                expect(mainPageSocket).eql(socket);
-                                mainPageSocket.end();
-
-                                mainPageSocket = null;
-                            }
-                            else {
-                                socket.write([
-                                    'HTTP/1.1 200 Ok',
-                                    'Content-Length: 5',
-                                    '',
-                                    'Hello'
-                                ].join('\r\n'));
-                            }
-                        }
-                    });
+                    }
                 });
-
-                function sendRequest (options) {
-                    return new Promise((resolve, reject) => {
-                        const req = http.request(options, res => {
-                            const chunks = [];
-
-                            res.on('data', chunk => chunks.push(chunk));
-                            res.on('end', () => resolve(Buffer.concat(chunks).toString()));
-                        });
-
-                        req.on('error', reject);
-                        req.end();
-                    });
-                }
-
-                session.handlePageError = (ctx, err) => {
-                    error = err;
-                };
-
-                return getFreePort()
-                    .then(port => new Promise(resolve => server.listen(port, resolve.bind(null, port))))
-                    .then(port => {
-                        const proxyUrl = proxy.openSession(`http://127.0.0.1:${port}/`, session);
-
-                        reqOptions = Object.assign(urlLib.parse(proxyUrl), {
-                            method:  'GET',
-                            agent:   agent,
-                            headers: { accept: 'text/html' }
-                        });
-
-                        return sendRequest(reqOptions);
-                    })
-                    .then(body => {
-                        expect(body).eql('');
-
-                        reqOptions.path += 'redirect';
-
-                        return sendRequest(reqOptions);
-                    })
-                    .catch(err => {
-                        expect(err.toString()).eql('Error: socket hang up');
-
-                        return sendRequest(reqOptions);
-                    })
-                    .then(body => {
-                        expect(body).include('Hello');
-                        expect(error).to.be.null;
-                        server.close();
-                    });
             });
-        }
+
+            function sendRequest (options) {
+                return new Promise((resolve, reject) => {
+                    const req = http.request(options, res => {
+                        const chunks = [];
+
+                        res.on('data', chunk => chunks.push(chunk));
+                        res.on('end', () => resolve(Buffer.concat(chunks).toString()));
+                    });
+
+                    req.on('error', reject);
+                    req.end();
+                });
+            }
+
+            session.handlePageError = (ctx, err) => {
+                error = err;
+            };
+
+            return getFreePort()
+                .then(port => new Promise(resolve => server.listen(port, resolve.bind(null, port))))
+                .then(port => {
+                    const proxyUrl = proxy.openSession(`http://127.0.0.1:${port}/`, session);
+
+                    reqOptions = Object.assign(urlLib.parse(proxyUrl), {
+                        method:  'GET',
+                        agent:   agent,
+                        headers: { accept: 'text/html' }
+                    });
+
+                    return sendRequest(reqOptions);
+                })
+                .then(body => {
+                    expect(body).eql('');
+
+                    reqOptions.path += 'redirect';
+
+                    return sendRequest(reqOptions);
+                })
+                .catch(err => {
+                    expect(err.toString()).eql('Error: socket hang up');
+
+                    return sendRequest(reqOptions);
+                })
+                .then(body => {
+                    expect(body).include('Hello');
+                    expect(error).to.be.null;
+                    server.close();
+                });
+        });
 
         it('Should not hung if an error is raised in resource processor', () => {
             const options         = {


### PR DESCRIPTION
DevExpress/testcafe-hammerhead#190:
> Then we should try to remove yakka dependency and try native http agent. Node 10 shipped with broken keep alive. It should be fixed now. If it's not, health monitor will show us signficant performance regression (~x1.5-x2)

### Changes
1. Remove `yakaa` dependency, use native `http`/`https` `Agent`.