### PR TITLE
fix `form.elements.length has incorrect value if a form has a file input` (close #2009)

### DIFF
--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -694,6 +694,13 @@ export default class ShadowUI extends SandboxBase {
         el[INTERNAL_PROPS.shadowUIElement] = true;
     }
 
+    // GH-2009
+    static markFormAsShadow (form) {
+        ShadowUI.markAsShadowContainerCollection(form.elements);
+        ShadowUI.markAsShadowContainerCollection(form.children);
+        ShadowUI.markAsShadowContainerCollection(form.childNodes);
+    }
+
     static markElementAndChildrenAsShadow (el) {
         ShadowUI.markElementAsShadow(el);
 

--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -696,6 +696,7 @@ export default class ShadowUI extends SandboxBase {
 
     // GH-2009
     static markFormAsShadow (form) {
+        ShadowUI._markAsShadowContainer(form);
         ShadowUI.markAsShadowContainerCollection(form.elements);
         ShadowUI.markAsShadowContainerCollection(form.children);
         ShadowUI.markAsShadowContainerCollection(form.childNodes);

--- a/src/client/sandbox/upload/hidden-info.ts
+++ b/src/client/sandbox/upload/hidden-info.ts
@@ -14,6 +14,8 @@ function createInput (form) {
     nativeMethods.inputValueSetter.call(hiddenInput, '[]');
     nativeMethods.appendChild.call(form, hiddenInput);
 
+    ShadowUI.markFormAsShadow(form);
+
     return hiddenInput;
 }
 

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -159,7 +159,7 @@ function getFiles (filesInfo) {
 
 module('hidden info');
 
-test('hidden input should not affect both the length value (form.elements, form.children, form.childNodes) and childElementCount (GH-2009)', function () {
+test('hidden input should not affect both the length/count value and the elements order (GH-2009)', function () {
     var form   = document.createElement('form');
     var input1 = document.createElement('input');
     var input2 = document.createElement('input');
@@ -183,42 +183,35 @@ test('hidden input should not affect both the length value (form.elements, form.
         ].join('\n');
     }
 
+    function checkLength (expeсted) {
+        strictEqual(form.elements.length, expeсted);
+        strictEqual(form.children.length, expeсted);
+        strictEqual(form.childNodes.length, expeсted);
+        strictEqual(form.childElementCount, expeсted);
+    }
+
     return uploadSandbox.doUpload(input1, './file.txt')
         .then(function () {
-            strictEqual(form.elements.length, 1);
-            strictEqual(form.children.length, 1);
-            strictEqual(form.childNodes.length, 1);
-            strictEqual(form.childElementCount, 1);
+            checkLength(1);
+
+            strictEqual(form.firstChild, form.lastChild);
+            strictEqual(form.firstElementChild, form.lastElementChild);
+
 
             form.appendChild(input2);
 
-            return uploadSandbox.doUpload(input2, 'folder/file.png');
-        })
-        .then(function () {
-            strictEqual(form.elements.length, 2);
-            strictEqual(form.children.length, 2);
-            strictEqual(form.childNodes.length, 2);
-            strictEqual(form.childElementCount, 2);
-
-            strictEqual(form.elements[0], input1);
-            strictEqual(form.elements[1], input2);
-
-            strictEqual(form.children[0], input1);
-            strictEqual(form.children[1], input2);
-
-            strictEqual(form.childNodes[0], input1);
-            strictEqual(form.childNodes[1], input2);
-
-            strictEqual(form.firstChild, input1);
-            strictEqual(form.firstElementChild, input1);
-            strictEqual(form.lastChild, input2);
-            strictEqual(form.lastElementChild, input2);
+            checkLength(2);
 
             if (!browserUtils.isIE11) {
                 eval(getForOfLoopCode('form.elements'));
                 eval(getForOfLoopCode('form.children'));
                 eval(getForOfLoopCode('form.childNodes'));
             }
+
+            strictEqual(form.firstChild, input1);
+            strictEqual(form.firstElementChild, input1);
+            strictEqual(form.lastChild, input2);
+            strictEqual(form.lastElementChild, input2);
 
             form.parentNode.removeChild(form);
         });

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -160,18 +160,64 @@ function getFiles (filesInfo) {
 module('hidden info');
 
 test('hidden input should not affect both the length value (form.elements, form.children, form.childNodes) and childElementCount (GH-2009)', function () {
-    var form  = document.createElement('form');
-    var input = document.createElement('input');
+    var form   = document.createElement('form');
+    var input1 = document.createElement('input');
+    var input2 = document.createElement('input');
+
+    input1.id = 'input1';
+    input2.id = 'input2';
 
     document.body.appendChild(form);
-    form.appendChild(input);
+    form.appendChild(input1);
 
-    return uploadSandbox.doUpload(input, './file.txt')
+    var expectedElements = [input1, input2];
+
+    function testForOfLoop (iterable) {
+        var index = 0;
+
+        for (var el of iterable) {
+            strictEqual(el, expectedElements[index]);
+
+            index++;
+        }
+    }
+
+    return uploadSandbox.doUpload(input1, './file.txt')
         .then(function () {
             strictEqual(form.elements.length, 1);
             strictEqual(form.children.length, 1);
             strictEqual(form.childNodes.length, 1);
             strictEqual(form.childElementCount, 1);
+
+            form.appendChild(input2);
+
+            return uploadSandbox.doUpload(input2, 'folder/file.png');
+        })
+        .then(function () {
+            strictEqual(form.elements.length, 2);
+            strictEqual(form.children.length, 2);
+            strictEqual(form.childNodes.length, 2);
+            strictEqual(form.childElementCount, 2);
+
+            strictEqual(form.elements[0], input1);
+            strictEqual(form.elements[1], input2);
+
+            strictEqual(form.children[0], input1);
+            strictEqual(form.children[1], input2);
+
+            strictEqual(form.childNodes[0], input1);
+            strictEqual(form.childNodes[1], input2);
+
+            strictEqual(form.firstChild, input1);
+            strictEqual(form.firstElementChild, input1);
+            strictEqual(form.lastChild, input2);
+            strictEqual(form.lastElementChild, input2);
+
+            if (!browserUtils.isIE11) {
+                testForOfLoop(form.elements);
+                testForOfLoop(form.children);
+                testForOfLoop(form.childNodes);
+            }
 
             form.parentNode.removeChild(form);
         });

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -172,6 +172,8 @@ test('hidden input should not affect both the length value (form.elements, form.
             strictEqual(form.children.length, 1);
             strictEqual(form.childNodes.length, 1);
             strictEqual(form.childElementCount, 1);
+
+            form.parentNode.removeChild(form);
         });
 });
 

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -159,6 +159,21 @@ function getFiles (filesInfo) {
 
 module('hidden info');
 
+test('hidden input should not affect the length value (form.elements, form.children, form.childNodes) (GH-2009)', function () {
+    var form  = document.createElement('form');
+    var input = document.createElement('input');
+
+    document.body.appendChild(form);
+    form.appendChild(input);
+
+    return uploadSandbox.doUpload(input, ['./file.txt'])
+        .then(function () {
+            strictEqual(form.elements.length, 1);
+            strictEqual(form.children.length, 1);
+            strictEqual(form.childNodes.length, 1);
+        });
+});
+
 test('get/set upload info', function () {
     var fileInputWithoutForm = $('<input type="file">')[0];
     var fileInputWithForm    = $('<form><input type="file"></form>').children()[0];

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -159,18 +159,19 @@ function getFiles (filesInfo) {
 
 module('hidden info');
 
-test('hidden input should not affect the length value (form.elements, form.children, form.childNodes) (GH-2009)', function () {
+test('hidden input should not affect both the length value (form.elements, form.children, form.childNodes) and childElementCount (GH-2009)', function () {
     var form  = document.createElement('form');
     var input = document.createElement('input');
 
     document.body.appendChild(form);
     form.appendChild(input);
 
-    return uploadSandbox.doUpload(input, ['./file.txt'])
+    return uploadSandbox.doUpload(input, './file.txt')
         .then(function () {
             strictEqual(form.elements.length, 1);
             strictEqual(form.children.length, 1);
             strictEqual(form.childNodes.length, 1);
+            strictEqual(form.childElementCount, 1);
         });
 });
 

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -170,16 +170,17 @@ test('hidden input should not affect both the length value (form.elements, form.
     document.body.appendChild(form);
     form.appendChild(input1);
 
-    var expectedElements = [input1, input2];
+    var expectedElements = [input1, input2]; // eslint-disable-line no-unused-vars
 
-    function testForOfLoop (iterable) {
-        var index = 0;
-
-        for (var el of iterable) {
-            strictEqual(el, expectedElements[index]);
-
-            index++;
-        }
+    // NOTE: We are forced to use this hack because IE11 raises a syntax error if a page contains the 'for..of' loop
+    function getForOfLoopCode (iterableObjString) {
+        return [
+            'var index = 0;',
+            'for (var el of ' + iterableObjString + ') {',
+            '    strictEqual(el, expectedElements[index]);',
+            '    index++;',
+            '}'
+        ].join('\n');
     }
 
     return uploadSandbox.doUpload(input1, './file.txt')
@@ -214,9 +215,9 @@ test('hidden input should not affect both the length value (form.elements, form.
             strictEqual(form.lastElementChild, input2);
 
             if (!browserUtils.isIE11) {
-                testForOfLoop(form.elements);
-                testForOfLoop(form.children);
-                testForOfLoop(form.childNodes);
+                eval(getForOfLoopCode('form.elements'));
+                eval(getForOfLoopCode('form.children'));
+                eval(getForOfLoopCode('form.childNodes'));
             }
 
             form.parentNode.removeChild(form);


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/2009
https://github.com/DevExpress/testcafe-hammerhead/issues/2010

### Changes
1. Form with a hidden input: mark `form.elements`, `form.children` and `form.childNodes` as shadow collections.
2. Form with a hidden input: mark the form as a shadow container (the `childElementCount` case).