### PR TITLE
fix `Not finding an element in IE11` (close #1890)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "del-cli": "^1.1.0",
     "endpoint-utils": "^1.0.1",
     "eslint": "4.17.0",
-    "eslint-plugin-hammerhead": "0.1.11",
+    "eslint-plugin-hammerhead": "0.2.0",
     "express": "4.16.3",
     "express-ntlm": "2.1.5",
     "gulp": "^4.0.0",

--- a/src/client/sandbox/native-methods.js
+++ b/src/client/sandbox/native-methods.js
@@ -401,6 +401,11 @@ class NativeMethods {
                 this.webSocketUrlGetter = urlPropDescriptor.get;
         }
 
+        // NOTE: the classList property is located in HTMLElement prototype in IE11
+        this.elementClassListPropOwnerName = win.Element.prototype.hasOwnProperty('classList') ? 'Element' : 'HTMLElement';
+
+        this.elementClassListGetter = win.Object.getOwnPropertyDescriptor(win[this.elementClassListPropOwnerName].prototype, 'classList').get;
+
         this.messageEventOriginGetter       = win.Object.getOwnPropertyDescriptor(win.MessageEvent.prototype, 'origin').get;
         this.htmlCollectionLengthGetter     = win.Object.getOwnPropertyDescriptor(win.HTMLCollection.prototype, 'length').get;
         this.nodeListLengthGetter           = win.Object.getOwnPropertyDescriptor(win.NodeList.prototype, 'length').get;

--- a/src/client/sandbox/node/window.js
+++ b/src/client/sandbox/node/window.js
@@ -901,7 +901,7 @@ export default class WindowSandbox extends SandboxBase {
                 if (!domTokenList) {
                     const span = nativeMethods.createElement.call(document, 'span');
 
-                    domTokenList   = span.classList;
+                    domTokenList   = nativeMethods.elementClassListGetter.call(span);
                     span.className = windowSandbox.nodeSandbox.element.getAttributeCore(this, ['sandbox']) || '';
 
                     nativeMethods.objectDefineProperty.call(window.Object, domTokenList, SANDBOX_DOM_TOKEN_LIST_OWNER, { value: this });

--- a/src/client/utils/dom.js
+++ b/src/client/utils/dom.js
@@ -677,7 +677,7 @@ export function addClass (el, className) {
     const classNames = className.split(/\s+/);
 
     for (const currentClassName of classNames)
-        nativeMethods.tokenListAdd.call(el.classList, currentClassName);
+        nativeMethods.tokenListAdd.call(nativeMethods.elementClassListGetter.call(el), currentClassName);
 }
 
 export function removeClass (el, className) {
@@ -687,14 +687,14 @@ export function removeClass (el, className) {
     const classNames = className.split(/\s+/);
 
     for (const currentClassName of classNames)
-        nativeMethods.tokenListRemove.call(el.classList, currentClassName);
+        nativeMethods.tokenListRemove.call(nativeMethods.elementClassListGetter.call(el), currentClassName);
 }
 
 export function hasClass (el, className) {
     if (!el)
         return false;
 
-    return nativeMethods.tokenListContains.call(el.classList, className);
+    return nativeMethods.tokenListContains.call(nativeMethods.elementClassListGetter.call(el), className);
 }
 
 export function parseDocumentCharset () {

--- a/test/client/fixtures/utils/dom-test.js
+++ b/test/client/fixtures/utils/dom-test.js
@@ -1002,3 +1002,27 @@ if (window.HTMLElement.prototype.matches && window.HTMLElement.prototype.closest
         window.HTMLElement.prototype.matches = storedMatchesFn;
     });
 }
+
+test('hammerhead should use the native classList getter in addClass, removeClass and hasClass functions (GH-1890)', function () {
+    var div                           = document.createElement('div');
+    var elementClassListPropOwnerName = window.Element.prototype.hasOwnProperty('classList') ? 'Element' : 'HTMLElement';
+    var storedСlassListDescriptor     = Object.getOwnPropertyDescriptor(window[elementClassListPropOwnerName].prototype, 'classList');
+
+    Object.defineProperty(window[elementClassListPropOwnerName].prototype, 'classList', {
+        get: function () {
+            ok(false);
+        },
+
+        configurable: true
+    });
+
+    document.body.appendChild(div);
+
+    domUtils.addClass(div, 'test');
+    ok(domUtils.hasClass(div, 'test'));
+    domUtils.removeClass(div, 'test');
+
+    div.parentNode.removeChild(div);
+
+    Object.defineProperty(window[elementClassListPropOwnerName], 'classList', storedСlassListDescriptor);
+});


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1890

### Changes
1. Use native `Element.classList`/`HTMLElement.classList` (IE11 case).