### PR TITLE
fix `calling overridden window.Worker should not cause the "use the 'new'..." error` (part of #1970)

### DIFF
--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -427,10 +427,10 @@ export default class WindowSandbox extends SandboxBase {
                 if (typeof scriptURL === 'string')
                     scriptURL = getProxyUrl(scriptURL, { resourceType: stringifyResourceType({ isScript: true }) });
 
-                if (arguments.length === 1)
-                    return isCalledWithoutNewKeyword ? nativeMethods.Worker.call(this, scriptURL) : new nativeMethods.Worker(scriptURL);
+                if (isCalledWithoutNewKeyword)
+                    return nativeMethods.Worker.apply(this, arguments);
 
-                return isCalledWithoutNewKeyword ? nativeMethods.Worker.call(this, scriptURL, options) : new nativeMethods.Worker(scriptURL, options);
+                return arguments.length === 1 ? new nativeMethods.Worker(scriptURL) : new nativeMethods.Worker(scriptURL, options);
             };
 
             window.Worker                       = WorkerWrapper;

--- a/test/client/fixtures/sandbox/node/classes-test.js
+++ b/test/client/fixtures/sandbox/node/classes-test.js
@@ -150,7 +150,7 @@ if (window.Worker) {
         }, TypeError);
     });
 
-    test('checking parameters (GH-1132', function () {
+    test('checking parameters (GH-1132)', function () {
         var savedNativeWorker = nativeMethods.Worker;
         var workerOptions     = { name: 'test' };
         var resourceType      = urlUtils.stringifyResourceType({ isScript: true });
@@ -173,15 +173,46 @@ if (window.Worker) {
 
         nativeMethods.Worker = savedNativeWorker;
     });
+
+    test('should work with the operator "instanceof" (GH-690)', function () {
+        var blob   = new Blob(['if(true) {}'], { type: 'text/javascript' });
+        var url    = URL.createObjectURL(blob);
+        var worker = new Worker(url);
+
+        ok(worker instanceof Worker);
+    });
+
+    test('calling overridden window.Worker should not cause the "use the \'new\'..." error (GH-1970)', function () {
+        expect(0);
+
+        var SavedWindowWorker = window.Worker;
+
+        window.Worker = function (scriptURL) {
+            return new SavedWindowWorker(scriptURL);
+        };
+
+        try {
+            // eslint-disable-next-line no-new
+            new Worker('/test');
+        }
+        catch (e) {
+            ok(false);
+        }
+
+        window.Worker = SavedWindowWorker;
+    });
+
+    test('calling Worker without the "new" keyword (GH-1970)', function () {
+        expect(browserUtils.isIE11 || browserUtils.isMSEdge ? 0 : 1);
+
+        try {
+            Worker('/test');
+        }
+        catch (e) {
+            ok(true);
+        }
+    });
 }
-
-test('should work with the operator "instanceof" (GH-690)', function () {
-    var blob   = new Blob(['if(true) {}'], { type: 'text/javascript' });
-    var url    = URL.createObjectURL(blob);
-    var worker = new Worker(url);
-
-    ok(worker instanceof Worker);
-});
 
 module('EventSource');
 


### PR DESCRIPTION
Part of https://github.com/DevExpress/testcafe-hammerhead/issues/1970

### Changes
1. Fix "constructor is called without the `new` keyword" check ("Constructor Worker requires 'new'..." user case).
2. Fix "calling without `new`" case (process `scriptURL`).