### PR TITLE
fix `Reach Router doesn't navigate in Testcafe tests` (close #1863)

### DIFF
--- a/src/client/sandbox/code-instrumentation/location/index.ts
+++ b/src/client/sandbox/code-instrumentation/location/index.ts
@@ -27,6 +27,7 @@ export default class LocationAccessorsInstrumentation extends SandboxBase {
 
     static getLocationWrapper (owner) {
         // NOTE: IE11 case. We can get cross-domain location wrapper without any exceptions.
+        // We return owner.location in this case, as in other browsers.
         if (isIE && isCrossDomainWindows(window, owner))
             return owner.location;
 

--- a/src/client/sandbox/code-instrumentation/location/index.ts
+++ b/src/client/sandbox/code-instrumentation/location/index.ts
@@ -1,8 +1,9 @@
 import LocationWrapper from './wrapper';
 import SandboxBase from '../../base';
-import { isLocation } from '../../../utils/dom';
+import { isLocation, isCrossDomainWindows } from '../../../utils/dom';
 import INSTRUCTION from '../../../../processing/script/instruction';
 import nativeMethods from '../../native-methods';
+import { isIE } from '../../../utils/browser';
 
 const LOCATION_WRAPPER = 'hammerhead|location-wrapper';
 
@@ -25,6 +26,10 @@ export default class LocationAccessorsInstrumentation extends SandboxBase {
     }
 
     static getLocationWrapper (owner) {
+        // NOTE: IE11 case. We can get cross-domain location wrapper without any exceptions.
+        if (isIE && isCrossDomainWindows(window, owner))
+            return owner.location;
+
         // NOTE: When the owner is cross-domain, we cannot get its location wrapper, so we return the original
         // location, which cannot be accessed but behaves like a real one. Cross-domain location retains the 'replace'
         // and 'assign' methods, so we intercept calls to them through MethodCallInstrumentation.

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -528,19 +528,25 @@ export function isBlob (instance): boolean {
 }
 
 export function isLocation (instance): boolean {
+    if (!instance)
+        return false;
+
     if (instance instanceof nativeMethods.locationClass ||
         nativeMethods.objectToString.call(instance) === '[object Location]')
         return true;
 
     try {
-        // eslint-disable-next-line no-restricted-properties
-        return instance && typeof instance === 'object' && instance.href !== void 0 && instance.assign !== void 0;
+        // eslint-disable-next-line no-proto
+        if (instance.__proto__.constructor.toString().indexOf('Location') > -1)
+            return true;
     }
     catch (e) {
         // NOTE: Try to detect cross-domain window location.
         // A cross-domain location has no the "assign" function in Safari.
         return instance.replace && (isSafari || !!instance.assign);
     }
+
+    return false;
 }
 
 export function isSVGElement (instance): boolean {

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -537,16 +537,13 @@ export function isLocation (instance): boolean {
 
     try {
         // eslint-disable-next-line no-proto
-        if (instance.__proto__.constructor.toString().indexOf('Location') > -1)
-            return true;
+        return instance.__proto__.constructor.toString().indexOf('Location') > -1;
     }
     catch (e) {
         // NOTE: Try to detect cross-domain window location.
         // A cross-domain location has no the "assign" function in Safari.
         return instance.replace && (isSafari || !!instance.assign);
     }
-
-    return false;
 }
 
 export function isSVGElement (instance): boolean {

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -5,7 +5,7 @@ import nativeMethods from '../sandbox/native-methods';
 import * as urlUtils from './url';
 import { get as getStyle } from './style';
 import { sameOriginCheck } from './destination-location';
-import { isFirefox, isWebKit, isIE, isMSEdge, isSafari } from './browser';
+import { isFirefox, isWebKit, isIE, isMSEdge } from './browser';
 import { getNativeQuerySelectorAll } from './query-selector';
 import { instanceAndPrototypeToStringAreEqual } from '../utils/feature-detection';
 
@@ -531,7 +531,7 @@ export function isLocation (instance): boolean {
     if (!instance)
         return false;
 
-    if (isIE || isSafari) {
+    if (isIE) {
         let instanceCtor = null;
 
         try {
@@ -540,8 +540,7 @@ export function isLocation (instance): boolean {
         }
         catch (e) {
             // NOTE: Try to detect cross-domain window location.
-            // A cross-domain location has no the "assign" function in Safari.
-            return instance.replace && (isSafari || !!instance.assign);
+            return instance.replace && !!instance.assign;
         }
 
         if (instanceCtor) {

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -527,25 +527,28 @@ export function isBlob (instance): boolean {
     return instance && instanceToString(instance) === '[object Blob]';
 }
 
+function isLocationByProto (instance): boolean {
+    let instanceCtor = null;
+
+    try {
+        // eslint-disable-next-line no-proto
+        instanceCtor = instance.__proto__;
+    }
+    catch (e) {
+        // NOTE: Try to detect cross-domain window location.
+        // A cross-domain location has no the "assign" function in Safari.
+        return instance.replace && (isSafari || !!instance.assign);
+    }
+
+    return instanceCtor && nativeMethods.objectToString.call(instanceCtor) === '[object LocationPrototype]';
+}
+
 export function isLocation (instance): boolean {
     if (!instance)
         return false;
 
-    if (isIE || isSafari) {
-        let instanceCtor = null;
-
-        try {
-            // eslint-disable-next-line no-proto
-            instanceCtor = instance.__proto__;
-        }
-        catch (e) {
-            // NOTE: Try to detect cross-domain window location.
-            // A cross-domain location has no the "assign" function in Safari.
-            return instance.replace && (isSafari || !!instance.assign);
-        }
-
-        return instanceCtor && nativeMethods.objectToString.call(instanceCtor) === '[object LocationPrototype]';
-    }
+    if (isIE || isSafari)
+        return isLocationByProto(instance);
 
     return instance instanceof nativeMethods.locationClass ||
         nativeMethods.objectToString.call(instance) === '[object Location]';

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -536,7 +536,7 @@ export function isLocation (instance): boolean {
 
         try {
             // eslint-disable-next-line no-proto
-            instanceCtor = instance.__proto__ && instance.__proto__.constructor;
+            instanceCtor = instance.__proto__;
         }
         catch (e) {
             // NOTE: Try to detect cross-domain window location.
@@ -544,22 +544,11 @@ export function isLocation (instance): boolean {
             return instance.replace && (isSafari || !!instance.assign);
         }
 
-        if (instanceCtor) {
-            let toStringMeth = null;
-
-            if (typeof instanceCtor === 'object')
-                toStringMeth = nativeMethods.objectToString;
-            else if (typeof instanceCtor === 'function')
-                toStringMeth = nativeMethods.functionToString;
-
-            return toStringMeth && toStringMeth.call(instanceCtor).indexOf('Location') > -1;
-        }
-
-        return false;
+        return instanceCtor && nativeMethods.objectToString.call(instanceCtor) === '[object LocationPrototype]';
     }
 
     return instance instanceof nativeMethods.locationClass ||
-           nativeMethods.objectToString.call(instance) === '[object Location]';
+        nativeMethods.objectToString.call(instance) === '[object Location]';
 }
 
 export function isSVGElement (instance): boolean {

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -5,7 +5,7 @@ import nativeMethods from '../sandbox/native-methods';
 import * as urlUtils from './url';
 import { get as getStyle } from './style';
 import { sameOriginCheck } from './destination-location';
-import { isFirefox, isWebKit, isIE, isMSEdge } from './browser';
+import { isFirefox, isWebKit, isIE, isMSEdge, isSafari } from './browser';
 import { getNativeQuerySelectorAll } from './query-selector';
 import { instanceAndPrototypeToStringAreEqual } from '../utils/feature-detection';
 
@@ -531,7 +531,7 @@ export function isLocation (instance): boolean {
     if (!instance)
         return false;
 
-    if (isIE) {
+    if (isIE || isSafari) {
         let instanceCtor = null;
 
         try {
@@ -540,7 +540,8 @@ export function isLocation (instance): boolean {
         }
         catch (e) {
             // NOTE: Try to detect cross-domain window location.
-            return instance.replace && !!instance.assign;
+            // A cross-domain location has no the "assign" function in Safari.
+            return instance.replace && (isSafari || !!instance.assign);
         }
 
         if (instanceCtor) {

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -36,14 +36,30 @@ function getFocusableSelector () {
     return 'input, select, textarea, button, body, iframe, [contenteditable="true"], [contenteditable=""], [tabIndex]';
 }
 
-function isHidden (el: HTMLElement) {
+function isHidden (el: HTMLElement): boolean {
     return el.offsetWidth <= 0 && el.offsetHeight <= 0;
 }
 
-function isAlwaysNotEditableElement (el: HTMLElement) {
+function isAlwaysNotEditableElement (el: HTMLElement): boolean {
     const tagName = getTagName(el);
 
     return tagName && (NOT_CONTENT_EDITABLE_ELEMENTS_RE.test(tagName) || INPUT_ELEMENTS_RE.test(tagName));
+}
+
+function isLocationByProto (instance): boolean {
+    let instanceCtor = null;
+
+    try {
+        // eslint-disable-next-line no-proto
+        instanceCtor = instance.__proto__;
+    }
+    catch (e) {
+        // NOTE: Try to detect cross-domain window location.
+        // A cross-domain location has no the "assign" function in Safari.
+        return instance.replace && (isSafari || !!instance.assign);
+    }
+
+    return instanceCtor && nativeMethods.objectToString.call(instanceCtor) === '[object LocationPrototype]';
 }
 
 function closestFallback (el: Node, selector: string) {
@@ -525,22 +541,6 @@ export function isDocument (instance): boolean {
 
 export function isBlob (instance): boolean {
     return instance && instanceToString(instance) === '[object Blob]';
-}
-
-function isLocationByProto (instance): boolean {
-    let instanceCtor = null;
-
-    try {
-        // eslint-disable-next-line no-proto
-        instanceCtor = instance.__proto__;
-    }
-    catch (e) {
-        // NOTE: Try to detect cross-domain window location.
-        // A cross-domain location has no the "assign" function in Safari.
-        return instance.replace && (isSafari || !!instance.assign);
-    }
-
-    return instanceCtor && nativeMethods.objectToString.call(instanceCtor) === '[object LocationPrototype]';
 }
 
 export function isLocation (instance): boolean {

--- a/test/client/fixtures/page-navigation-watch-test.js
+++ b/test/client/fixtures/page-navigation-watch-test.js
@@ -74,13 +74,6 @@ test('location = ...', function () {
         });
 });
 
-test('location = { href, assign }', function () {
-    return navigateIframe('location = { href: "./index.html", assign: function(){} };')
-        .then(function (url) {
-            strictEqual(url, iframeLocation + 'index.html');
-        });
-});
-
 test('window.location = ...', function () {
     return navigateIframe('window.location = "./index.html";')
         .then(function (url) {

--- a/test/client/fixtures/page-navigation-watch-test.js
+++ b/test/client/fixtures/page-navigation-watch-test.js
@@ -74,6 +74,13 @@ test('location = ...', function () {
         });
 });
 
+test('location = { href, assign }', function () {
+    return navigateIframe('location = { href: "./index.html", assign: function(){} };')
+        .then(function (url) {
+            strictEqual(url, iframeLocation + 'index.html');
+        });
+});
+
 test('window.location = ...', function () {
     return navigateIframe('window.location = "./index.html";')
         .then(function (url) {

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -92,6 +92,13 @@ var ENSURE_URL_TRAILING_SLASH_TEST_CASES = [
     }
 ];
 
+test('"isLocation" (GH-1863)', function () {
+    var locationCopy = extend({}, window.location);
+
+    ok(domUtils.isLocation(window.location));
+    ok(!domUtils.isLocation(locationCopy));
+});
+
 test('iframe with empty src', function () {
     function assert (iframe) {
         new CodeInstrumentation({}, {}, messageSandbox).attach(iframe.contentWindow);
@@ -463,19 +470,6 @@ test('should omit the default port on page navigation', function () {
     hammerhead.win = storedWindow;
 });
 
-test('"isLocation" for window.location and iframe.contentWindow.location', function () {
-    var windowLocation = getLocation(window.location);
-
-    ok(windowLocation instanceof LocationWrapper);
-
-    return createTestIframe({ src: getCrossDomainPageUrl('../../../data/cross-domain/simple-page.html') })
-        .then(function (crossDomainIframe) {
-            var iframeLocation = getLocation(crossDomainIframe.contentWindow.location);
-
-            ok(iframeLocation instanceof LocationWrapper);
-        });
-});
-
 if (window.location.ancestorOrigins) {
     module('ancestorOrigins');
 
@@ -745,10 +739,4 @@ test('set a relative url to a cross-domain location', function () {
             checkLocation(iframes[0].contentWindow.location);
             checkLocation(iframes[1].contentWindow.location);
         });
-});
-
-test('"isLocation" for the cloned location object should not return the "true" value (GH-1863)', function () {
-    var locationCopy = getLocation(extend({}, window.location));
-
-    ok(!(locationCopy instanceof LocationWrapper));
 });

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -748,18 +748,17 @@ test('"isLocation" for the cloned location object should not return the "true" v
 test('"isLocation" for the cross-domain iframe location (GH-1863)', function () {
     return createTestIframe({ src: getCrossDomainPageUrl('../../../data/cross-domain/simple-page.html') })
         .then(function (crossDomainIframe) {
-            window.testIframe = crossDomainIframe;
+            window.testIframeLocation = crossDomainIframe.contentWindow.location;
 
             var getIframeLocationScript = processScript('(function getIframeLocation () {' +
-                                                        'var location = window.testIframe.contentWindow.location;' +
+                                                        'var location = window.testIframeLocation;' +
                                                         'return location;' +
                                                         '})();');
 
-            var locationWrapper     = eval(getIframeLocationScript);
-            var locationWrapperCtor = Object.getPrototypeOf(locationWrapper).constructor;
+            var iframeLocation = eval(getIframeLocationScript);
 
-            notEqual(locationWrapperCtor.toString().indexOf('LocationWrapper'), -1, 'should contain "LocationWrapper"');
+            ok(iframeLocation instanceof LocationWrapper);
 
-            delete window.testIframe;
+            delete window.testIframeLocation;
         });
 });

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -6,6 +6,7 @@ var urlUtils                = hammerhead.get('./utils/url');
 var sharedUrlUtils          = hammerhead.get('../utils/url');
 var destLocation            = hammerhead.get('./utils/destination-location');
 var urlResolver             = hammerhead.get('./utils/url-resolver');
+var extend                  = hammerhead.get('./utils/extend');
 
 var Promise       = hammerhead.Promise;
 var nativeMethods = hammerhead.nativeMethods;
@@ -729,4 +730,17 @@ test('set a relative url to a cross-domain location', function () {
             checkLocation(iframes[0].contentWindow.location);
             checkLocation(iframes[1].contentWindow.location);
         });
+});
+
+test('"isLocation" for the cloned location object should not return the "true" value (GH-1863)', function () {
+    var getLocationCopyScript = processScript('(function getLocation () {' +
+                                              extend.toString() +
+                                              'var location = extend({}, window.location);' +
+                                              'return location;' +
+                                              '})();');
+
+    var locationCopy     = eval(getLocationCopyScript);
+    var locationCopyCtor = Object.getPrototypeOf(locationCopy).constructor;
+
+    strictEqual(locationCopyCtor.toString().indexOf('LocationWrapper'), -1, 'should not contains "LocationWrapper"');
 });

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -13,8 +13,6 @@ var nativeMethods = hammerhead.nativeMethods;
 var browserUtils  = hammerhead.utils.browser;
 var domUtils      = hammerhead.utils.dom;
 
-var getLocation = window[INSTRUCTION.getLocation];
-
 var messageSandbox = hammerhead.sandbox.event.message;
 
 var getWindowMock = function (opts) {
@@ -482,10 +480,10 @@ if (window.location.ancestorOrigins) {
                 return createTestIframe({}, iframe.contentDocument.body);
             })
             .then(function (nestedIframe) {
-                var getLocationInstruction = nestedIframe.contentWindow[INSTRUCTION.getLocation];
-                var locationWrapper        = getLocationInstruction(nestedIframe.contentWindow.location);
-                var ancestorOrigins        = locationWrapper.ancestorOrigins;
-                var nativeAncestorOrigins  = nestedIframe.contentWindow.location.ancestorOrigins;
+                var getLocation           = nestedIframe.contentWindow[INSTRUCTION.getLocation];
+                var locationWrapper       = getLocation(nestedIframe.contentWindow.location);
+                var ancestorOrigins       = locationWrapper.ancestorOrigins;
+                var nativeAncestorOrigins = nestedIframe.contentWindow.location.ancestorOrigins;
 
                 nestedIframe.contentWindow.parent.parent = {
                     location: {

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -461,6 +461,33 @@ test('should omit the default port on page navigation', function () {
     hammerhead.win = storedWindow;
 });
 
+test('"isLocation" for window.location and iframe.contentWindow.location', function () {
+    var getLocationScript = processScript('(function getLocation () {' +
+        'var location = window.location;' +
+        'return location;' +
+        '})();');
+
+    var windowLocation = eval(getLocationScript);
+
+    ok(windowLocation instanceof LocationWrapper);
+
+    return createTestIframe({ src: getCrossDomainPageUrl('../../../data/cross-domain/simple-page.html') })
+        .then(function (crossDomainIframe) {
+            window.testIframeLocation = crossDomainIframe.contentWindow.location;
+
+            var getIframeLocationScript = processScript('(function getIframeLocation () {' +
+                'var location = window.testIframeLocation;' +
+                'return location;' +
+                '})();');
+
+            var iframeLocation = eval(getIframeLocationScript);
+
+            ok(iframeLocation instanceof LocationWrapper);
+
+            delete window.testIframeLocation;
+        });
+});
+
 if (window.location.ancestorOrigins) {
     module('ancestorOrigins');
 
@@ -743,31 +770,4 @@ test('"isLocation" for the cloned location object should not return the "true" v
     var locationCopyCtor = Object.getPrototypeOf(locationCopy).constructor;
 
     strictEqual(locationCopyCtor.toString().indexOf('LocationWrapper'), -1, 'should not contain "LocationWrapper"');
-});
-
-test('"isLocation" for window.location and iframe.contentWindow.location', function () {
-    var getLocationScript = processScript('(function getLocation () {' +
-        'var location = window.location;' +
-        'return location;' +
-        '})();');
-
-    var windowLocation = eval(getLocationScript);
-
-    ok(windowLocation instanceof LocationWrapper);
-
-    return createTestIframe({ src: getCrossDomainPageUrl('../../../data/cross-domain/simple-page.html') })
-        .then(function (crossDomainIframe) {
-            window.testIframeLocation = crossDomainIframe.contentWindow.location;
-
-            var getIframeLocationScript = processScript('(function getIframeLocation () {' +
-                'var location = window.testIframeLocation;' +
-                'return location;' +
-                '})();');
-
-            var iframeLocation = eval(getIframeLocationScript);
-
-            ok(iframeLocation instanceof LocationWrapper);
-
-            delete window.testIframeLocation;
-        });
 });

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -745,15 +745,24 @@ test('"isLocation" for the cloned location object should not return the "true" v
     strictEqual(locationCopyCtor.toString().indexOf('LocationWrapper'), -1, 'should not contain "LocationWrapper"');
 });
 
-test('"isLocation" for the cross-domain iframe location (GH-1863)', function () {
+test('"isLocation" for window.location and iframe.contentWindow.location', function () {
+    var getLocationScript = processScript('(function getLocation () {' +
+        'var location = window.location;' +
+        'return location;' +
+        '})();');
+
+    var windowLocation = eval(getLocationScript);
+
+    ok(windowLocation instanceof LocationWrapper);
+
     return createTestIframe({ src: getCrossDomainPageUrl('../../../data/cross-domain/simple-page.html') })
         .then(function (crossDomainIframe) {
             window.testIframeLocation = crossDomainIframe.contentWindow.location;
 
             var getIframeLocationScript = processScript('(function getIframeLocation () {' +
-                                                        'var location = window.testIframeLocation;' +
-                                                        'return location;' +
-                                                        '})();');
+                'var location = window.testIframeLocation;' +
+                'return location;' +
+                '})();');
 
             var iframeLocation = eval(getIframeLocationScript);
 

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -742,5 +742,24 @@ test('"isLocation" for the cloned location object should not return the "true" v
     var locationCopy     = eval(getLocationCopyScript);
     var locationCopyCtor = Object.getPrototypeOf(locationCopy).constructor;
 
-    strictEqual(locationCopyCtor.toString().indexOf('LocationWrapper'), -1, 'should not contains "LocationWrapper"');
+    strictEqual(locationCopyCtor.toString().indexOf('LocationWrapper'), -1, 'should not contain "LocationWrapper"');
+});
+
+test('"isLocation" for the cross-domain iframe location (GH-1863)', function () {
+    return createTestIframe({ src: getCrossDomainPageUrl('../../../data/cross-domain/simple-page.html') })
+        .then(function (crossDomainIframe) {
+            window.testIframe = crossDomainIframe;
+
+            var getIframeLocationScript = processScript('(function getIframeLocation () {' +
+                                                        'var location = window.testIframe.contentWindow.location;' +
+                                                        'return location;' +
+                                                        '})();');
+
+            var locationWrapper     = eval(getIframeLocationScript);
+            var locationWrapperCtor = Object.getPrototypeOf(locationWrapper).constructor;
+
+            notEqual(locationWrapperCtor.toString().indexOf('LocationWrapper'), -1, 'should contain "LocationWrapper"');
+
+            delete window.testIframe;
+        });
 });


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1863

### Changes
1. Fix the `isLocation` check: `isLocation` for the **cloned location object** should not return the `true` value.
