### PR TITLE
fix `Salesforce Lightning Experience does not render some component properly` (close #1874)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "del-cli": "^1.1.0",
     "endpoint-utils": "^1.0.1",
     "eslint": "4.17.0",
-    "eslint-plugin-hammerhead": "0.2.0",
+    "eslint-plugin-hammerhead": "0.3.0",
     "eslint-plugin-typescript": "^0.14.0",
     "express": "4.16.3",
     "express-ntlm": "2.1.5",

--- a/src/client/sandbox/event/focus-blur.ts
+++ b/src/client/sandbox/event/focus-blur.ts
@@ -205,7 +205,7 @@ export default class FocusBlurSandbox extends SandboxBase {
             const activeElement = domUtils.getActiveElement(curDocument);
 
             // NOTE: If the element was not focused and has a parent with tabindex, we focus this parent.
-            const parent             = el.parentNode;
+            const parent             = nativeMethods.nodeParentNodeGetter.call(el);
             const parentWithTabIndex = parent === document ? null : domUtils.closest(parent, '[tabindex]');
 
             if (type === 'focus' && activeElement !== el && parentWithTabIndex && forMouseEvent) {

--- a/src/client/sandbox/event/hover.ts
+++ b/src/client/sandbox/event/hover.ts
@@ -28,7 +28,7 @@ export default class HoverSandbox extends SandboxBase {
             // NOTE: Assign a pseudo-class marker to the elements until the joint parent is found.
             if (newHoveredElement !== jointParent) {
                 nativeMethods.setAttribute.call(newHoveredElement, INTERNAL_ATTRS.hoverPseudoClass, '');
-                newHoveredElement = newHoveredElement.parentNode;
+                newHoveredElement = nativeMethods.nodeParentNodeGetter.call(newHoveredElement);
             }
             else
                 break;
@@ -48,7 +48,7 @@ export default class HoverSandbox extends SandboxBase {
                 // NOTE: Check that the current element is a joint parent for the hovered elements.
                 if (!el.contains(newHoveredElement)) {
                     nativeMethods.removeAttribute.call(el, INTERNAL_ATTRS.hoverPseudoClass);
-                    el = el.parentNode;
+                    el = nativeMethods.nodeParentNodeGetter.call(el);
                 }
                 else {
                     jointParent = el;

--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -548,9 +548,10 @@ export default class EventSimulator {
         // button, not a child, so the child does not receive the click event.
         if (browserUtils.isIE) {
             if (args.type === 'click' || args.type === 'mouseup' || args.type === 'mousedown') {
-                const closestButton = domUtils.closest(el.parentNode, 'button');
+                const elParent      = nativeMethods.nodeParentNodeGetter.call(el);
+                const closestButton = domUtils.closest(elParent, 'button');
 
-                if (el.parentNode && closestButton) {
+                if (elParent && closestButton) {
                     if (nativeMethods.getAttribute.call(closestButton, 'type') === 'submit')
                         el = closestButton;
                 }

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -208,6 +208,7 @@ class NativeMethods {
     messageEventOriginGetter: any;
     htmlCollectionLengthGetter: any;
     nodeListLengthGetter: any;
+    nodeParentNodeGetter: any;
     elementChildElementCountGetter: any;
     inputFilesGetter: any;
     styleSheetHrefGetter: any;
@@ -810,6 +811,7 @@ class NativeMethods {
         this.nodeLastChildGetter             = win.Object.getOwnPropertyDescriptor(win.Node.prototype, 'lastChild').get;
         this.nodeNextSiblingGetter           = win.Object.getOwnPropertyDescriptor(win.Node.prototype, 'nextSibling').get;
         this.nodePrevSiblingGetter           = win.Object.getOwnPropertyDescriptor(win.Node.prototype, 'previousSibling').get;
+        this.nodeParentNodeGetter            = win.Object.getOwnPropertyDescriptor(win.Node.prototype, 'parentNode').get;
         this.elementFirstElementChildGetter  = win.Object.getOwnPropertyDescriptor(win.Element.prototype, 'firstElementChild').get;
         this.elementLastElementChildGetter   = win.Object.getOwnPropertyDescriptor(win.Element.prototype, 'lastElementChild').get;
         this.elementNextElementSiblingGetter = win.Object.getOwnPropertyDescriptor(win.Element.prototype, 'nextElementSibling').get;

--- a/src/client/sandbox/node/document/writer.ts
+++ b/src/client/sandbox/node/document/writer.ts
@@ -129,8 +129,10 @@ export default class DocumentWriter {
         while (nativeMethods.elementFirstElementChildGetter.call(beginMarker))
             beginMarker = nativeMethods.elementFirstElementChildGetter.call(beginMarker);
 
-        if (nativeMethods.nodeFirstChildGetter.call(beginMarker.parentNode) !== beginMarker)
-            beginMarker = nativeMethods.nodeFirstChildGetter.call(beginMarker.parentNode);
+        const beginMarkerParent = nativeMethods.nodeParentNodeGetter.call(beginMarker);
+
+        if (nativeMethods.nodeFirstChildGetter.call(beginMarkerParent) !== beginMarker)
+            beginMarker = nativeMethods.nodeFirstChildGetter.call(beginMarkerParent);
         else if (isCommentNode(nativeMethods.nodeFirstChildGetter.call(beginMarker)))
             beginMarker = nativeMethods.nodeFirstChildGetter.call(beginMarker);
 
@@ -148,8 +150,10 @@ export default class DocumentWriter {
         while (nativeMethods.elementLastElementChildGetter.call(endMarker))
             endMarker = nativeMethods.elementLastElementChildGetter.call(endMarker);
 
-        if (nativeMethods.nodeLastChildGetter.call(endMarker.parentNode) !== endMarker)
-            endMarker = nativeMethods.nodeLastChildGetter.call(endMarker.parentNode);
+        const endMarkerParent = nativeMethods.nodeParentNodeGetter.call(endMarker);
+
+        if (nativeMethods.nodeLastChildGetter.call(endMarkerParent) !== endMarker)
+            endMarker = nativeMethods.nodeLastChildGetter.call(endMarkerParent);
         else if (isCommentNode(nativeMethods.nodeLastChildGetter.call(endMarker)))
             endMarker = nativeMethods.nodeLastChildGetter.call(endMarker);
 
@@ -157,18 +161,18 @@ export default class DocumentWriter {
     }
 
     _updateParentTagChain (container, endMarker) {
-        let endMarkerParent = getTagName(endMarker) !== END_MARKER_TAG_NAME ? endMarker : endMarker.parentNode;
+        let endMarkerParent = getTagName(endMarker) !== END_MARKER_TAG_NAME ? endMarker : nativeMethods.nodeParentNodeGetter.call(endMarker);
 
         if (isCommentNode(endMarker)) {
             this.isNonClosedComment = true;
-            endMarkerParent         = endMarker.parentNode;
+            endMarkerParent         = nativeMethods.nodeParentNodeGetter.call(endMarker);
         }
 
         this.parentTagChain = [];
 
         while (endMarkerParent !== container) {
             this.parentTagChain.unshift(getTagName(endMarkerParent));
-            endMarkerParent = endMarkerParent.parentNode;
+            endMarkerParent = nativeMethods.nodeParentNodeGetter.call(endMarkerParent);
         }
     }
 
@@ -191,7 +195,9 @@ export default class DocumentWriter {
 
         beginMarker = nativeMethods.createElement.call(document, BEGIN_MARKER_TAG_NAME);
 
-        nativeMethods.insertBefore.call(elWithContent.parentNode, beginMarker, elWithContent);
+        const elWithContentParent = nativeMethods.nodeParentNodeGetter.call(elWithContent);
+
+        nativeMethods.insertBefore.call(elWithContentParent, beginMarker, elWithContent);
     }
 
     static _createStartsWithClosingTagRegExp (tagName) {
@@ -240,13 +246,16 @@ export default class DocumentWriter {
             }
         }
 
-        nativeMethods.appendChild.call(elWithContent.parentNode, endMarker);
+        const elWithContentParent = nativeMethods.nodeParentNodeGetter.call(elWithContent);
+
+        nativeMethods.appendChild.call(elWithContentParent, endMarker);
     }
 
     static _addOnDocumentRecreationScript (endMarker) {
-        const span = nativeMethods.createElement.call(endMarker.ownerDocument, 'span');
+        const span            = nativeMethods.createElement.call(endMarker.ownerDocument, 'span');
+        const endMarkerParent = nativeMethods.nodeParentNodeGetter.call(endMarker);
 
-        nativeMethods.insertBefore.call(endMarker.parentNode, span, endMarker);
+        nativeMethods.insertBefore.call(endMarkerParent, span, endMarker);
         nativeMethods.elementOuterHTMLSetter.call(span, ON_WINDOW_RECREATION_SCRIPT_TEMPLATE);
     }
 

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -779,10 +779,6 @@ export default class ElementSandbox extends SandboxBase {
 
         this._createOverridedMethods();
 
-        window.Element.prototype.insertBefore              = this.overriddenMethods.insertBefore;
-        window.Element.prototype.appendChild               = this.overriddenMethods.appendChild;
-        window.Element.prototype.replaceChild              = this.overriddenMethods.replaceChild;
-        window.Element.prototype.removeChild               = this.overriddenMethods.removeChild;
         window.Element.prototype.setAttribute              = this.overriddenMethods.setAttribute;
         window.Element.prototype.setAttributeNS            = this.overriddenMethods.setAttributeNS;
         window.Element.prototype.getAttribute              = this.overriddenMethods.getAttribute;

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -476,7 +476,7 @@ export default class ElementSandbox extends SandboxBase {
                 const position = args[0];
                 const html     = args[1];
                 const el       = this;
-                const parentEl = el.parentNode;
+                const parentEl = nativeMethods.nodeParentNodeGetter.call(el);
 
                 if (args.length > 1 && html !== null) {
                     args[1] = processHtml(String(html), {
@@ -674,7 +674,9 @@ export default class ElementSandbox extends SandboxBase {
     }
 
     static _hasShadowUIParentOrContainsShadowUIClassPostfix (el) {
-        return el.parentNode && domUtils.isShadowUIElement(el.parentNode) || ShadowUI.containsShadowUIClassPostfix(el);
+        const parent = nativeMethods.nodeParentNodeGetter.call(el);
+
+        return parent && domUtils.isShadowUIElement(parent) || ShadowUI.containsShadowUIClassPostfix(el);
     }
 
     _isFirstBaseTagOnPage (el) {

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -739,7 +739,7 @@ export default class WindowSandbox extends SandboxBase {
                 if (ShadowUI.isShadowContainerCollection(this))
                     return windowSandbox.shadowUI.getShadowUICollectionLength(this, length);
                 // IE11 and Edge have a strange behavior: shadow container collection flag may be lost (GH-1763)
-                else if (isIE && length && isHeadOrBodyElement(this[0].parentNode)) {
+                else if (isIE && length && isHeadOrBodyElement(nativeMethods.nodeParentNodeGetter.call(this[0]))) {
                     ShadowUI.markAsShadowContainerCollection(this);
 
                     return windowSandbox.shadowUI.getShadowUICollectionLength(this, length);
@@ -1196,7 +1196,7 @@ export default class WindowSandbox extends SandboxBase {
             },
             setter: function (value) {
                 const el       = this;
-                const parentEl = el.parentNode;
+                const parentEl = nativeMethods.nodeParentNodeGetter.call(el);
 
                 DOMMutationTracker.onElementChanged(el);
 

--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -230,7 +230,7 @@ export default class ShadowUI extends SandboxBase {
 
     _bringRootToWindowTopLeft () {
         let rootHasParentWithNonStaticPosition = false;
-        let parent                             = this.root.parentNode;
+        let parent                             = nativeMethods.nodeParentNodeGetter.call(this.root);
 
         while (parent) {
             const elementPosition = getStyle(parent, 'position');
@@ -238,7 +238,7 @@ export default class ShadowUI extends SandboxBase {
             if (IS_NON_STATIC_POSITION_RE.test(elementPosition))
                 rootHasParentWithNonStaticPosition = true;
 
-            parent = parent.parentNode;
+            parent = nativeMethods.nodeParentNodeGetter.call(parent);
         }
 
         if (rootHasParentWithNonStaticPosition) {
@@ -441,7 +441,7 @@ export default class ShadowUI extends SandboxBase {
         // NOTE: Fix for B239138 - The 'Cannot read property 'document' of null' error
         // is thrown on recording on the unroll.me site. There was an issue when
         // document.body was replaced, so we need to reattach a UI to a new body manually.
-        const isRootInBody = this.root.parentNode === this.document.body;
+        const isRootInBody = nativeMethods.nodeParentNodeGetter.call(this.root) === this.document.body;
 
         if (!(isRootInDom && isRootLastChild && isRootInBody))
             this.nativeMethods.appendChild.call(this.document.body, this.root);
@@ -532,7 +532,7 @@ export default class ShadowUI extends SandboxBase {
                 shadowUIElements.push(item);
         }
 
-        const collectionOwner = shadowUIElements.length && shadowUIElements[0].parentNode;
+        const collectionOwner = shadowUIElements.length && nativeMethods.nodeParentNodeGetter.call(shadowUIElements[0]);
 
         for (const shadowUIElement of shadowUIElements)
             nativeMethods.appendChild.call(collectionOwner, shadowUIElement);
@@ -602,8 +602,11 @@ export default class ShadowUI extends SandboxBase {
             '.' + SHADOW_UI_CLASS_NAME.selfRemovingScript);
         const length              = nativeMethods.nodeListLengthGetter.call(selfRemovingScripts);
 
-        for (let i = 0; i < length; i++)
-            nativeMethods.removeChild.call(selfRemovingScripts[i].parentNode, selfRemovingScripts[i]);
+        for (let i = 0; i < length; i++) {
+            const parent = nativeMethods.nodeParentNodeGetter.call(selfRemovingScripts[i]);
+
+            nativeMethods.removeChild.call(parent, selfRemovingScripts[i]);
+        }
     }
 
     // API
@@ -679,7 +682,7 @@ export default class ShadowUI extends SandboxBase {
     }
 
     insertBeforeRoot (el) {
-        const rootParent      = this.getRoot().parentNode;
+        const rootParent      = this.nativeMethods.nodeParentNodeGetter.call(this.getRoot());
         const lastParentChild = this.nativeMethods.nodeLastChildGetter.call(rootParent);
 
         return nativeMethods.insertBefore.call(rootParent, el, lastParentChild);

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -68,7 +68,7 @@ function closestFallback (el: Node, selector: string) {
         if (matches(el, selector))
             return el;
 
-        el = el.parentNode;
+        el = nativeMethods.nodeParentNodeGetter.call(el);
     }
 
     return null;
@@ -195,14 +195,19 @@ export function getScrollbarSize () {
         const scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
 
         scrollbarSize = scrollbarWidth;
-        scrollDiv.parentNode.removeChild(scrollDiv);
+
+        const parent = nativeMethods.nodeParentNodeGetter.call(scrollDiv);
+
+        parent.removeChild(scrollDiv);
     }
 
     return scrollbarSize;
 }
 
 export function getSelectParent (child) {
-    return closest(child.parentNode, 'select');
+    const parent = nativeMethods.nodeParentNodeGetter.call(child);
+
+    return closest(parent, 'select');
 }
 
 export function getSelectVisibleChildren (select: HTMLSelectElement) {
@@ -263,7 +268,9 @@ export function findDocument (el): Document {
     if (el.ownerDocument && el.ownerDocument.defaultView)
         return el.ownerDocument;
 
-    return el.parentNode ? findDocument(el.parentNode) : document;
+    const parent = isElementNode(el) && nativeMethods.nodeParentNodeGetter.call(el);
+
+    return parent ? findDocument(parent) : document;
 }
 
 export function isContentEditableElement (el: Node) {
@@ -271,7 +278,7 @@ export function isContentEditableElement (el: Node) {
     let element           = null;
 
     if (isTextNode(el))
-        element = el.parentElement || el.parentNode;
+        element = el.parentElement || nativeMethods.nodeParentNodeGetter.call(el);
     else
         element = el;
 
@@ -718,7 +725,7 @@ export function parseDocumentCharset () {
 
 export function getParents (el, selector?) {
     // eslint-disable-next-line no-restricted-properties
-    let parent = el.parentNode || el.host;
+    let parent = nativeMethods.nodeParentNodeGetter.call(el) || el.host;
 
     const parents = [];
 
@@ -728,7 +735,7 @@ export function getParents (el, selector?) {
             parents.push(parent);
 
         // eslint-disable-next-line no-restricted-properties
-        parent = parent.parentNode || parent.host;
+        parent = nativeMethods.nodeParentNodeGetter.call(parent) || parent.host;
     }
 
     return parents;
@@ -736,13 +743,13 @@ export function getParents (el, selector?) {
 
 export function findParent (node, includeSelf = false, predicate) {
     if (!includeSelf)
-        node = node.parentNode;
+        node = nativeMethods.nodeParentNodeGetter.call(node);
 
     while (node) {
         if (typeof predicate !== 'function' || predicate(node))
             return node;
 
-        node = node.parentNode;
+        node = nativeMethods.nodeParentNodeGetter.call(node);
     }
 
     return null;

--- a/src/client/utils/html.ts
+++ b/src/client/utils/html.ts
@@ -120,7 +120,9 @@ function processHtmlInternal (html, process) {
 
     let processedHtml = process(container) ? nativeMethods.elementInnerHTMLGetter.call(container) : html;
 
-    nativeMethods.removeChild.call(container.parentNode, container);
+    const containerParent = nativeMethods.nodeParentNodeGetter.call(container);
+
+    nativeMethods.removeChild.call(containerParent, container);
     processedHtml = unwrapHtmlText(processedHtml);
 
     // NOTE: hack for IE (GH-1083)
@@ -215,8 +217,10 @@ export function cleanUpHtml (html) {
         });
 
         find(container, SHADOW_UI_ELEMENTS_SELECTOR, el => {
-            if (el.parentNode) {
-                nativeMethods.removeChild.call(el.parentNode, el);
+            const parent = nativeMethods.nodeParentNodeGetter.call(el);
+
+            if (parent) {
+                nativeMethods.removeChild.call(parent, el);
                 changed = true;
             }
         });
@@ -331,8 +335,8 @@ export function dispose () {
 }
 
 export function isInternalHtmlParserElement (el) {
-    while (el.parentNode)
-        el = el.parentNode;
+    while (nativeMethods.nodeParentNodeGetter.call(el))
+        el = nativeMethods.nodeParentNodeGetter.call(el);
 
     return !!el[HTML_PARSER_ELEMENT_FLAG];
 }

--- a/src/client/utils/style.ts
+++ b/src/client/utils/style.ts
@@ -332,7 +332,7 @@ export function isElementVisible (el, doc) {
         if (get(el, 'display', doc) === 'none' || get(el, 'visibility', doc) === 'hidden')
             return false;
 
-        el = el.parentNode;
+        el = nativeMethods.nodeParentNodeGetter.call(el);
     }
 
     return true;

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -483,7 +483,7 @@ test('should override document methods on a prototype level (GH-1827)', function
 });
 
 test('patching Node methods on the client side: appendChild, insertBefore, replaceChild, removeChild (GH-1874)', function () {
-    // expect(12);
+    expect(8);
 
     function checkMeth (methName) {
         strictEqual(window.Node.prototype[methName], window.HTMLBodyElement.prototype[methName], methName);
@@ -496,13 +496,11 @@ test('patching Node methods on the client side: appendChild, insertBefore, repla
             ok(true, methName);
         };
 
-        strictEqual(window.Node.prototype[methName], window.HTMLBodyElement.prototype[methName], methName);
-
         document.body[methName]();
     }
 
     [
-        // 'appendChild',
+        'appendChild',
         'insertBefore',
         'replaceChild',
         'removeChild',

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -482,6 +482,26 @@ test('should override document methods on a prototype level (GH-1827)', function
     document.createElement('div');
 });
 
+test('GH-1874', function () {
+    expect(3);
+
+    strictEqual(window.Node.prototype.appendChild, window.HTMLBodyElement.prototype.appendChild);
+
+    var savedAppendChild = window.Node.prototype.appendChild;
+
+    window.Node.prototype.appendChild = function () {
+        window.Node.prototype.appendChild = savedAppendChild;
+
+        ok(true);
+    };
+
+    var div = document.createElement('div');
+
+    document.body.appendChild(div);
+
+    strictEqual(window.Node.prototype.appendChild, window.HTMLBodyElement.prototype.appendChild);
+});
+
 module('resgression');
 
 test('document.write for several tags in iframe (T215136)', function () {

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -482,24 +482,33 @@ test('should override document methods on a prototype level (GH-1827)', function
     document.createElement('div');
 });
 
-test('GH-1874', function () {
-    expect(3);
+test('patching Node methods on the client side: appendChild, insertBefore, replaceChild, removeChild (GH-1874)', function () {
+    // expect(12);
 
-    strictEqual(window.Node.prototype.appendChild, window.HTMLBodyElement.prototype.appendChild);
+    function checkMeth (methName) {
+        strictEqual(window.Node.prototype[methName], window.HTMLBodyElement.prototype[methName], methName);
 
-    var savedAppendChild = window.Node.prototype.appendChild;
+        var savedMeth = window.Node.prototype[methName];
 
-    window.Node.prototype.appendChild = function () {
-        window.Node.prototype.appendChild = savedAppendChild;
+        window.Node.prototype[methName] = function () {
+            window.Node.prototype[methName] = savedMeth;
 
-        ok(true);
-    };
+            ok(true, methName);
+        };
 
-    var div = document.createElement('div');
+        strictEqual(window.Node.prototype[methName], window.HTMLBodyElement.prototype[methName], methName);
 
-    document.body.appendChild(div);
+        document.body[methName]();
+    }
 
-    strictEqual(window.Node.prototype.appendChild, window.HTMLBodyElement.prototype.appendChild);
+    [
+        // 'appendChild',
+        'insertBefore',
+        'replaceChild',
+        'removeChild',
+    ].forEach(function (methName) {
+        checkMeth(methName);
+    });
 });
 
 module('resgression');


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1874

### Changes
1. Fix the "patching Node methods on the client side: `appendChild`, `insertBefore`, `replaceChild`, `removeChild`" case.
2. Replace `.parentNode` calls to native in the hammerhead's client code.
3. Update `eslint-plugin-hammerhead`.

### Native/Proxy differences
**Native:**
```
> Object.getPrototypeOf(document.body).appendChild === window.Node.prototype.appendChild
< true

> window.Node.prototype.appendChild = null
< null

> Object.getPrototypeOf(document.body).appendChild === window.Node.prototype.appendChild
< true
```

**Proxy:**
```
> Object.getPrototypeOf(document.body).appendChild === window.Node.prototype.appendChild
< true

> window.Node.prototype.appendChild = null
< null

> Object.getPrototypeOf(document.body).appendChild === window.Node.prototype.appendChild
< false // !
```

### Reproducing example (`Node.prototype` methods overriding)
Page: https://developer.salesforce.com/docs/component-library/tools/playground

`/api/runtime/lwc/0.35.4/engine.js`:
```js
    // monkey patching Node methods to be able to detect the insertions and removal of
    // root elements created via createElement.
    assign(Node.prototype, {
        appendChild(newChild) {
            const appendedNode = appendChild.call(this, newChild);
            return callNodeSlot(appendedNode, ConnectingSlot);
        },
        insertBefore(newChild, referenceNode) {
            ...
        },
        removeChild(oldChild) {
            ...
        },
        replaceChild(newChild, oldChild) {
            ...
        },
    });
```
and
```js
    /**
     * This method is almost identical to document.createElement
     * (https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement)
     * with the slightly difference that in the options, you can pass the `is`
     * property set to a Constructor instead of just a string value. E.g.:
     *
     * const el = createElement('x-foo', { is: FooCtor });
     *
     * If the value of `is` attribute is not a constructor,
     * then it throws a TypeError.
     */
    function createElement$2(sel, options) {
        ...
    }
```
