### PR TITLE
fix: remove stripping of www-authenticate header (reverts #974)

### DIFF
--- a/src/request-pipeline/header-transforms/transforms.ts
+++ b/src/request-pipeline/header-transforms/transforms.ts
@@ -151,9 +151,6 @@ export const responseTransforms = {
     'x-content-security-policy-report-only': skip,
     'x-webkit-csp':                          skip,
 
-    // NOTE: Even if we are not able to be authorized, we should prevent showing the native credentials window.
-    'www-authenticate': skip,
-
     // NOTE: We perform CORS checks on our side, so we skip the related headers.
     'access-control-allow-origin': skip,
 

--- a/test/server/auth-test.js
+++ b/test/server/auth-test.js
@@ -131,8 +131,6 @@ describe('Authentication', () => {
                 .catch(err => {
                     expect(err.statusCode).equal(401);
                     expect(err.error).equal('Access denied');
-                    // NOTE: prevent showing the native credentials window.
-                    expect(err.response.headers['www-authenticate']).to.be.undefined;
                 });
         });
 


### PR DESCRIPTION
This reverts PR #974 

The aforementioned PR does not make clear why the stripping of `www-authenticate` is necessary.

Regardless, this header is not uncommonly sent in request responses. We found that the application that we were testing is breaking because of the removal of this header from the response.

Please see [this article](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate) for more information on the `www-authenticate` header.