### PR TITLE
fix `The `change` event shouldn't be raised on an upload input if the value wasn't changed after `setFilesToUpload `` (close #1844)

### DIFF
--- a/src/client/sandbox/upload/index.ts
+++ b/src/client/sandbox/upload/index.ts
@@ -2,7 +2,7 @@ import INTERNAL_PROPS from '../../../processing/dom/internal-properties';
 import SandboxBase from '../base';
 import UploadInfoManager from './info-manager';
 import { isFileInput } from '../../utils/dom';
-import { isIE, isFirefox, version as browserVersion } from '../../utils/browser';
+import { isIE, isFirefox, isChrome, isMacPlatform, isSafari, version as browserVersion } from '../../utils/browser';
 import { stopPropagation, preventDefault } from '../../utils/event';
 import { get as getSandboxBackup } from '../backup';
 import nativeMethods from '../native-methods';
@@ -105,8 +105,8 @@ export default class UploadSandbox extends SandboxBase {
     }
 
     // GH-1844
-    static _isChangeEventNeeded (fileList, inputInfoFiles) : boolean {
-        if (isFirefox)
+    static _needToRaiseChangeEvent (fileList, inputInfoFiles) : boolean {
+        if (isFirefox || (isMacPlatform && isChrome || isSafari))
             return true;
 
         for (let i = 0; i < fileList.length; i++ ) {
@@ -142,7 +142,7 @@ export default class UploadSandbox extends SandboxBase {
 
                     /*eslint-disable no-restricted-properties*/
                     if (!inputInfo || data.fileList.length !== inputInfo.files.length ||
-                        UploadSandbox._isChangeEventNeeded(data.fileList, inputInfo.files))
+                        UploadSandbox._needToRaiseChangeEvent(data.fileList, inputInfo.files))
                         this._riseChangeEvent(input);
                     /*eslint-enable no-restricted-properties*/
                 }

--- a/src/client/sandbox/upload/index.ts
+++ b/src/client/sandbox/upload/index.ts
@@ -105,15 +105,15 @@ export default class UploadSandbox extends SandboxBase {
     }
 
     // GH-1844
-    static _needToRaiseChangeEvent (fileList, inputInfoFiles) : boolean {
+    static _needToRaiseChangeEvent (filesToUpload, currentFiles) : boolean {
         if (isFirefox || (isMacPlatform && isChrome || isSafari))
             return true;
 
-        for (let i = 0; i < fileList.length; i++ ) {
+        for (const file of filesToUpload) {
             let found = false;
 
-            for (let j = 0; j < inputInfoFiles.length; j++) {
-                if (fileList[i].name === inputInfoFiles[j].name) {
+            for (const currentFile of currentFiles) {
+                if (file.name === currentFile.name) {
                     found = true;
                     break;
                 }

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -575,8 +575,6 @@ test('change event in the case of the same file/files selection (GH-1844)', func
             return uploadSandbox.doUpload(fileInput, ['folder/file.png', './file.txt']);
         })
         .then(function () {
-            fileInput.onchange = changeHandler;
-
             return uploadSandbox.doUpload(fileInput, ['./file.txt', 'folder/file.png']);
         })
         .then(function () {

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -538,6 +538,47 @@ asyncTest('change event', function () {
     uploadSandbox.doUpload(fileInput, './file.txt');
 });
 
+test('change event in the case of the same file/files selection (GH-1844)', function () {
+    var assertionsCount     = browserUtils.isFirefox ? 4 : 0;
+    var isChangeEventNeeded = browserUtils.isFirefox;
+
+    expect(assertionsCount);
+
+    var fileInput = $('<input type="file" name="test" id="777">')[0];
+
+    var changeHandler = function () {
+        ok(isChangeEventNeeded);
+    };
+
+    return uploadSandbox.doUpload(fileInput, './file.txt')
+        .then(function () {
+            fileInput.onchange = changeHandler;
+
+            return uploadSandbox.doUpload(fileInput, './file.txt');
+        })
+        .then(function () {
+            return uploadSandbox.doUpload(fileInput, ['./file.txt']);
+        })
+        .then(function () {
+            fileInput.onchange = null;
+
+            return uploadSandbox.doUpload(fileInput, ['folder/file.png', './file.txt']);
+        })
+        .then(function () {
+            fileInput.onchange = changeHandler;
+
+            return uploadSandbox.doUpload(fileInput, ['folder/file.png', './file.txt']);
+        })
+        .then(function () {
+            fileInput.onchange = changeHandler;
+
+            return uploadSandbox.doUpload(fileInput, ['./file.txt', 'folder/file.png']);
+        })
+        .then(function () {
+            fileInput.onchange = null;
+        });
+});
+
 test('multi-select files', function () {
     var fileInput = $('<input type="file" name="test" id="id">')[0];
     var value     = '';

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -6,11 +6,16 @@ var INTERNAL_PROPS    = hammerhead.get('../processing/dom/internal-properties');
 
 var Promise        = hammerhead.Promise;
 var transport      = hammerhead.transport;
-var browserUtils   = hammerhead.utils.browser;
 var uploadSandbox  = hammerhead.sandbox.upload;
 var infoManager    = hammerhead.sandbox.upload.infoManager;
 var eventSimulator = hammerhead.sandbox.event.eventSimulator;
 var nativeMethods  = hammerhead.nativeMethods;
+
+var browserUtils  = hammerhead.utils.browser;
+var isChrome      = browserUtils.isChrome;
+var isFirefox     = browserUtils.isFirefox;
+var isSafari      = browserUtils.isSafari;
+var isMacPlatform = browserUtils.isMacPlatform;
 
 // ----- Server API mock ---------
 // Virtual file system:
@@ -539,8 +544,8 @@ asyncTest('change event', function () {
 });
 
 test('change event in the case of the same file/files selection (GH-1844)', function () {
-    var assertionsCount     = browserUtils.isFirefox ? 4 : 0;
-    var isChangeEventNeeded = browserUtils.isFirefox;
+    var isChangeEventNeeded = isFirefox || (isMacPlatform && isChrome || isSafari);
+    var assertionsCount     = isChangeEventNeeded ? 4 : 0;
 
     expect(assertionsCount);
 

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -544,15 +544,15 @@ asyncTest('change event', function () {
 });
 
 test('change event in the case of the same file/files selection (GH-1844)', function () {
-    var isChangeEventNeeded = isFirefox || (isMacPlatform && isChrome || isSafari);
-    var assertionsCount     = isChangeEventNeeded ? 4 : 0;
+    var needToRaiseChangeEvent = isFirefox || (isMacPlatform && isChrome || isSafari);
+    var assertionsCount        = needToRaiseChangeEvent ? 4 : 0;
 
     expect(assertionsCount);
 
     var fileInput = $('<input type="file" name="test" id="777">')[0];
 
     var changeHandler = function () {
-        ok(isChangeEventNeeded);
+        ok(needToRaiseChangeEvent);
     };
 
     return uploadSandbox.doUpload(fileInput, './file.txt')


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/1844

### Changes
1. Fix the `change` event behavior.

### Native `change` event behavior
Test page:
```html
<html>
<head></head>
<body>
    <label for="upload">Choose a file:</label>

    <input type="file" multiple="true" id="upload">

    <script>
        var uploadInput = document.getElementById('upload');

        ['change', 'input']
            .forEach(function (event) {
                uploadInput.addEventListener(event, function (e) {
                    console.log(e.type);
                });
            });
    </script>
</body>
</html>
```
Result:
```
Single select:
// Windows 10

Step 1: Select `file-1.txt`.
// Chrome, Firefox: input, change; Edge: change; IE11: change, input;

Step 2: Select `file-1.txt`.
// Firefox: input, change; Chrome, Edge, IE11: no events


// Multiple select:

Step 1: Select `file-1.txt`, `file-2.txt`.
// [macOS Mojave, Windows 10] Chrome: input, change; [macOS Mojave] Safari: change

Step 2: Select `file-1.txt`, `file-2.txt`.
// [macOS Mojave, Windows 10] Chrome: no events; [macOS Mojave] Safari: no events

Step 3: Select `file-2.txt`, `file-1.txt`.
// [Windows 10] Chrome: no events; [macOS Mojave] Chrome: input, change;
// [macOS Mojave] Safari: change
```
