### PR TITLE
Fix 'Clicking anchor tags does not navigate to target destinations' (close #2080)

### DIFF
--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -63,7 +63,7 @@ function isLocationByProto (instance: any): boolean {
 
     return instanceCtor &&
         (nativeMethods.objectToString.call(instanceCtor) === '[object LocationPrototype]' ||
-         nativeMethods.objectToString.call(instanceCtor) === '[object Location]'); // "iPhone" Chrome device emulation case (GH-2080)
+         nativeMethods.objectToString.call(instanceCtor) === '[object Location]'); // NOTE: "iPhone" Chrome device emulation case (GH-2080)
 }
 
 function closestFallback (el: Node, selector: string) {

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -63,7 +63,7 @@ function isLocationByProto (instance: any): boolean {
 
     return instanceCtor &&
         (nativeMethods.objectToString.call(instanceCtor) === '[object LocationPrototype]' ||
-         nativeMethods.objectToString.call(instanceCtor) === '[object Location]'); // Chrome device emulation case (GH-2080)
+         nativeMethods.objectToString.call(instanceCtor) === '[object Location]'); // "iPhone" Chrome device emulation case (GH-2080)
 }
 
 function closestFallback (el: Node, selector: string) {

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -61,9 +61,13 @@ function isLocationByProto (instance: any): boolean {
         return instance.replace && (isSafari || !!instance.assign);
     }
 
-    return instanceCtor &&
-        (nativeMethods.objectToString.call(instanceCtor) === '[object LocationPrototype]' ||
-         nativeMethods.objectToString.call(instanceCtor) === '[object Location]'); // NOTE: "iPhone" Chrome device emulation case (GH-2080)
+    if (!instanceCtor)
+        return false;
+
+    const stringifiedInstanceCtor = nativeMethods.objectToString.call(instanceCtor);
+
+    return stringifiedInstanceCtor === '[object LocationPrototype]' ||
+        stringifiedInstanceCtor === '[object Location]'; // NOTE: "iPhone" Chrome device emulation case (GH-2080)
 }
 
 function closestFallback (el: Node, selector: string) {

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -61,7 +61,9 @@ function isLocationByProto (instance: any): boolean {
         return instance.replace && (isSafari || !!instance.assign);
     }
 
-    return instanceCtor && nativeMethods.objectToString.call(instanceCtor) === '[object LocationPrototype]';
+    return instanceCtor &&
+        (nativeMethods.objectToString.call(instanceCtor) === '[object LocationPrototype]' ||
+         nativeMethods.objectToString.call(instanceCtor) === '[object Location]'); // Chrome device emulation case (GH-2080)
 }
 
 function closestFallback (el: Node, selector: string) {

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -97,6 +97,21 @@ test('"isLocation" (GH-1863)', function () {
     ok(!domUtils.isLocation(locationCopy));
 });
 
+if (browserUtils.isChrome) {
+    test('"isLocation" in the case of the "iPhone" Chrome emulation mode (GH-2080)', function () {
+        var storedIsSafariValue = browserUtils.isSafari;
+
+        browserUtils.isSafari = true; // We set it to "true" to test the "iPhone" Chrome emulation mode (GH-2080)
+
+        var locationCopy = extend({}, window.location);
+
+        ok(domUtils.isLocation(window.location));
+        ok(!domUtils.isLocation(locationCopy));
+
+        browserUtils.isSafari = storedIsSafariValue;
+    });
+}
+
 test('iframe with empty src', function () {
     function assert (iframe) {
         new CodeInstrumentation({}, messageSandbox).attach(iframe.contentWindow);

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -101,7 +101,7 @@ if (browserUtils.isChrome) {
     test('"isLocation" in the case of the "iPhone" Chrome emulation mode (GH-2080)', function () {
         var storedIsSafariValue = browserUtils.isSafari;
 
-        browserUtils.isSafari = true; // We set it to "true" to test the "iPhone" Chrome emulation mode (GH-2080)
+        browserUtils.isSafari = true; // NOTE: we set it to "true" to test the "iPhone" Chrome emulation mode (GH-2080)
 
         var locationCopy = extend({}, window.location);
 


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/issues/2080

### Changes
1. Fix `isLocationByProto` in the case of the "iPhone X" Chrome emulation mode.

### Details
"iPhone X" Chrome emulation mode (before the fix):
`__get$Loc(location)` -> `isLocation()` -> `_browser.isSafari === true` (emulation mode) -> `isLocationByProto()`:
```js
return instanceCtor && _nativeMethods.default.objectToString.call(instanceCtor) === '[object LocationPrototype]';
// _nativeMethods.default.objectToString.call(instanceCtor) === [object Location]
```

### `browserUtils` differences
"-" - Chrome 76 (no emulation mode)
"+" - Chrome 76 ("iPhone X" emulation mode).
```diff
- fullVersion: "76.0"
+ fullVersion: "11.0"
isAndroid: false
- isChrome: true
+ isChrome: false
isElectron: false
isFirefox: false
isIE: false
isIE9: false
isIE10: false
isIE11: false
- isIOS: false
+ isIOS: true
isMSEdge: false
isMacPlatform: false
- isMobile: false
+ isMobile: true
- isSafari: false
+ isSafari: true
isTablet: false
isWebKit: true
- version: 76
+ version: 11
- webkitVersion: "537.36"
+ webkitVersion: "604.1.38"
```