### PR TITLE
Allow internal listeners to unsubscribe when executed (closes DevExpress/testcafe#3652)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@types/node": "^10.12.18",
     "babel-eslint": "8.2.1",
     "babel-plugin-add-module-exports": "^1.0.0",
-    "babel-plugin-transform-for-of-as-array": "1.1.1",
     "basic-auth": "1.0.4",
     "body-parser": "^1.18.3",
     "chai": "^2.3.0",

--- a/src/client/.babelrc
+++ b/src/client/.babelrc
@@ -10,6 +10,8 @@
   ],
   "plugins": [
     "babel-plugin-add-module-exports",
-    "babel-plugin-transform-for-of-as-array"
+    ["@babel/plugin-transform-for-of", {
+      "assumeArray": true
+    }]
   ]
 }

--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -131,7 +131,10 @@ export default class Listeners extends EventEmitter {
                 stopPropagation(e);
             };
 
-            for (const internalHandler of internalHandlers) {
+            // NOTE: Some listeners can remove itself when executed, so we need to copy the list of listeners here
+            const currentInternalHandlers = internalHandlers.slice(0);
+
+            for (const internalHandler of currentInternalHandlers) {
                 internalHandler.call(el, e, elWindow[EVENT_SANDBOX_DISPATCH_EVENT_FLAG], preventEvent, cancelHandlers, stopEventPropagation);
 
                 if (eventPrevented || stopPropagationCalled)

--- a/test/client/fixtures/sandbox/event/internal-listeners-test.js
+++ b/test/client/fixtures/sandbox/event/internal-listeners-test.js
@@ -492,6 +492,34 @@ test('only one of several handlers must be called (element handlers) (T233158)',
     $container.off('click', clickHandler);
 });
 
+test('should allow removing a listener inside a listener (testcafe/#3652', function () {
+    var event                       = 'click';
+    var expendableHandlerCallCount  = 0;
+    var normalHandlerCallCount      = 0;
+
+    function expendableHandler () {
+        expendableHandlerCallCount++;
+
+        listeners.removeInternalEventListener(container, [event], expendableHandler);
+    }
+
+    function normalEventHandler () {
+        normalHandlerCallCount++;
+    }
+
+    listeners.initElementListening(container, [event]);
+
+    listeners.addInternalEventListener(container, [event], normalEventHandler);
+    listeners.addInternalEventListener(container, [event], expendableHandler);
+    listeners.addInternalEventListener(container, [event], normalEventHandler);
+
+    dispatchEvent(container, event);
+    dispatchEvent(container, event);
+
+    strictEqual(normalHandlerCallCount, 4);
+    strictEqual(expendableHandlerCallCount, 1);
+});
+
 if (browserUtils.isIE) {
     test('only one of several handlers must be called (MSPointerDown, pointerdown combination) (T233158)', function () {
         var events              = browserUtils.isMSEdge ? 'pointerdown MSPointerDown' : 'pointerdown';


### PR DESCRIPTION
Closes DevExpress/testcafe#3652.

`babel-plugin-transform-for-of-as-array` caches an array length when transforming `for-of` cycles:
```js
for(const x of xs)

// Transformed To

for(var _i = 0, _length = xs.length; i < _length; ++i)
```

It can throw a runtime exception if an element is deleted from the array inside the cycle's body.

`babel/plugin-transform-for-of` produces a safer transpiled code:
```js
for(const x of xs)

// Transformed To

for(var _i = 0; i < xs._length; ++i)
```
