### PR TITLE
[WIP]

### DIFF
--- a/src/client/sandbox/code-instrumentation/index.ts
+++ b/src/client/sandbox/code-instrumentation/index.ts
@@ -33,9 +33,8 @@ export default class CodeInstrumentation extends SandboxBase {
         this._locationAccessorsInstrumentation.attach(window);
         this.elementPropertyAccessors = this._propertyAccessorsInstrumentation.attach(window);
 
-        // NOTE: In Google Chrome, iframes whose src contains html code raise the 'load' event twice.
-        // So, we need to define code instrumentation functions as 'configurable' so that they can be redefined.
-        // NOTE: GH-260
+        // NOTE: The browser's 'document' and 'window' can be overridden (for instance, after a 'document.write' call).
+        // So, we need to define all internal properties stored in the 'window' or 'document' with the 'configurable' option to be able to redefine them.
         nativeMethods.objectDefineProperty(window, INSTRUCTION.getEval, {
             value: (evalFn: Function) => {
                 // @ts-ignore

--- a/src/client/sandbox/code-instrumentation/location/index.ts
+++ b/src/client/sandbox/code-instrumentation/location/index.ts
@@ -48,8 +48,8 @@ export default class LocationAccessorsInstrumentation extends SandboxBase {
         const document        = window.document;
         const locationWrapper = new LocationWrapper(window, this._messageSandbox, this._locationChangedEventCallback);
 
-        // NOTE: In Google Chrome, iframes whose src contains html code raise the 'load' event twice.
-        // So, we need to define code instrumentation functions as 'configurable' so that they can be redefined.
+        // NOTE: The browser's 'document' and 'window' can be overridden (for instance, after a 'document.write' call).
+        // So, we need to define all internal properties stored in the 'window' or 'document' with the 'configurable' option to be able to redefine them.
         nativeMethods.objectDefineProperty(window, LOCATION_WRAPPER, { value: locationWrapper, configurable: true });
         nativeMethods.objectDefineProperty(document, LOCATION_WRAPPER, { value: locationWrapper, configurable: true });
         nativeMethods.objectDefineProperty(window, INSTRUCTION.getLocation, {

--- a/src/client/sandbox/code-instrumentation/methods.ts
+++ b/src/client/sandbox/code-instrumentation/methods.ts
@@ -62,8 +62,8 @@ export default class MethodCallInstrumentation extends SandboxBase {
     attach (window: Window) {
         super.attach(window);
 
-        // NOTE: In Google Chrome, iframes whose src contains html code raise the 'load' event twice.
-        // So, we need to define code instrumentation functions as 'configurable' so that they can be redefined.
+        // NOTE: The browser's 'document' and 'window' can be overridden (for instance, after a 'document.write' call).
+        // So, we need to define all internal properties stored in the 'window' or 'document' with the 'configurable' option to be able to redefine them.
         nativeMethods.objectDefineProperty(window, INSTRUCTION.callMethod, {
             value: (owner: any, methName: any, args: Array<any>) => {
                 if (typeUtils.isNullOrUndefined(owner))

--- a/src/client/sandbox/code-instrumentation/properties/index.ts
+++ b/src/client/sandbox/code-instrumentation/properties/index.ts
@@ -119,8 +119,8 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
         const accessors     = this._createPropertyAccessors();
         const windowSandbox = this._windowSandbox;
 
-        // NOTE: In Google Chrome, iframes whose src contains html code raise the 'load' event twice.
-        // So, we need to define code instrumentation functions as 'configurable' so that they can be redefined.
+        // NOTE: The browser's 'document' and 'window' can be overridden (for instance, after a 'document.write' call).
+        // So, we need to define all internal properties stored in the 'window' or 'document' with the 'configurable' option to be able to redefine them.
         nativeMethods.objectDefineProperty(window, INSTRUCTION.getProperty, {
             value: (owner, propName) => {
                 if (typeUtils.isNullOrUndefined(owner))

--- a/src/client/sandbox/console.ts
+++ b/src/client/sandbox/console.ts
@@ -3,6 +3,7 @@ import { isCrossDomainWindows } from '../utils/dom';
 import nativeMethods from '../sandbox/native-methods';
 /*eslint-disable no-unused-vars*/
 import MessageSandbox from './event/message';
+import { ConsoleMethodCalledServiceMessage } from '../../typings/proxy';
 /*eslint-enable no-unused-vars*/
 
 export default class ConsoleSandbox extends SandboxBase {
@@ -13,7 +14,7 @@ export default class ConsoleSandbox extends SandboxBase {
     constructor (private readonly _messageSandbox: MessageSandbox) { //eslint-disable-line no-unused-vars
         super();
 
-        this._serviceMsgReceivedEventCallback = ({ message }) => {
+        this._serviceMsgReceivedEventCallback = ({ message } : { message: ConsoleMethodCalledServiceMessage }) => {
             if (message.cmd === this.CONSOLE_METH_CALLED_EVENT)
                 this.emit(this.CONSOLE_METH_CALLED_EVENT, { meth: message.meth, line: message.line });
         };
@@ -47,7 +48,7 @@ export default class ConsoleSandbox extends SandboxBase {
         };
     }
 
-    attach (window: Window) {
+    attach (window: Window): void {
         super.attach(window);
 
         this._proxyConsoleMeth('log');

--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -101,7 +101,7 @@ export default class MessageSandbox extends SandboxBase {
         return { message, originUrl, targetUrl, type };
     }
 
-    private _removeInternalMsgFromQueue (sendFunc) {
+    private _removeInternalMsgFromQueue (sendFunc: Function) {
         for (let index = 0, length = this.iframeInternalMsgQueue.length; index < length; index++) {
             if (this.iframeInternalMsgQueue[index].sendFunc === sendFunc) {
                 this.iframeInternalMsgQueue.splice(index, 1);
@@ -136,8 +136,8 @@ export default class MessageSandbox extends SandboxBase {
         this._listeners.addInternalEventListener(window, ['message'], onMessageHandler);
         this._listeners.setEventListenerWrapper(window, ['message'], onWindowMessageHandler);
 
-        // NOTE: In Google Chrome, iframes whose src contains html code raise the 'load' event twice.
-        // So, we need to define code instrumentation functions as 'configurable' so that they can be redefined.
+        // NOTE: The browser's 'document' and 'window' can be overridden (for instance, after a 'document.write' call).
+        // So, we need to define all internal properties stored in the 'window' or 'document' with the 'configurable' option to be able to redefine them.
         nativeMethods.objectDefineProperty(window, this.RECEIVE_MSG_FN, {
             value:        onMessageHandler,
             configurable: true
@@ -199,7 +199,7 @@ export default class MessageSandbox extends SandboxBase {
         const canSendDirectly = !isCrossDomainWindows(targetWindow, this.window) && !!targetWindow[this.RECEIVE_MSG_FN];
 
         if (canSendDirectly) {
-            const sendFunc = force => {
+            const sendFunc = (force: boolean) => {
                 // NOTE: In IE, this function is called on the timeout despite the fact that the timer has been cleared
                 // in the unload event handler, so we check whether the function is in the queue
                 if (force || this._removeInternalMsgFromQueue(sendFunc)) {

--- a/src/client/sandbox/iframe.ts
+++ b/src/client/sandbox/iframe.ts
@@ -3,13 +3,12 @@ import SandboxBase from './base';
 import settings from '../settings';
 import nativeMethods from '../sandbox/native-methods';
 import { isShadowUIElement, isIframeWithoutSrc, getTagName } from '../utils/dom';
-import { isFirefox, isIE, isWebKit } from '../utils/browser';
+import { isFirefox, isIE } from '../utils/browser';
 // @ts-ignore
 import * as JSON from 'json-hammerhead';
 /*eslint-disable no-unused-vars*/
 import NodeMutation from './node/mutation';
 import CookieSandbox from './cookie';
-import DomProcessor from '../../processing/dom';
 /*eslint-enable no-unused-vars*/
 
 const IFRAME_WINDOW_INITED = 'hammerhead|iframe-window-inited';
@@ -19,8 +18,6 @@ export default class IframeSandbox extends SandboxBase {
     EVAL_HAMMERHEAD_SCRIPT_EVENT: string = 'hammerhead|event|eval-hammerhead-script';
     EVAL_EXTERNAL_SCRIPT_EVENT: string = 'hammerhead|event|eval-external-script';
     IFRAME_DOCUMENT_CREATED_EVENT: string = 'hammerhead|event|iframe-document-created';
-
-    shouldReinitializeIframe: boolean = false;
 
     constructor (private readonly _nodeMutation: NodeMutation, //eslint-disable-line no-unused-vars
                  private readonly _cookieSandbox: CookieSandbox) { //eslint-disable-line no-unused-vars
@@ -55,19 +52,6 @@ export default class IframeSandbox extends SandboxBase {
         this.emit(this.RUN_TASK_SCRIPT_EVENT, iframe);
     }
 
-    private _calculateNecessaryOfAdditionalInitialization (iframe: HTMLIFrameElement): void {
-        if (!isWebKit)
-            return;
-
-        const iframeSrc                      = this.nativeMethods.getAttribute.call(iframe, 'src');
-        const isIframeWithJavaScriptProtocol = DomProcessor.isJsProtocol(iframeSrc);
-
-        if (!isIframeWithJavaScriptProtocol)
-            return;
-
-        this.shouldReinitializeIframe = true;
-    }
-
     private _raiseReadyToInitEvent (iframe: HTMLIFrameElement) {
         if (!isIframeWithoutSrc(iframe))
             return;
@@ -82,9 +66,8 @@ export default class IframeSandbox extends SandboxBase {
             if (contentDocument.write.toString() === this.nativeMethods.documentWrite.toString())
                 this.emit(this.IFRAME_DOCUMENT_CREATED_EVENT, { iframe });
         }
-        else if (!contentWindow[IFRAME_WINDOW_INITED] && !contentWindow[INTERNAL_PROPS.hammerhead] || this.shouldReinitializeIframe) {
+        else if (!contentWindow[IFRAME_WINDOW_INITED] && !contentWindow[INTERNAL_PROPS.hammerhead]) {
             this._ensureIframeNativeMethodsForIE(iframe);
-            this._calculateNecessaryOfAdditionalInitialization(iframe);
 
             // NOTE: Ok, the iframe is fully loaded now, but Hammerhead is not injected.
             nativeMethods.objectDefineProperty(contentWindow, IFRAME_WINDOW_INITED, { value: true });

--- a/src/client/sandbox/iframe.ts
+++ b/src/client/sandbox/iframe.ts
@@ -20,7 +20,7 @@ export default class IframeSandbox extends SandboxBase {
     EVAL_EXTERNAL_SCRIPT_EVENT: string = 'hammerhead|event|eval-external-script';
     IFRAME_DOCUMENT_CREATED_EVENT: string = 'hammerhead|event|iframe-document-created';
 
-    needReinitializeIframe: boolean = false;
+    shouldReinitializeIframe: boolean = false;
 
     constructor (private readonly _nodeMutation: NodeMutation, //eslint-disable-line no-unused-vars
                  private readonly _cookieSandbox: CookieSandbox) { //eslint-disable-line no-unused-vars
@@ -65,7 +65,7 @@ export default class IframeSandbox extends SandboxBase {
         if (!isIframeWithJavaScriptProtocol)
             return;
 
-        this.needReinitializeIframe = true;
+        this.shouldReinitializeIframe = true;
     }
 
     private _raiseReadyToInitEvent (iframe: HTMLIFrameElement) {
@@ -82,7 +82,7 @@ export default class IframeSandbox extends SandboxBase {
             if (contentDocument.write.toString() === this.nativeMethods.documentWrite.toString())
                 this.emit(this.IFRAME_DOCUMENT_CREATED_EVENT, { iframe });
         }
-        else if (!contentWindow[IFRAME_WINDOW_INITED] && !contentWindow[INTERNAL_PROPS.hammerhead] || this.needReinitializeIframe) {
+        else if (!contentWindow[IFRAME_WINDOW_INITED] && !contentWindow[INTERNAL_PROPS.hammerhead] || this.shouldReinitializeIframe) {
             this._ensureIframeNativeMethodsForIE(iframe);
             this._calculateNecessaryOfAdditionalInitialization(iframe);
 

--- a/src/client/sandbox/iframe.ts
+++ b/src/client/sandbox/iframe.ts
@@ -105,6 +105,7 @@ export default class IframeSandbox extends SandboxBase {
     }
 
     static isWindowInited (window: Window) {
+        // @ts-ignore
         return window[IFRAME_WINDOW_INITED];
     }
 

--- a/src/client/sandbox/node/index.ts
+++ b/src/client/sandbox/node/index.ts
@@ -125,8 +125,8 @@ export default class NodeSandbox extends SandboxBase {
             this.doc.attach(contentWindow, contentDocument);
         });
 
-        // NOTE: In Google Chrome, iframes whose src contains html code raise the 'load' event twice.
-        // So, we need to define code instrumentation functions as 'configurable' so that they can be redefined.
+        // NOTE: The browser's 'document' and 'window' can be overridden (for instance, after a 'document.write' call).
+        // So, we need to define all internal properties stored in the 'window' or 'document' with the 'configurable' option to be able to redefine them.
         nativeMethods.objectDefineProperty(window, INTERNAL_PROPS.processDomMethodName, {
             value: (el, doc) => {
                 // NOTE: TestCafe creates a shadow-ui root before the DOMContentLoaded event (once document.body is

--- a/src/client/utils/cookie.ts
+++ b/src/client/utils/cookie.ts
@@ -5,7 +5,7 @@ const COOKIE_PAIR_REGEX        = /^((?:=)?([^=;]*)\s*=\s*)?([^\n\r\0]*)/;
 const TRAILING_SEMICOLON_REGEX = /;+$/;
 const FIX_COOKIE_DATE          = /((?:\s|,)[0-9]{1,2})(?:\s|-)([A-Za-z]{3})(?:\s|-)([0-9]{4}\s)/;
 
-export function parse (str) {
+export function parse (str: string) {
     str = trim(str);
 
     const trailingSemicolonCheck = TRAILING_SEMICOLON_REGEX.exec(str);
@@ -38,8 +38,8 @@ export function parse (str) {
     while (attrValStrings.length) {
         const attrValueStr = attrValStrings.shift();
         const separatorIdx = attrValueStr.indexOf('=');
-        let key            = null;
-        let value          = null;
+        let key            = '';
+        let value          = '';
         let date           = null;
 
         if (separatorIdx === -1)
@@ -100,7 +100,7 @@ export function formatClientString (parsedCookie) {
     return cookieStr;
 }
 
-export function setDefaultValues (parsedCookie, { hostname, pathname }) {
+export function setDefaultValues (parsedCookie, { hostname, pathname }: { hostname: string, pathname: string }) {
     if (!parsedCookie.domain)
         parsedCookie.domain = hostname; // eslint-disable-line no-restricted-properties
 
@@ -115,7 +115,7 @@ export function setDefaultValues (parsedCookie, { hostname, pathname }) {
         parsedCookie.expires = 'Infinity';
 }
 
-export function domainMatch (currentDomain, cookieDomain) {
+export function domainMatch (currentDomain: string, cookieDomain: string) {
     if (!cookieDomain)
         return true;
 
@@ -132,7 +132,7 @@ export function domainMatch (currentDomain, cookieDomain) {
            currentDomain.charAt(cookieDomainIdx - 1) === '.';
 }
 
-export function pathMatch (currentPath, cookiePath) {
+export function pathMatch (currentPath: string, cookiePath: string) {
     if (!cookiePath || cookiePath.charAt(0) !== '/' || currentPath === cookiePath)
         return true;
 

--- a/src/client/utils/html.ts
+++ b/src/client/utils/html.ts
@@ -261,6 +261,7 @@ export function cleanUpHtml (html) {
             const innerHtml = nativeMethods.elementInnerHTMLGetter.call(el);
 
             if (innerHtml.indexOf(INIT_SCRIPT_FOR_IFRAME_TEMPLATE) !== -1) {
+                debugger;
                 nativeMethods.elementInnerHTMLSetter.call(el, innerHtml.replace(INIT_SCRIPT_FOR_IFRAME_TEMPLATE, ''));
 
                 changed = true;
@@ -319,6 +320,7 @@ export function processHtml (html, options: ProcessHTMLOptions = {}) {
         if (!parentTag) {
             if (htmlElements.length) {
                 for (const htmlElement of htmlElements) {
+                    debugger;
                     const firstScriptOrStyle = nativeMethods.elementQuerySelector.call(htmlElement, SCRIPT_AND_STYLE_SELECTOR);
 
                     if (firstScriptOrStyle)

--- a/src/client/utils/html.ts
+++ b/src/client/utils/html.ts
@@ -261,7 +261,6 @@ export function cleanUpHtml (html) {
             const innerHtml = nativeMethods.elementInnerHTMLGetter.call(el);
 
             if (innerHtml.indexOf(INIT_SCRIPT_FOR_IFRAME_TEMPLATE) !== -1) {
-                debugger;
                 nativeMethods.elementInnerHTMLSetter.call(el, innerHtml.replace(INIT_SCRIPT_FOR_IFRAME_TEMPLATE, ''));
 
                 changed = true;
@@ -320,7 +319,6 @@ export function processHtml (html, options: ProcessHTMLOptions = {}) {
         if (!parentTag) {
             if (htmlElements.length) {
                 for (const htmlElement of htmlElements) {
-                    debugger;
                     const firstScriptOrStyle = nativeMethods.elementQuerySelector.call(htmlElement, SCRIPT_AND_STYLE_SELECTOR);
 
                     if (firstScriptOrStyle)

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -3,7 +3,7 @@ import net from 'net';
 import Session from '../session';
 import { ExternalProxySettingsRaw } from '../typings/session';
 import Router from './router';
-import { StaticContent, ServiceMessage, ServerInfo } from '../typings/proxy';
+import { StaticContent, ServerServiceMessage, ServerInfo } from '../typings/proxy';
 /*eslint-enable no-unused-vars*/
 import http from 'http';
 import https from 'https';
@@ -18,7 +18,7 @@ import SERVICE_ROUTES from './service-routes';
 
 const SESSION_IS_NOT_OPENED_ERR: string = 'Session is not opened in proxy';
 
-function parseAsJson (msg: Buffer): ServiceMessage | null {
+function parseAsJson (msg: Buffer): ServerServiceMessage | null {
     try {
         return JSON.parse(msg.toString());
     }

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -1,6 +1,6 @@
 /*eslint-disable no-unused-vars*/
 import Proxy from '../proxy';
-import { ServerInfo, ServiceMessage } from '../typings/proxy';
+import { ServerInfo, ServerServiceMessage } from '../typings/proxy';
 import RequestPipelineContext from '../request-pipeline/context';
 import RequestFilterRule from '../request-pipeline/request-hooks/request-filter-rule';
 import ResponseMock from '../request-pipeline/request-hooks/response-mock';
@@ -102,7 +102,7 @@ export default abstract class Session extends EventEmitter {
         this.pendingStateSnapshot = snapshot;
     }
 
-    async handleServiceMessage (msg: ServiceMessage, serverInfo: ServerInfo): Promise<object> {
+    async handleServiceMessage (msg: ServerServiceMessage, serverInfo: ServerInfo): Promise<object> {
         if (this[msg.cmd])
             return await this[msg.cmd](msg, serverInfo);
 

--- a/src/typings/proxy.d.ts
+++ b/src/typings/proxy.d.ts
@@ -6,9 +6,17 @@ export interface ServerInfo {
     domain: string
 }
 
-export interface ServiceMessage {
-    sessionId: string;
+export interface BaseServiceMessage {
     cmd: string;
+}
+
+export interface ServerServiceMessage extends BaseServiceMessage {
+    sessionId: string;
+}
+
+export interface ConsoleMethodCalledServiceMessage extends BaseServiceMessage {
+    meth: string;
+    line: string;
 }
 
 export interface StaticContent {

--- a/src/typings/upload.d.ts
+++ b/src/typings/upload.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import { ServiceMessage } from './proxy';
+import { ServerServiceMessage } from './proxy';
 /* eslint-enable no-unused-vars */
 
 export interface FileInfo {
@@ -14,11 +14,11 @@ export interface FileInputInfo {
     value: string;
 }
 
-export interface GetUploadedFilesServiceMessage extends ServiceMessage {
+export interface GetUploadedFilesServiceMessage extends ServerServiceMessage {
     filePaths: Array<string>;
 }
 
-export interface StoreUploadedFilesServiceMessage extends ServiceMessage {
+export interface StoreUploadedFilesServiceMessage extends ServerServiceMessage {
     data: Array<string>;
     fileNames: Array<string>;
 }


### PR DESCRIPTION
Changes:
* fix in the `src/client/sandbox/iframe.ts` file
* update comment - `In Google Chrome, iframes whose src contains html code raise the 'load' event twice.` It's outdated information. Since 73 version, Chrome raised only 1 'load' event. But we still necessary override iframe several times.
* small amount of typings