### PR TITLE
fix `Uncaught TypeError: Cannot convert object to primitive value in console.js` (close #1750)

### DIFF
--- a/src/client/utils/types.js
+++ b/src/client/utils/types.js
@@ -16,14 +16,3 @@ export function isPrimitiveType (obj) {
 
     return objType !== 'object' && objType !== 'function';
 }
-
-export function isConvertibleToString (obj) {
-    try {
-        String(obj);
-
-        return true;
-    }
-    catch (e) {
-        return false;
-    }
-}

--- a/src/client/utils/types.js
+++ b/src/client/utils/types.js
@@ -16,3 +16,14 @@ export function isPrimitiveType (obj) {
 
     return objType !== 'object' && objType !== 'function';
 }
+
+export function isConvertibleToString (obj) {
+    try {
+        String(obj);
+
+        return true;
+    }
+    catch (e) {
+        return false;
+    }
+}

--- a/test/client/fixtures/sandbox/console-test.js
+++ b/test/client/fixtures/sandbox/console-test.js
@@ -13,12 +13,6 @@ if (window.console && typeof window.console.log !== 'undefined') {
     test('must convert `log`, `warn`, `error` and `info` methods arguments to string lines (GH-1750)', function () {
         var handledConsoleMethodLines = [];
 
-        var objWithoutPrototype = {
-            key: 'value'
-        };
-
-        Object.setPrototypeOf(objWithoutPrototype, null);
-
         var testCases = [
             true,
             false,
@@ -27,15 +21,16 @@ if (window.console && typeof window.console.log !== 'undefined') {
             42,
             'string',
             {},
+            Object.create(null),
             {
                 toString: function () {
-                    return '123';
+                    return Object.create(null);
                 }
-            },
-            objWithoutPrototype
+            }
         ];
 
-        var expectedHandledConsoleMethodLines = ['true', 'false', 'null', 'undefined', '42', 'string', '[object Object]', '123', '{"key":"value"}'];
+        var expectedHandledConsoleMethodLines = ['true', 'false', 'null', 'undefined', '42', 'string', '[object Object]',
+            'object', 'object'];
 
         // NOTE: IE11 doesn't support 'Symbol'
         if (!browserUtils.isIE11) {


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1750

### Changes
1. Fix overridden console methods (`log`, `warn`, `error`, `info`) logic: try `String(arg)` converting, **otherwise return "object" string**.

### Reference
https://github.com/DevExpress/testcafe-hammerhead/issues/1779