### PR TITLE
fix `Some iframe tests fail on latest Chrome 73` (close #1966)

### DIFF
--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -177,9 +177,9 @@ test('quotes in the cookies are not escaped when a task script for an iframe is 
 asyncTest('an error occurs when proxing two nested iframes (a top iframe has src with javascript protocol) (GH-125)', function () {
     var iframe                         = document.createElement('iframe');
     var countNestedIframeLoadEvents    = 0;
-    var maxCountNestedIframeLoadEvents = browserUtils.isWebKit ? 2 : 1;
+    var maxCountNestedIframeLoadEvents = browserUtils.isWebKit && !browserUtils.isChrome ? 2 : 1;
     var countXhrLoadEvents             = 0;
-    var validCountXhrLoadEvents        = browserUtils.isWebKit ? 2 : 1;
+    var validCountXhrLoadEvents        = browserUtils.isWebKit && !browserUtils.isChrome ? 2 : 1;
 
     // NOTE: NetworkError occurs in IE11 after some Windows 10 update (iframe without src case) (GH-1837)
     var skipIframeCheck = false;
@@ -239,7 +239,7 @@ asyncTest('an error occurs when proxing two nested iframes (a top iframe has src
 asyncTest('native methods of the iframe document aren`t overridden for iframe with javascript src (GH-358)', function () {
     var iframe            = document.createElement('iframe');
     var loadEventCount    = 0;
-    var maxLoadEventCount = browserUtils.isWebKit ? 2 : 1;
+    var maxLoadEventCount = browserUtils.isWebKit && !browserUtils.isChrome ? 2 : 1;
 
     iframe.id = 'test_nmsghf';
     iframe.setAttribute('src', 'javascript:"<html><body>test</body></html>"');

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -177,9 +177,9 @@ test('quotes in the cookies are not escaped when a task script for an iframe is 
 asyncTest('an error occurs when proxing two nested iframes (a top iframe has src with javascript protocol) (GH-125)', function () {
     var iframe                         = document.createElement('iframe');
     var countNestedIframeLoadEvents    = 0;
-    var maxCountNestedIframeLoadEvents = browserUtils.isWebKit && (!browserUtils.isChrome || browserUtils.isAndroid) ? 2 : 1;
+    var maxCountNestedIframeLoadEvents = browserUtils.isWebKit && (!browserUtils.isChrome || browserUtils.isAndroid) ? 2 : 1; // GH-1966
     var countXhrLoadEvents             = 0;
-    var validCountXhrLoadEvents        = browserUtils.isWebKit && (!browserUtils.isChrome || browserUtils.isAndroid) ? 2 : 1;
+    var validCountXhrLoadEvents        = browserUtils.isWebKit && (!browserUtils.isChrome || browserUtils.isAndroid) ? 2 : 1; // GH-1966
 
     // NOTE: NetworkError occurs in IE11 after some Windows 10 update (iframe without src case) (GH-1837)
     var skipIframeCheck = false;
@@ -239,7 +239,7 @@ asyncTest('an error occurs when proxing two nested iframes (a top iframe has src
 asyncTest('native methods of the iframe document aren`t overridden for iframe with javascript src (GH-358)', function () {
     var iframe            = document.createElement('iframe');
     var loadEventCount    = 0;
-    var maxLoadEventCount = browserUtils.isWebKit && (!browserUtils.isChrome || browserUtils.isAndroid) ? 2 : 1;
+    var maxLoadEventCount = browserUtils.isWebKit && (!browserUtils.isChrome || browserUtils.isAndroid) ? 2 : 1; // GH-1966
 
     iframe.id = 'test_nmsghf';
     iframe.setAttribute('src', 'javascript:"<html><body>test</body></html>"');

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -177,9 +177,9 @@ test('quotes in the cookies are not escaped when a task script for an iframe is 
 asyncTest('an error occurs when proxing two nested iframes (a top iframe has src with javascript protocol) (GH-125)', function () {
     var iframe                         = document.createElement('iframe');
     var countNestedIframeLoadEvents    = 0;
-    var maxCountNestedIframeLoadEvents = browserUtils.isWebKit && !browserUtils.isChrome ? 2 : 1;
+    var maxCountNestedIframeLoadEvents = browserUtils.isWebKit && (!browserUtils.isChrome || browserUtils.isAndroid) ? 2 : 1;
     var countXhrLoadEvents             = 0;
-    var validCountXhrLoadEvents        = browserUtils.isWebKit && !browserUtils.isChrome ? 2 : 1;
+    var validCountXhrLoadEvents        = browserUtils.isWebKit && (!browserUtils.isChrome || browserUtils.isAndroid) ? 2 : 1;
 
     // NOTE: NetworkError occurs in IE11 after some Windows 10 update (iframe without src case) (GH-1837)
     var skipIframeCheck = false;
@@ -239,7 +239,7 @@ asyncTest('an error occurs when proxing two nested iframes (a top iframe has src
 asyncTest('native methods of the iframe document aren`t overridden for iframe with javascript src (GH-358)', function () {
     var iframe            = document.createElement('iframe');
     var loadEventCount    = 0;
-    var maxLoadEventCount = browserUtils.isWebKit && !browserUtils.isChrome ? 2 : 1;
+    var maxLoadEventCount = browserUtils.isWebKit && (!browserUtils.isChrome || browserUtils.isAndroid) ? 2 : 1;
 
     iframe.id = 'test_nmsghf';
     iframe.setAttribute('src', 'javascript:"<html><body>test</body></html>"');


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1966

### Changes:
1. Fix `maxCountNestedIframeLoadEvents` and `maxLoadEventCount` values.

### `onload` count check
```js
var count  = 0;
var iframe = document.createElement('iframe');

iframe.src    = 'javascript:(function(){document.open(); document.write(\'test\'); document.close();})();';
iframe.onload = function () {
    console.log('onload', ++count);
};

document.body.appendChild(iframe);
```