### PR TITLE
fix the "Get selection on input with "email" type" test in Firefox 68 (close #2071)

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -54,8 +54,7 @@ const CLIENT_TESTS_BROWSERS = [
     },
     {
         platform:    'Windows 10',
-        browserName: 'firefox',
-        version:     '67'
+        browserName: 'firefox'
     },
     {
         platform:    'Windows 10',
@@ -86,8 +85,7 @@ const CLIENT_TESTS_BROWSERS = [
     },
     {
         browserName: 'firefox',
-        platform:    'OS X 10.11',
-        version:     '67'
+        platform:    'OS X 10.11'
     }
 ];
 

--- a/src/client/sandbox/event/selection.ts
+++ b/src/client/sandbox/event/selection.ts
@@ -43,11 +43,11 @@ export default class Selection {
             const selectionSetter = () => {
                 // NOTE: These browsers cannot restore the `selectionStart` and `selectionEnd` properties when we change the `type` attribute.
                 // So we need to use our own mechanism to store the `selectionStart` and `selectionEnd` properties.
-                const shouldChangeType     = domUtils.isInputWithoutSelectionProperties(el);
+                const useInternalSelection = domUtils.isInputWithoutSelectionProperties(el);
                 const savedType            = el.type;
                 let res;
 
-                if (shouldChangeType)
+                if (useInternalSelection)
                     el.type = 'text';
 
                 // NOTE: In MSEdge, an error occurs when the setSelectionRange method is called for an input with
@@ -60,7 +60,7 @@ export default class Selection {
                     res = fn.call(el, 0, 0, selectionDirection);
                 }
 
-                if (shouldChangeType) {
+                if (useInternalSelection ) {
                     el[INTERNAL_PROPS.selection] = {
                         selectionStart:     el.selectionStart,
                         selectionEnd:       el.selectionEnd,

--- a/test/client/fixtures/sandbox/selection-test.js
+++ b/test/client/fixtures/sandbox/selection-test.js
@@ -47,7 +47,7 @@ test('Get selection on input with "email" type', function () {
     var input     = createTestInput('email', inputTestValue);
     var selection = selectionSandbox.getSelection(input);
 
-    var isNotSupportedBrowser = browserUtils.isFirefox && browserVersion < 51 || isIE || browserUtils.isChrome && browserVersion > 74;
+    var isNotSupportedBrowser = browserUtils.isFirefox && browserVersion > 67 || isIE || browserUtils.isChrome && browserVersion > 74;
 
     strictEqual(selection.start, isNotSupportedBrowser ? 0 : inputTestValue.length);
     strictEqual(selection.end, isNotSupportedBrowser ? 0 : inputTestValue.length);


### PR DESCRIPTION
### Todo
- [ ] check _skipped_ tests in `testcafe` : `only: 'chrome'`

https://github.com/DevExpress/testcafe-hammerhead/issues/2071

### Changes
1. Fix the Firefox 68 expected selection values (`start`, `end`) in the test. Remove the old version logic (Firefox 51).
2. Naming in **src/client/sandbox/event/selection.ts**: `shouldChangeType` --> `useInternalSelection` (in the context of https://github.com/DevExpress/testcafe-hammerhead/pull/2050/files#diff-404d6dc479ed092f7042f23d3de2fe57R147).

### Notes
https://github.com/DevExpress/testcafe-hammerhead/issues/2071#issuecomment-510801557