### PR TITLE
fix `hover does not fire pointerenter event` (close #1847)

### DIFF
--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -541,7 +541,7 @@ export default class EventSimulator {
         if (args.type !== 'mouseover' && args.type !== 'mouseenter' && shouldIgnoreMouseEventInsideIframe(el, args.clientX, args.clientY))
             return true;
 
-        const pointerRegExp = /mouse(down|up|move|over|out)/;
+        const pointerRegExp = /mouse(down|up|move|over|enter|out)/;
 
         // NOTE: In IE, submit doesn't work if a click is simulated for some submit button's children (for example,
         // img, B236676). In addition, if a test is being recorded in IE, the target of a click event is always a

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -387,16 +387,17 @@ asyncTest('mouse events in iframe', function () {
                 'mousemove',
                 'pointerover',
                 'mouseover',
+                'pointerenter',
                 'mouseenter',
                 'click',
                 'dblclick',
                 'contextmenu'
             ];
 
-            var eventsInsideFrame = ['pointerover', 'mouseover', 'mouseenter'];
+            var eventsInsideFrame = ['pointerover', 'mouseover', 'pointerenter', 'mouseenter'];
 
             if (!eventUtils.hasPointerEvents) {
-                const pointerRegExp = /pointer(down|up|move|over)/;
+                const pointerRegExp = /pointer(down|up|move|over|enter)/;
 
                 allEvents = allEvents.filter(function (eventName) {
                     return !pointerRegExp.test(eventName);


### PR DESCRIPTION
### Todo
- [x] ~~add `...out` events to the "mouse events in iframe" test?~~
- [ ] add test to `testcafe` repo. test/client/fixtures/automation/hover-test.js:
```js
asyncTest('check pointerover, pointerenter, mouseover and mouseenter events', function () {
    const el = document.createElement('div');

    el.setAttribute('style', 'width:200px; height:200px; background-color: #ff4a4c');

    document.body.appendChild(el);

    [
        'pointerover', 'pointerenter', 'mouseover', 'mouseenter'
    ]
        .forEach( function (event) {
            el.addEventListener(event, function () {
                ok(true);
            });
        });

    const hover = new HoverAutomation(el, new MouseOptions({ offsetX: 0, offsetY: 0 }));

    hover
        .run()
        .then(function () {
            expect(4);
            start();

            document.body.removeChild(el);
        });
});
```

https://github.com/DevExpress/testcafe-hammerhead/issues/1847

### Changes
1. Add `pointerenter` to the `mouseenter` related event.

### Notes
[Mouse Event and Pointer Event order: `over`, `enter`, `out`, `leave`. Example page](https://gist.github.com/Farfurix/0ecd6f523fdc9afe932894032d9ae5eb)