### PR TITLE
fix process styles when stylesheets get updated

### DIFF
--- a/src/client/sandbox/native-methods.js
+++ b/src/client/sandbox/native-methods.js
@@ -553,7 +553,7 @@ class NativeMethods {
         this.styleGetPropertyValue = win.CSSStyleDeclaration.prototype.getPropertyValue;
         this.styleSetProperty      = win.CSSStyleDeclaration.prototype.setProperty;
         this.styleRemoveProperty   = win.CSSStyleDeclaration.prototype.removeProperty;
-        this.styleSheetsInsertRule = win.CSSStyleSheet.prototype.insertRule;
+        this.styleSheetInsertRule = win.CSSStyleSheet.prototype.insertRule;
 
         // Console
         this.console = win.console;

--- a/src/client/sandbox/native-methods.js
+++ b/src/client/sandbox/native-methods.js
@@ -553,6 +553,7 @@ class NativeMethods {
         this.styleGetPropertyValue = win.CSSStyleDeclaration.prototype.getPropertyValue;
         this.styleSetProperty      = win.CSSStyleDeclaration.prototype.setProperty;
         this.styleRemoveProperty   = win.CSSStyleDeclaration.prototype.removeProperty;
+        this.styleSheetsInsertRule = win.CSSStyleSheet.prototype.insertRule;
 
         // Console
         this.console = win.console;

--- a/src/client/sandbox/style.js
+++ b/src/client/sandbox/style.js
@@ -225,9 +225,10 @@ export default class StyleSandbox extends SandboxBase {
             }
         });
 
-        window.CSSStyleSheet.prototype.insertRule = function (value, index) {
-            value = styleProcessor.process(value, getProxyUrl);
-            nativeMethods.styleSheetsInsertRule.call(this, value, index);
+        window.CSSStyleSheet.prototype.insertRule = function (rule, index) {
+            const newRule = styleProcessor.process(rule, getProxyUrl);
+
+            return nativeMethods.styleSheetInsertRule.call(this, newRule, index);
         };
 
         window.CSSStyleDeclaration.prototype.getPropertyValue = function (...args) {

--- a/src/client/sandbox/style.js
+++ b/src/client/sandbox/style.js
@@ -225,6 +225,11 @@ export default class StyleSandbox extends SandboxBase {
             }
         });
 
+        window.CSSStyleSheet.prototype.insertRule = function (value, index) {
+            value = styleProcessor.process(value, getProxyUrl);
+            nativeMethods.styleSheetsInsertRule.call(this, value, index);
+        };
+
         window.CSSStyleDeclaration.prototype.getPropertyValue = function (...args) {
             const value = nativeMethods.styleGetPropertyValue.apply(this, args);
 

--- a/test/client/fixtures/sandbox/style-test.js
+++ b/test/client/fixtures/sandbox/style-test.js
@@ -55,6 +55,18 @@ test('cssText', function () {
     strictEqual(div.style.cssText.indexOf(proxyUrl), -1);
 });
 
+test('insertRule', function () {
+    var style    = document.createElement('style');
+    var url      = '/image.png';
+    var proxyUrl = urlUtils.getProxyUrl(url);
+
+    document.head.appendChild(style);
+
+    document.styleSheets[0].insertRule('div { background-image:url("' + url + '"); }');
+
+    strictEqual(document.styleSheets[0].rules[0].cssText, 'div { background-image: ' + 'url("' + proxyUrl + '")' + '; }');
+});
+
 test('url properties', function () {
     var div      = document.createElement('div');
     var url      = 'http://some.domain.com/image.png';

--- a/test/client/fixtures/sandbox/style-test.js
+++ b/test/client/fixtures/sandbox/style-test.js
@@ -62,11 +62,11 @@ test('insertRule', function () {
 
     document.head.appendChild(style);
 
-    var actualRuleIndex = document.styleSheets[0].insertRule('div { background-image:url("' + url + '"); }');
-    var actualRule = document.styleSheets[0].rules[0].cssText;
+    var actualRuleIndex = document.styleSheets[0].insertRule('div { background-image: url("' + url + '"); }');
+    var actualRule = removeDoubleQuotes(document.styleSheets[0].rules[0].cssText);
 
     strictEqual(actualRuleIndex, 0);
-    strictEqual(actualRule, 'div { background-image: ' + 'url("' + proxyUrl + '")' + '; }');
+    strictEqual(actualRule, removeDoubleQuotes('div { background-image: url("' + proxyUrl + '")' + '; }'));
 });
 
 test('url properties', function () {

--- a/test/client/fixtures/sandbox/style-test.js
+++ b/test/client/fixtures/sandbox/style-test.js
@@ -63,7 +63,8 @@ test('insertRule', function () {
     document.head.appendChild(style);
 
     var actualRuleIndex = document.styleSheets[0].insertRule('div { background-image: url("' + url + '"); }');
-    var actualRule = removeDoubleQuotes(document.styleSheets[0].rules[0].cssText);
+    var actualRules = document.styleSheets[0].rules || document.styleSheets[0].cssRules;
+    var actualRule = removeDoubleQuotes(actualRules[0].cssText);
 
     strictEqual(actualRuleIndex, 0);
     strictEqual(actualRule, removeDoubleQuotes('div { background-image: url("' + proxyUrl + '")' + '; }'));

--- a/test/client/fixtures/sandbox/style-test.js
+++ b/test/client/fixtures/sandbox/style-test.js
@@ -62,9 +62,11 @@ test('insertRule', function () {
 
     document.head.appendChild(style);
 
-    document.styleSheets[0].insertRule('div { background-image:url("' + url + '"); }');
+    var actualRuleIndex = document.styleSheets[0].insertRule('div { background-image:url("' + url + '"); }');
+    var actualRule = document.styleSheets[0].rules[0].cssText;
 
-    strictEqual(document.styleSheets[0].rules[0].cssText, 'div { background-image: ' + 'url("' + proxyUrl + '")' + '; }');
+    strictEqual(actualRuleIndex, 0);
+    strictEqual(actualRule, 'div { background-image: ' + 'url("' + proxyUrl + '")' + '; }');
 });
 
 test('url properties', function () {


### PR DESCRIPTION
Some css-in-js librairies, like styled-components, which rewrite its stylesheets on page load, it is necessary to process again the styles on **CSSStyleSheet.insertRule**.

(for css-in-js user: it fixes css hover, urls and so on)
