### PR TITLE
fix `Css source map regex is commenting code` (close #1907)

### DIFF
--- a/src/processing/style.js
+++ b/src/processing/style.js
@@ -8,7 +8,7 @@ import reEscape from '../utils/regexp-escape';
 import INTERNAL_ATTRS from '../processing/dom/internal-attributes';
 import { isSpecialPage } from '../utils/url';
 
-const SOURCE_MAP_RE                       = /(?:\/\*[\s]*(?:#|@)[\s]*sourceMappingURL\s*=[\s\S]*?\*\/)|(?:\/\/[\t ]*(?:#|@)[\t ]*sourceMappingURL[\t ]*=.*)/ig;
+const SOURCE_MAP_RE                       = /(?:\/\*\s*(?:#|@)\s*sourceMappingURL\s*=[\s\S]*?\*\/)|(?:\/\/[\t ]*(?:#|@)[\t ]*sourceMappingURL[\t ]*=.*)/ig;
 const CSS_URL_PROPERTY_VALUE_PATTERN      = /(url\s*\(\s*)(?:(')([^\s']*)(')|(")([^\s"]*)(")|([^\s)]*))(\s*\))|(@import\s+)(?:(')([^\s']*)(')|(")([^\s"]*)("))/g;
 const STYLESHEET_PROCESSING_START_COMMENT = '/*hammerhead|stylesheet|start*/';
 const STYLESHEET_PROCESSING_END_COMMENT   = '/*hammerhead|stylesheet|end*/';

--- a/src/processing/style.js
+++ b/src/processing/style.js
@@ -8,7 +8,7 @@ import reEscape from '../utils/regexp-escape';
 import INTERNAL_ATTRS from '../processing/dom/internal-attributes';
 import { isSpecialPage } from '../utils/url';
 
-const SOURCE_MAP_RE                       = /(\/\*+[\s\S]*?sourceMappingURL\s*=[\s\S]*?\*\/)|(\/\/.*?sourceMappingURL\s*=.*?[\r\n])/ig;
+const SOURCE_MAP_RE                       = /(?:\/\*[\s\S]*?sourceMappingURL\s*=[\s\S]*?\*\/)|(?:\/\/.*?sourceMappingURL\s*=.*?[\r\n])/ig;
 const CSS_URL_PROPERTY_VALUE_PATTERN      = /(url\s*\(\s*)(?:(')([^\s']*)(')|(")([^\s"]*)(")|([^\s)]*))(\s*\))|(@import\s+)(?:(')([^\s']*)(')|(")([^\s"]*)("))/g;
 const STYLESHEET_PROCESSING_START_COMMENT = '/*hammerhead|stylesheet|start*/';
 const STYLESHEET_PROCESSING_END_COMMENT   = '/*hammerhead|stylesheet|end*/';

--- a/src/processing/style.js
+++ b/src/processing/style.js
@@ -8,7 +8,7 @@ import reEscape from '../utils/regexp-escape';
 import INTERNAL_ATTRS from '../processing/dom/internal-attributes';
 import { isSpecialPage } from '../utils/url';
 
-const SOURCE_MAP_RE                       = /(?:\/\*[\s\S]*?sourceMappingURL\s*=[\s\S]*?\*\/)|(?:\/\/.*?sourceMappingURL[^\S\n]*=.*)/ig;
+const SOURCE_MAP_RE                       = /(?:\/\*[\s]*(?:#|@)[\s]*sourceMappingURL\s*=[\s\S]*?\*\/)|(?:\/\/[\t ]*(?:#|@)[\t ]*sourceMappingURL[\t ]*=.*)/ig;
 const CSS_URL_PROPERTY_VALUE_PATTERN      = /(url\s*\(\s*)(?:(')([^\s']*)(')|(")([^\s"]*)(")|([^\s)]*))(\s*\))|(@import\s+)(?:(')([^\s']*)(')|(")([^\s"]*)("))/g;
 const STYLESHEET_PROCESSING_START_COMMENT = '/*hammerhead|stylesheet|start*/';
 const STYLESHEET_PROCESSING_END_COMMENT   = '/*hammerhead|stylesheet|end*/';

--- a/src/processing/style.js
+++ b/src/processing/style.js
@@ -8,7 +8,7 @@ import reEscape from '../utils/regexp-escape';
 import INTERNAL_ATTRS from '../processing/dom/internal-attributes';
 import { isSpecialPage } from '../utils/url';
 
-const SOURCE_MAP_RE                       = /(?:\/\*[\s\S]*?sourceMappingURL\s*=[\s\S]*?\*\/)|(?:\/\/.*?sourceMappingURL\s*=.*?[\r\n])/ig;
+const SOURCE_MAP_RE                       = /(?:\/\*[\s\S]*?sourceMappingURL\s*=[\s\S]*?\*\/)|(?:\/\/.*?sourceMappingURL[^\S\n]*=.*)/ig;
 const CSS_URL_PROPERTY_VALUE_PATTERN      = /(url\s*\(\s*)(?:(')([^\s']*)(')|(")([^\s"]*)(")|([^\s)]*))(\s*\))|(@import\s+)(?:(')([^\s']*)(')|(")([^\s"]*)("))/g;
 const STYLESHEET_PROCESSING_START_COMMENT = '/*hammerhead|stylesheet|start*/';
 const STYLESHEET_PROCESSING_END_COMMENT   = '/*hammerhead|stylesheet|end*/';

--- a/src/processing/style.js
+++ b/src/processing/style.js
@@ -8,7 +8,7 @@ import reEscape from '../utils/regexp-escape';
 import INTERNAL_ATTRS from '../processing/dom/internal-attributes';
 import { isSpecialPage } from '../utils/url';
 
-const SOURCE_MAP_RE                       = /#\s*sourceMappingURL\s*=\s*[^\s]+(\s|\*\/)/i;
+const SOURCE_MAP_RE                       = /(\/\*+[\s\S]*?sourceMappingURL\s*=[\s\S]*?\*\/)|(\/\/.*?sourceMappingURL\s*=.*?[\r\n])/ig;
 const CSS_URL_PROPERTY_VALUE_PATTERN      = /(url\s*\(\s*)(?:(')([^\s']*)(')|(")([^\s"]*)(")|([^\s)]*))(\s*\))|(@import\s+)(?:(')([^\s']*)(')|(")([^\s"]*)("))/g;
 const STYLESHEET_PROCESSING_START_COMMENT = '/*hammerhead|stylesheet|start*/';
 const STYLESHEET_PROCESSING_END_COMMENT   = '/*hammerhead|stylesheet|end*/';
@@ -34,8 +34,8 @@ class StyleProcessor {
         // NOTE: Replace the :hover pseudo-class.
         css = css.replace(HOVER_PSEUDO_CLASS_RE, '[' + INTERNAL_ATTRS.hoverPseudoClass + ']$1');
 
-        // NOTE: Remove the ‘source map’ directive.
-        css = css.replace(SOURCE_MAP_RE, '$1');
+        // NOTE: Remove all 'source map' directives.
+        css = css.replace(SOURCE_MAP_RE, '');
 
         // NOTE: Replace URLs in CSS rules with proxy URLs.
         return prefix + this._replaceStylsheetUrls(css, urlReplacer) + postfix;

--- a/test/server/data/stylesheet/src.css
+++ b/test/server/data/stylesheet/src.css
@@ -2,7 +2,7 @@
 #
     sourceMappingURL
     =
-    test.css.map
+    https://example.com/test.css.map
 */
 span {
     background: url('http://some.url') no-repeat -6px -52px;
@@ -37,5 +37,5 @@ select {
 #item {
     background-image:url('about:blank');
 }
-// # sourceMappingURL = test.css.map
+// # sourceMappingURL = https://example.com/test.css.map
 //  @  sourceMappingURL=

--- a/test/server/data/stylesheet/src.css
+++ b/test/server/data/stylesheet/src.css
@@ -1,3 +1,4 @@
+/* # sourceMappingURL=test.css.map */
 span {
     background: url('http://some.url') no-repeat -6px -52px;
     width: 18px;
@@ -5,6 +6,7 @@ span {
     float: left;
     margin-top: 8px;
 }
+/* @ sourceMappingURL = test.css.map  */
 
 .content {
     margin: 0 auto;
@@ -30,3 +32,5 @@ select {
 #item {
     background-image:url('about:blank');
 }
+// # sourceMappingURL=test.css.map
+// @ sourceMappingURL = test.css.map

--- a/test/server/data/stylesheet/src.css
+++ b/test/server/data/stylesheet/src.css
@@ -1,4 +1,9 @@
-/* # sourceMappingURL=test.css.map */
+/*
+#
+    sourceMappingURL
+    =
+    test.css.map
+*/
 span {
     background: url('http://some.url') no-repeat -6px -52px;
     width: 18px;
@@ -6,13 +11,13 @@ span {
     float: left;
     margin-top: 8px;
 }
-/* @ sourceMappingURL = test.css.map  */
 
 .content {
     margin: 0 auto;
     color: #ffffff;
     font-family: Helvetica, Tahoma, Geneva, sans-serif;
 }
+/* @ sourceMappingURL=*/
 
 .copyright {
     padding-top: 26px;
@@ -32,5 +37,5 @@ select {
 #item {
     background-image:url('about:blank');
 }
-// # sourceMappingURL=test.css.map
-// @ sourceMappingURL = test.css.map
+// # sourceMappingURL = test.css.map
+//  @  sourceMappingURL=


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1907

### Changes
1. Fix `SOURCE_MAP_RE`: remove all "source map" directives in `StyleProcessor.process`. 

### Notes
[Source Map Revision 3 Proposal](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.lmz475t4mvbx)