### PR TITLE
Fix wrong uncaught js error event construction

### DIFF
--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -117,8 +117,8 @@ export default class WindowSandbox extends SandboxBase {
             stack = event.reason && event.reason.stack;
         }
         else if (type === this.UNCAUGHT_JS_ERROR_EVENT) {
-            msg   = event.error.message;
-            stack = event.error.stack;
+            msg   = event.error ? event.error.message : event.message;
+            stack = event.error && event.error.stack;
         }
 
         stack = WindowSandbox._prepareStack(msg, stack);

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -370,7 +370,7 @@ export function ensureTrailingSlash (srcUrl, processedUrl) {
 }
 
 export function isSpecialPage (url) {
-    return SPECIAL_PAGES.includes(url);
+    return SPECIAL_PAGES.indexOf(url) !== -1;
 }
 
 export function isRelativeUrl (url) {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -370,7 +370,7 @@ export function ensureTrailingSlash (srcUrl, processedUrl) {
 }
 
 export function isSpecialPage (url) {
-    return SPECIAL_PAGES.indexOf(url) !== -1;
+    return SPECIAL_PAGES.includes(url);
 }
 
 export function isRelativeUrl (url) {

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -333,25 +333,38 @@ test('UNCAUGHT_JS_ERROR_EVENT', function () {
 
     var testCases = [
         {
-            error: {
-                message: void 0,
-                stack:   void 0
+            event: {
+                error: {
+                    message: void 0,
+                    stack:   void 0
+                },
             },
             expectedStack: 'undefined:\n    No stack trace available'
         },
         {
-            error: {
-                message: 'test message',
-                stack:   '    line 1\n    line2'
+            event: {
+                error: {
+                    message: 'test message',
+                    stack:   '    line 1\n    line2'
+                },
             },
             expectedStack: 'test message:\n    line 1\n    line2'
         },
         {
-            error: {
-                message: 'test message',
-                stack:   'Error: test message:\n    line1\n    line2'
+            event: {
+                error: {
+                    message: 'test message',
+                    stack:   'Error: test message:\n    line1\n    line2'
+                },
             },
             expectedStack: 'Error: test message:\n    line1\n    line2'
+        },
+        {
+            event: {
+                error:   null,
+                message: 'test message'
+            },
+            expectedStack: 'test message:\n    No stack trace available'
         }
     ];
 
@@ -365,7 +378,7 @@ test('UNCAUGHT_JS_ERROR_EVENT', function () {
             };
 
             windowSandox.on(hammerhead.EVENTS.uncaughtJsError, handler);
-            windowSandox._raiseUncaughtJsErrorEvent(hammerhead.EVENTS.uncaughtJsError, { error: testCase.error }, window);
+            windowSandox._raiseUncaughtJsErrorEvent(hammerhead.EVENTS.uncaughtJsError, testCase.event, window);
         });
     };
 


### PR DESCRIPTION
@LavrovArtem 

"ResizeObserver loop limit exceeded" has a different error event format (`event.error` equals `null`).
