### PR TITLE
fix `Use stored `HTMLIFrameElement.contentWindow`, `HTMLIFrameElement.contentDocument` and `HTMLFrameElement.contentWindow` getters in whole code`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "del-cli": "^1.1.0",
     "endpoint-utils": "^1.0.1",
     "eslint": "4.17.0",
-    "eslint-plugin-hammerhead": "0.1.10",
+    "eslint-plugin-hammerhead": "0.1.11",
     "express": "4.16.3",
     "express-ntlm": "2.1.5",
     "gulp": "^4.0.0",

--- a/src/client/sandbox/event/message.js
+++ b/src/client/sandbox/event/message.js
@@ -226,9 +226,9 @@ export default class MessageSandbox extends SandboxBase {
             let targetWindow = null;
 
             const sendPingRequest = () => {
-                if (targetIframe.contentWindow) {
-                    targetWindow = targetIframe.contentWindow;
+                targetWindow = nativeMethods.iframeContentWindowGetter.call(targetIframe);
 
+                if (targetWindow) {
                     this.sendServiceMsg({
                         cmd:           this.pingCmd,
                         isPingRequest: true

--- a/src/client/sandbox/event/message.js
+++ b/src/client/sandbox/event/message.js
@@ -226,7 +226,7 @@ export default class MessageSandbox extends SandboxBase {
             let targetWindow = null;
 
             const sendPingRequest = () => {
-                targetWindow = nativeMethods.iframeContentWindowGetter.call(targetIframe);
+                targetWindow = nativeMethods.contentWindowGetter.call(targetIframe);
 
                 if (targetWindow) {
                     this.sendServiceMsg({

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -333,9 +333,8 @@ export default class EventSimulator {
 
     _raiseNativeClick (el, originClick) {
         // NOTE: B254199
-        const isElementInIframe = domUtils.isElementInIframe(el);
-        const iframe            = isElementInIframe ? domUtils.getIframeByElement(el) : null;
-        const curWindow         = iframe ? nativeMethods.iframeContentWindowGetter.call(iframe) : window;
+        const iframe            = domUtils.isElementInIframe(el) && domUtils.getIframeByElement(el);
+        const curWindow         = iframe ? nativeMethods.contentWindowGetter.call(iframe) : window;
         const prevWindowEvent   = curWindow.event;
 
         if (browserUtils.isIE11)
@@ -681,9 +680,8 @@ export default class EventSimulator {
     }
 
     _raiseDispatchEvent (el, ev) {
-        const isElementInIframe = domUtils.isElementInIframe(el);
-        const iframe            = isElementInIframe ? domUtils.getIframeByElement(el) : null;
-        const curWindow         = iframe ? nativeMethods.iframeContentWindowGetter.call(iframe) : window;
+        const iframe            = domUtils.isElementInIframe(el) && domUtils.getIframeByElement(el);
+        const curWindow         = iframe ? nativeMethods.contentWindowGetter.call(iframe) : window;
 
         if (browserUtils.isIE11 && iframe && curWindow) {
             // NOTE: In IE, when we raise an event by using the dispatchEvent function, the window.event object is null.

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -333,9 +333,9 @@ export default class EventSimulator {
 
     _raiseNativeClick (el, originClick) {
         // NOTE: B254199
-        const iframe            = domUtils.isElementInIframe(el) && domUtils.getIframeByElement(el);
-        const curWindow         = iframe ? nativeMethods.contentWindowGetter.call(iframe) : window;
-        const prevWindowEvent   = curWindow.event;
+        const iframe          = domUtils.isElementInIframe(el) && domUtils.getIframeByElement(el);
+        const curWindow       = iframe ? nativeMethods.contentWindowGetter.call(iframe) : window;
+        const prevWindowEvent = curWindow.event;
 
         if (browserUtils.isIE11)
             delete curWindow.event;
@@ -680,8 +680,8 @@ export default class EventSimulator {
     }
 
     _raiseDispatchEvent (el, ev) {
-        const iframe            = domUtils.isElementInIframe(el) && domUtils.getIframeByElement(el);
-        const curWindow         = iframe ? nativeMethods.contentWindowGetter.call(iframe) : window;
+        const iframe    = domUtils.isElementInIframe(el) && domUtils.getIframeByElement(el);
+        const curWindow = iframe ? nativeMethods.contentWindowGetter.call(iframe) : window;
 
         if (browserUtils.isIE11 && iframe && curWindow) {
             // NOTE: In IE, when we raise an event by using the dispatchEvent function, the window.event object is null.

--- a/src/client/sandbox/event/simulator.js
+++ b/src/client/sandbox/event/simulator.js
@@ -333,8 +333,10 @@ export default class EventSimulator {
 
     _raiseNativeClick (el, originClick) {
         // NOTE: B254199
-        const curWindow       = domUtils.isElementInIframe(el) ? domUtils.getIframeByElement(el).contentWindow : window;
-        const prevWindowEvent = curWindow.event;
+        const isElementInIframe = domUtils.isElementInIframe(el);
+        const iframe            = isElementInIframe ? domUtils.getIframeByElement(el) : null;
+        const curWindow         = iframe ? nativeMethods.iframeContentWindowGetter.call(iframe) : window;
+        const prevWindowEvent   = curWindow.event;
 
         if (browserUtils.isIE11)
             delete curWindow.event;
@@ -681,7 +683,7 @@ export default class EventSimulator {
     _raiseDispatchEvent (el, ev) {
         const isElementInIframe = domUtils.isElementInIframe(el);
         const iframe            = isElementInIframe ? domUtils.getIframeByElement(el) : null;
-        const curWindow         = iframe ? iframe.contentWindow : window;
+        const curWindow         = iframe ? nativeMethods.iframeContentWindowGetter.call(iframe) : window;
 
         if (browserUtils.isIE11 && iframe && curWindow) {
             // NOTE: In IE, when we raise an event by using the dispatchEvent function, the window.event object is null.

--- a/src/client/sandbox/iframe.js
+++ b/src/client/sandbox/iframe.js
@@ -36,8 +36,8 @@ export default class IframeSandbox extends SandboxBase {
     }
 
     _ensureIframeNativeMethodsForChrome (iframe) {
-        const contentWindow   = nativeMethods.iframeContentWindowGetter.call(iframe);
-        const contentDocument = nativeMethods.iframeContentDocumentGetter.call(iframe);
+        const contentWindow   = nativeMethods.contentWindowGetter.call(iframe);
+        const contentDocument = nativeMethods.contentDocumentGetter.call(iframe);
 
         if (!this.iframeNativeMethodsBackup && this._shouldSaveIframeNativeMethods(iframe))
             this.iframeNativeMethodsBackup = new this.nativeMethods.constructor(contentDocument, contentWindow);
@@ -48,11 +48,12 @@ export default class IframeSandbox extends SandboxBase {
     }
 
     _ensureIframeNativeMethodsForIE (iframe) {
-        const contentWindow       = nativeMethods.iframeContentWindowGetter.call(iframe);
-        const contentDocument     = nativeMethods.iframeContentDocumentGetter.call(iframe);
+        const contentWindow       = nativeMethods.contentWindowGetter.call(iframe);
         const iframeNativeMethods = contentWindow[INTERNAL_PROPS.iframeNativeMethods];
 
         if (iframeNativeMethods) {
+            const contentDocument = nativeMethods.contentDocumentGetter.call(iframe);
+
             iframeNativeMethods.restoreDocumentMeths(contentDocument, contentWindow);
             delete contentWindow[INTERNAL_PROPS.iframeNativeMethods];
         }
@@ -86,8 +87,8 @@ export default class IframeSandbox extends SandboxBase {
         if (!isIframeWithoutSrc(iframe))
             return;
 
-        const contentWindow   = nativeMethods.iframeContentWindowGetter.call(iframe);
-        const contentDocument = nativeMethods.iframeContentDocumentGetter.call(iframe);
+        const contentWindow   = nativeMethods.contentWindowGetter.call(iframe);
+        const contentDocument = nativeMethods.contentDocumentGetter.call(iframe);
 
         if (!IframeSandbox.isIframeInitialized(iframe)) {
             // NOTE: Even if iframe is not loaded (iframe.contentDocument.documentElement does not exist), we
@@ -109,8 +110,8 @@ export default class IframeSandbox extends SandboxBase {
     }
 
     static isIframeInitialized (iframe) {
-        const contentWindow           = nativeMethods.iframeContentWindowGetter.call(iframe);
-        const contentDocument         = nativeMethods.iframeContentDocumentGetter.call(iframe);
+        const contentWindow           = nativeMethods.contentWindowGetter.call(iframe);
+        const contentDocument         = nativeMethods.contentDocumentGetter.call(iframe);
         const isFFIframeUninitialized = isFirefox && contentWindow.document.readyState === 'uninitialized';
 
         return !isFFIframeUninitialized && !!contentDocument.documentElement ||
@@ -134,7 +135,7 @@ export default class IframeSandbox extends SandboxBase {
             .replace('{{{referer}}}', escapeStringPatterns(referer))
             .replace('{{{iframeTaskScriptTemplate}}}', escapeStringPatterns(iframeTaskScriptTemplate));
 
-        const contentWindow = nativeMethods.iframeContentWindowGetter.call(e.iframe);
+        const contentWindow = nativeMethods.contentWindowGetter.call(e.iframe);
 
         contentWindow.eval.call(contentWindow, taskScript);
     }
@@ -149,7 +150,7 @@ export default class IframeSandbox extends SandboxBase {
 
         const tagName = getTagName(el);
 
-        if (tagName === 'iframe' && nativeMethods.iframeContentWindowGetter.call(el) ||
+        if (tagName === 'iframe' && nativeMethods.contentWindowGetter.call(el) ||
             tagName === 'frame' && nativeMethods.frameContentWindowGetter.call(el))
             this._raiseReadyToInitEvent(el);
 

--- a/src/client/sandbox/iframe.js
+++ b/src/client/sandbox/iframe.js
@@ -3,7 +3,7 @@ import SandboxBase from './base';
 import settings from '../settings';
 import nativeMethods from '../sandbox/native-methods';
 import { isJsProtocol } from '../../processing/dom';
-import { isShadowUIElement, isIframeWithoutSrc } from '../utils/dom';
+import { isShadowUIElement, isIframeWithoutSrc, getTagName } from '../utils/dom';
 import { isFirefox, isWebKit, isIE } from '../utils/browser';
 import * as JSON from '../json';
 
@@ -36,20 +36,25 @@ export default class IframeSandbox extends SandboxBase {
     }
 
     _ensureIframeNativeMethodsForChrome (iframe) {
+        const contentWindow   = nativeMethods.iframeContentWindowGetter.call(iframe);
+        const contentDocument = nativeMethods.iframeContentDocumentGetter.call(iframe);
+
         if (!this.iframeNativeMethodsBackup && this._shouldSaveIframeNativeMethods(iframe))
-            this.iframeNativeMethodsBackup = new this.nativeMethods.constructor(iframe.contentDocument, iframe.contentWindow);
+            this.iframeNativeMethodsBackup = new this.nativeMethods.constructor(contentDocument, contentWindow);
         else if (this.iframeNativeMethodsBackup) {
-            this.iframeNativeMethodsBackup.restoreDocumentMeths(iframe.contentDocument, iframe.contentWindow);
+            this.iframeNativeMethodsBackup.restoreDocumentMeths(contentDocument, contentWindow);
             this.iframeNativeMethodsBackup = null;
         }
     }
 
     _ensureIframeNativeMethodsForIE (iframe) {
-        const iframeNativeMethods = iframe.contentWindow[INTERNAL_PROPS.iframeNativeMethods];
+        const contentWindow       = nativeMethods.iframeContentWindowGetter.call(iframe);
+        const contentDocument     = nativeMethods.iframeContentDocumentGetter.call(iframe);
+        const iframeNativeMethods = contentWindow[INTERNAL_PROPS.iframeNativeMethods];
 
         if (iframeNativeMethods) {
-            iframeNativeMethods.restoreDocumentMeths(iframe.contentDocument, iframe.contentWindow);
-            delete iframe.contentWindow[INTERNAL_PROPS.iframeNativeMethods];
+            iframeNativeMethods.restoreDocumentMeths(contentDocument, contentWindow);
+            delete contentWindow[INTERNAL_PROPS.iframeNativeMethods];
         }
     }
 
@@ -81,30 +86,35 @@ export default class IframeSandbox extends SandboxBase {
         if (!isIframeWithoutSrc(iframe))
             return;
 
+        const contentWindow   = nativeMethods.iframeContentWindowGetter.call(iframe);
+        const contentDocument = nativeMethods.iframeContentDocumentGetter.call(iframe);
+
         if (!IframeSandbox.isIframeInitialized(iframe)) {
             // NOTE: Even if iframe is not loaded (iframe.contentDocument.documentElement does not exist), we
             // still need to override the document.write method without initializing Hammerhead. This method can
             // be called before iframe is fully loaded, we should override it now.
-            if (iframe.contentDocument.write.toString() === this.nativeMethods.documentWrite.toString())
+            if (contentDocument.write.toString() === this.nativeMethods.documentWrite.toString())
                 this.emit(this.IFRAME_DOCUMENT_CREATED_EVENT, { iframe });
         }
-        else if (!iframe.contentWindow[IFRAME_WINDOW_INITED] && !iframe.contentWindow[INTERNAL_PROPS.hammerhead]) {
+        else if (!contentWindow[IFRAME_WINDOW_INITED] && !contentWindow[INTERNAL_PROPS.hammerhead]) {
             this._ensureIframeNativeMethods(iframe);
 
             // NOTE: Ok, the iframe is fully loaded now, but Hammerhead is not injected.
-            nativeMethods.objectDefineProperty.call(this.window.Object, iframe.contentWindow, IFRAME_WINDOW_INITED, { value: true });
+            nativeMethods.objectDefineProperty.call(this.window.Object, contentWindow, IFRAME_WINDOW_INITED, { value: true });
 
             this._emitEvents(iframe);
 
-            iframe.contentWindow[INTERNAL_PROPS.processDomMethodName]();
+            contentWindow[INTERNAL_PROPS.processDomMethodName]();
         }
     }
 
     static isIframeInitialized (iframe) {
-        const isFFIframeUninitialized = isFirefox && iframe.contentWindow.document.readyState === 'uninitialized';
+        const contentWindow           = nativeMethods.iframeContentWindowGetter.call(iframe);
+        const contentDocument         = nativeMethods.iframeContentDocumentGetter.call(iframe);
+        const isFFIframeUninitialized = isFirefox && contentWindow.document.readyState === 'uninitialized';
 
-        return !isFFIframeUninitialized && !!iframe.contentDocument.documentElement ||
-               isIE && iframe.contentWindow[INTERNAL_PROPS.documentWasCleaned];
+        return !isFFIframeUninitialized && !!contentDocument.documentElement ||
+               isIE && contentWindow[INTERNAL_PROPS.documentWasCleaned];
     }
 
     static isWindowInited (window) {
@@ -124,7 +134,9 @@ export default class IframeSandbox extends SandboxBase {
             .replace('{{{referer}}}', escapeStringPatterns(referer))
             .replace('{{{iframeTaskScriptTemplate}}}', escapeStringPatterns(iframeTaskScriptTemplate));
 
-        e.iframe.contentWindow.eval.call(e.iframe.contentWindow, taskScript);
+        const contentWindow = nativeMethods.iframeContentWindowGetter.call(e.iframe);
+
+        contentWindow.eval.call(contentWindow, taskScript);
     }
 
     onIframeBeganToRun (iframe) {
@@ -135,7 +147,10 @@ export default class IframeSandbox extends SandboxBase {
         if (isShadowUIElement(el))
             return;
 
-        if (el.contentWindow)
+        const tagName = getTagName(el);
+
+        if (tagName === 'iframe' && nativeMethods.iframeContentWindowGetter.call(el) ||
+            tagName === 'frame' && nativeMethods.frameContentWindowGetter.call(el))
             this._raiseReadyToInitEvent(el);
 
         // NOTE: This handler exists for iframes without the src attribute. In some the browsers (e.g. Chrome)

--- a/src/client/sandbox/index.js
+++ b/src/client/sandbox/index.js
@@ -104,8 +104,8 @@ export default class Sandbox extends SandboxBase {
 
     onIframeDocumentRecreated (iframe) {
         if (iframe) {
-            const contentWindow   = nativeMethods.iframeContentWindowGetter.call(iframe);
-            const contentDocument = nativeMethods.iframeContentDocumentGetter.call(iframe);
+            const contentWindow   = nativeMethods.contentWindowGetter.call(iframe);
+            const contentDocument = nativeMethods.contentDocumentGetter.call(iframe);
 
             // NOTE: Try to find an existing iframe sandbox.
             const sandbox = getSandboxBackup(contentWindow);
@@ -155,7 +155,7 @@ export default class Sandbox extends SandboxBase {
 
         // NOTE: Eval Hammerhead code script.
         this.iframe.on(this.iframe.EVAL_HAMMERHEAD_SCRIPT_EVENT, e => {
-            nativeMethods.iframeContentWindowGetter.call(e.iframe).eval(`(${ initHammerheadClient.toString() })();//# sourceURL=hammerhead.js`);
+            nativeMethods.contentWindowGetter.call(e.iframe).eval(`(${ initHammerheadClient.toString() })();//# sourceURL=hammerhead.js`);
         });
 
         // NOTE: We need to reattach a sandbox to the recreated iframe document.

--- a/src/client/sandbox/index.js
+++ b/src/client/sandbox/index.js
@@ -104,22 +104,25 @@ export default class Sandbox extends SandboxBase {
 
     onIframeDocumentRecreated (iframe) {
         if (iframe) {
+            const contentWindow   = nativeMethods.iframeContentWindowGetter.call(iframe);
+            const contentDocument = nativeMethods.iframeContentDocumentGetter.call(iframe);
+
             // NOTE: Try to find an existing iframe sandbox.
-            const sandbox = getSandboxBackup(iframe.contentWindow);
+            const sandbox = getSandboxBackup(contentWindow);
 
             if (sandbox && Sandbox._canUseSandbox(sandbox))
             // NOTE: Inform the sandbox so that it restores communication with the recreated document.
-                sandbox.reattach(iframe.contentWindow, iframe.contentDocument);
+                sandbox.reattach(contentWindow, contentDocument);
             else {
                 // NOTE: Remove saved native methods for iframe
-                if (iframe.contentWindow[INTERNAL_PROPS.iframeNativeMethods])
-                    delete iframe.contentWindow[INTERNAL_PROPS.iframeNativeMethods];
+                if (contentWindow[INTERNAL_PROPS.iframeNativeMethods])
+                    delete contentWindow[INTERNAL_PROPS.iframeNativeMethods];
 
                 // NOTE: If the iframe sandbox is not found, this means that iframe is not initialized.
                 // In this case, we need to inject Hammerhead.
 
                 // HACK: IE10 cleans up overridden methods after the document.write method call.
-                this.nativeMethods.restoreDocumentMeths(iframe.contentDocument);
+                this.nativeMethods.restoreDocumentMeths(contentDocument);
 
                 // NOTE: A sandbox for this iframe is not found (iframe is not yet initialized).
                 // Inform IFrameSandbox about this, and it injects Hammerhead.
@@ -152,7 +155,7 @@ export default class Sandbox extends SandboxBase {
 
         // NOTE: Eval Hammerhead code script.
         this.iframe.on(this.iframe.EVAL_HAMMERHEAD_SCRIPT_EVENT, e => {
-            e.iframe.contentWindow.eval(`(${ initHammerheadClient.toString() })();//# sourceURL=hammerhead.js`);
+            nativeMethods.iframeContentWindowGetter.call(e.iframe).eval(`(${ initHammerheadClient.toString() })();//# sourceURL=hammerhead.js`);
         });
 
         // NOTE: We need to reattach a sandbox to the recreated iframe document.

--- a/src/client/sandbox/native-methods.js
+++ b/src/client/sandbox/native-methods.js
@@ -434,6 +434,9 @@ class NativeMethods {
         this.inputFormActionGetter          = inputFormActionDescriptor.get;
         this.buttonFormActionGetter         = buttonFormActionDescriptor.get;
         this.iframeSandboxGetter            = iframeSandboxDescriptor.get;
+        this.iframeContentWindowGetter      = win.Object.getOwnPropertyDescriptor(win.HTMLIFrameElement.prototype, 'contentWindow').get;
+        this.iframeContentDocumentGetter    = win.Object.getOwnPropertyDescriptor(win.HTMLIFrameElement.prototype, 'contentDocument').get;
+        this.frameContentWindowGetter       = win.Object.getOwnPropertyDescriptor(win.HTMLFrameElement.prototype, 'contentWindow').get;
 
         this.nodeTextContentGetter      = nodeTextContentDescriptor.get;
         this.htmlElementInnerTextGetter = htmlElementInnerTextDescriptor.get;

--- a/src/client/sandbox/native-methods.js
+++ b/src/client/sandbox/native-methods.js
@@ -434,8 +434,8 @@ class NativeMethods {
         this.inputFormActionGetter          = inputFormActionDescriptor.get;
         this.buttonFormActionGetter         = buttonFormActionDescriptor.get;
         this.iframeSandboxGetter            = iframeSandboxDescriptor.get;
-        this.iframeContentWindowGetter      = win.Object.getOwnPropertyDescriptor(win.HTMLIFrameElement.prototype, 'contentWindow').get;
-        this.iframeContentDocumentGetter    = win.Object.getOwnPropertyDescriptor(win.HTMLIFrameElement.prototype, 'contentDocument').get;
+        this.contentWindowGetter            = win.Object.getOwnPropertyDescriptor(win.HTMLIFrameElement.prototype, 'contentWindow').get;
+        this.contentDocumentGetter          = win.Object.getOwnPropertyDescriptor(win.HTMLIFrameElement.prototype, 'contentDocument').get;
         this.frameContentWindowGetter       = win.Object.getOwnPropertyDescriptor(win.HTMLFrameElement.prototype, 'contentWindow').get;
 
         this.nodeTextContentGetter      = nodeTextContentDescriptor.get;

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -697,7 +697,7 @@ export default class ElementSandbox extends SandboxBase {
 
     _onRemoveIframe (el) {
         if (domUtils.isDomElement(el) && domUtils.isIframeElement(el))
-            windowsStorage.remove(nativeMethods.iframeContentWindowGetter.call(el));
+            windowsStorage.remove(nativeMethods.contentWindowGetter.call(el));
     }
 
     _onElementAdded (el) {
@@ -709,7 +709,7 @@ export default class ElementSandbox extends SandboxBase {
 
             for (const iframe of iframes) {
                 this.onIframeAddedToDOM(iframe);
-                windowsStorage.add(nativeMethods.iframeContentWindowGetter.call(iframe));
+                windowsStorage.add(nativeMethods.contentWindowGetter.call(iframe));
             }
 
             const scripts = domUtils.getScripts(el);

--- a/src/client/sandbox/node/element.js
+++ b/src/client/sandbox/node/element.js
@@ -697,7 +697,7 @@ export default class ElementSandbox extends SandboxBase {
 
     _onRemoveIframe (el) {
         if (domUtils.isDomElement(el) && domUtils.isIframeElement(el))
-            windowsStorage.remove(el.contentWindow);
+            windowsStorage.remove(nativeMethods.iframeContentWindowGetter.call(el));
     }
 
     _onElementAdded (el) {
@@ -709,7 +709,7 @@ export default class ElementSandbox extends SandboxBase {
 
             for (const iframe of iframes) {
                 this.onIframeAddedToDOM(iframe);
-                windowsStorage.add(iframe.contentWindow);
+                windowsStorage.add(nativeMethods.iframeContentWindowGetter.call(iframe));
             }
 
             const scripts = domUtils.getScripts(el);

--- a/src/client/sandbox/node/index.js
+++ b/src/client/sandbox/node/index.js
@@ -100,8 +100,8 @@ export default class NodeSandbox extends SandboxBase {
         super.attach(window, document);
 
         this.iframeSandbox.on(this.iframeSandbox.IFRAME_DOCUMENT_CREATED_EVENT, ({ iframe }) => {
-            const contentWindow   = nativeMethods.iframeContentWindowGetter.call(iframe);
-            const contentDocument = nativeMethods.iframeContentDocumentGetter.call(iframe);
+            const contentWindow   = nativeMethods.contentWindowGetter.call(iframe);
+            const contentDocument = nativeMethods.contentDocumentGetter.call(iframe);
 
             // NOTE: Before overriding the iframe, we must restore native document methods.
             // Therefore, we save them before they are overridden.

--- a/src/client/sandbox/node/index.js
+++ b/src/client/sandbox/node/index.js
@@ -100,14 +100,17 @@ export default class NodeSandbox extends SandboxBase {
         super.attach(window, document);
 
         this.iframeSandbox.on(this.iframeSandbox.IFRAME_DOCUMENT_CREATED_EVENT, ({ iframe }) => {
+            const contentWindow   = nativeMethods.iframeContentWindowGetter.call(iframe);
+            const contentDocument = nativeMethods.iframeContentDocumentGetter.call(iframe);
+
             // NOTE: Before overriding the iframe, we must restore native document methods.
             // Therefore, we save them before they are overridden.
-            const iframeNativeMethods = new this.nativeMethods.constructor(iframe.contentDocument, iframe.contentWindow);
+            const iframeNativeMethods = new this.nativeMethods.constructor(contentDocument, contentWindow);
 
-            iframe.contentWindow[INTERNAL_PROPS.iframeNativeMethods] = iframeNativeMethods;
+            contentWindow[INTERNAL_PROPS.iframeNativeMethods] = iframeNativeMethods;
 
             // NOTE: Override only the document (in fact, we only need the 'write' and 'writeln' methods).
-            this.doc.attach(iframe.contentWindow, iframe.contentDocument);
+            this.doc.attach(contentWindow, contentDocument);
         });
 
         // NOTE: In Google Chrome, iframes whose src contains html code raise the 'load' event twice.

--- a/src/client/sandbox/shadow-ui.js
+++ b/src/client/sandbox/shadow-ui.js
@@ -45,8 +45,9 @@ export default class ShadowUI extends SandboxBase {
 
     _initEventCallbacks () {
         this.runTaskScriptEventCallback = e => {
-            const iframeHead = e.iframe.contentDocument.head;
-            const iframeBody = e.iframe.contentDocument.body;
+            const contentDocument = nativeMethods.iframeContentDocumentGetter.call(e.iframe);
+            const iframeHead      = contentDocument.head;
+            const iframeBody      = contentDocument.body;
 
             this._restoreUIStyleSheets(iframeHead, this._getUIStyleSheetsHtml());
             this.markShadowUIContainers(iframeHead, iframeBody);

--- a/src/client/sandbox/shadow-ui.js
+++ b/src/client/sandbox/shadow-ui.js
@@ -45,7 +45,7 @@ export default class ShadowUI extends SandboxBase {
 
     _initEventCallbacks () {
         this.runTaskScriptEventCallback = e => {
-            const contentDocument = nativeMethods.iframeContentDocumentGetter.call(e.iframe);
+            const contentDocument = nativeMethods.contentDocumentGetter.call(e.iframe);
             const iframeHead      = contentDocument.head;
             const iframeBody      = contentDocument.body;
 

--- a/src/client/utils/dom.js
+++ b/src/client/utils/dom.js
@@ -104,7 +104,7 @@ export function getIframeLocation (iframe) {
 
     try {
         // eslint-disable-next-line no-restricted-properties
-        documentLocation = nativeMethods.iframeContentDocumentGetter.call(iframe).location.href;
+        documentLocation = nativeMethods.contentDocumentGetter.call(iframe).location.href;
     }
     catch (e) {
         documentLocation = null;
@@ -344,7 +344,7 @@ export function isIframeWithoutSrc (iframe) {
 
     // NOTE: after 'document.write' or 'document.open' call for iframe with/without src
     // we will process it as iframe without src
-    if (nativeMethods.iframeContentWindowGetter.call(iframe)[INTERNAL_PROPS.documentWasCleaned])
+    if (nativeMethods.contentWindowGetter.call(iframe)[INTERNAL_PROPS.documentWasCleaned])
         return true;
 
     const iframeDocumentLocationHaveSupportedProtocol = urlUtils.isSupportedProtocol(iframeDocumentLocation);

--- a/src/client/utils/dom.js
+++ b/src/client/utils/dom.js
@@ -104,7 +104,7 @@ export function getIframeLocation (iframe) {
 
     try {
         // eslint-disable-next-line no-restricted-properties
-        documentLocation = iframe.contentDocument.location.href;
+        documentLocation = nativeMethods.iframeContentDocumentGetter.call(iframe).location.href;
     }
     catch (e) {
         documentLocation = null;
@@ -344,7 +344,7 @@ export function isIframeWithoutSrc (iframe) {
 
     // NOTE: after 'document.write' or 'document.open' call for iframe with/without src
     // we will process it as iframe without src
-    if (iframe.contentWindow[INTERNAL_PROPS.documentWasCleaned])
+    if (nativeMethods.iframeContentWindowGetter.call(iframe)[INTERNAL_PROPS.documentWasCleaned])
         return true;
 
     const iframeDocumentLocationHaveSupportedProtocol = urlUtils.isSupportedProtocol(iframeDocumentLocation);

--- a/src/client/utils/style.js
+++ b/src/client/utils/style.js
@@ -74,7 +74,7 @@ export function getElementScroll (el) {
         const currentIframe = domUtils.getIframeByElement(el);
 
         if (currentIframe)
-            currentWindow = currentIframe.contentWindow;
+            currentWindow = nativeMethods.iframeContentWindowGetter.call(currentIframe);
     }
 
     const targetEl = isHtmlElement ? currentWindow : el;

--- a/src/client/utils/style.js
+++ b/src/client/utils/style.js
@@ -74,7 +74,7 @@ export function getElementScroll (el) {
         const currentIframe = domUtils.getIframeByElement(el);
 
         if (currentIframe)
-            currentWindow = nativeMethods.iframeContentWindowGetter.call(currentIframe);
+            currentWindow = nativeMethods.contentWindowGetter.call(currentIframe);
     }
 
     const targetEl = isHtmlElement ? currentWindow : el;


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1850

### Changes
1. Use stored `HTMLIFrameElement.contentWindow`, `HTMLIFrameElement.contentDocument` and `HTMLFrameElement.contentWindow` getters in whole code.
2. Update `eslint-plugin-hammerhead` (https://github.com/LavrovArtem/eslint-plugin-hammerhead/commit/433846fee49a765673492a0a05f95a5624a71c89)