### PR TITLE
dragstart and drop events added to DOM_EVENTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "14.6.0",
+  "version": "14.6.1",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/client/utils/event.ts
+++ b/src/client/utils/event.ts
@@ -27,11 +27,18 @@ export const KEYBOARD_MODIFIERS_PARAMETER = {
     metaKey:  'Meta'
 };
 
-export const DOM_EVENTS = ['click', 'mousedown', 'mouseup', 'dblclick', 'contextmenu', 'mousemove', 'mouseover',
-    'mouseout', 'touchstart', 'touchmove', 'touchend', 'keydown', 'keypress', 'textInput', 'textinput', 'input', 'keyup', 'change', 'focus', 'blur',
-    'MSPointerDown', 'MSPointerMove', 'MSPointerOver', 'MSPointerOut', 'MSPointerUp', 'pointerdown',
-    'pointermove', 'pointerover', 'pointerout', 'pointerup', 'focusin', 'focusout', 'mouseenter', 'mouseleave',
-    'pointerenter', 'pointerleave'];
+export const DOM_EVENTS = [
+    'click', 'dblclick', 'contextmenu',
+    'mousedown', 'mouseup', 'mousemove', 'mouseover', 'mouseout', 'mouseenter', 'mouseleave',
+    'touchstart', 'touchmove', 'touchend',
+    'keydown', 'keypress', 'keyup',
+    'textInput', 'textinput', 'input', 'change',
+    'focus', 'blur',
+    'MSPointerDown', 'MSPointerMove', 'MSPointerOver', 'MSPointerOut', 'MSPointerUp',
+    'pointerdown', 'pointermove', 'pointerover', 'pointerout', 'pointerup', 'pointerenter', 'pointerleave',
+    'dragstart', 'drop',
+    'focusin', 'focusout'
+];
 
 export function preventDefault (ev, allowBubbling?: boolean) {
     if (ev.preventDefault)


### PR DESCRIPTION
It required for Studio needs. We did a [fix](https://github.com/DevExpress/testcafe-studio/commit/de15eb14164a2d7d2dd04b08c61d12103b2ddb3c) but it doesn't work properly for some particular cases, e.g. [a bug](https://github.com/DevExpress/testcafe-studio/issues/2340). 
The best way to fix it is to export all required in recorder events in  `DOM_EVENTS` and then reuse it.
