### PR TITLE
prevent error when empty string is processed

### DIFF
--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -57,7 +57,17 @@ export default class MessageSandbox extends SandboxBase {
     static _getMessageData (e) {
         const rawData = isMessageEvent(e) ? nativeMethods.messageEventDataGetter.call(e) : e.data;
 
-        return typeof rawData === 'string' ? parseJSON(rawData) : rawData;
+        if (typeof rawData !== 'string') return rawData;
+
+        let data = {};
+
+        try {
+            data = parseJSON(rawData);
+        }
+        // eslint-disable-next-line no-empty
+        catch (error) {
+        }
+        return data;
     }
 
     _onMessage (e) {


### PR DESCRIPTION
As stated in my comment in #1935, I think the `JSON.parse` must be surrounded with a `try/catch` block.

Thank you