### PR TITLE
Remove RequestPipelineContent.__getDestFromReferer and fix regression for #738

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -28,6 +28,14 @@ export const SPECIAL_PAGES: Array<string>                = [SPECIAL_BLANK_PAGE, 
 export const HTTP_DEFAULT_PORT: string  = '80';
 export const HTTPS_DEFAULT_PORT: string = '443';
 
+const SPECIAL_PAGE_DEST_RESOURCE_INFO = {
+    protocol:      'about:',
+    host:          '',
+    hostname:      '',
+    port:          '',
+    partAfterHost: ''
+};
+
 export function parseResourceType (resourceType: string): ResourceType {
     if (!resourceType) {
         return {
@@ -192,7 +200,7 @@ export function parseProxyUrl (proxyUrl: string): ParsedProxyUrl | null {
     if (!parsedDesc)
         return null;
 
-    const destUrl = match[2];
+    let destUrl = match[2];
 
     // Browser can redirect to a special page with hash (GH-1671)
     const destUrlWithoutHash = destUrl.replace(/#[\S\s]*$/, '');
@@ -200,13 +208,14 @@ export function parseProxyUrl (proxyUrl: string): ParsedProxyUrl | null {
     if (!isSpecialPage(destUrlWithoutHash) && !SUPPORTED_PROTOCOL_RE.test(destUrl))
         return null;
 
-    const destResourceInfo = !isSpecialPage(destUrlWithoutHash) ? parseUrl(omitDefaultPort(destUrl)) : {
-        protocol:      'about:',
-        host:          '',
-        hostname:      '',
-        port:          '',
-        partAfterHost: ''
-    };
+    let destResourceInfo = null;
+
+    if (isSpecialPage(destUrlWithoutHash))
+        destResourceInfo = SPECIAL_PAGE_DEST_RESOURCE_INFO;
+    else {
+        destUrl          = omitDefaultPort(destUrl);
+        destResourceInfo = parseUrl(destUrl);
+    }
 
     return {
         destUrl,

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -3185,48 +3185,32 @@ describe('Proxy', () => {
         it('Should omit default ports from destination request and `referrer` header urls (GH-738)', () => {
             const testCases              = [
                 {
-                    url:          'http://example.com:80',
-                    expectedHost: 'example.com',
-                    expectedPort: ''
+                    url:             'http://example.com:80',
+                    expectedHost:    'example.com',
+                    expectedPort:    '',
+                    referer:         'http://1.example.com:80',
+                    expectedReferer: 'http://1.example.com',
                 },
                 {
-                    url:          'http://example.com:8080',
-                    expectedHost: 'example.com:8080',
-                    expectedPort: '8080'
+                    url:             'http://example.com:8080',
+                    expectedHost:    'example.com:8080',
+                    expectedPort:    '8080',
+                    referer:         'http://1.example.com:8080',
+                    expectedReferer: 'http://1.example.com:8080',
                 },
                 {
-                    url:          'https://example.com:443',
-                    expectedHost: 'example.com',
-                    expectedPort: ''
+                    url:             'https://example.com:443',
+                    expectedHost:    'example.com',
+                    expectedPort:    '',
+                    referer:         'https://1.example.com:443',
+                    expectedReferer: 'https://1.example.com',
                 },
                 {
-                    url:          'https://example.com:443443',
-                    expectedHost: 'example.com:443443',
-                    expectedPort: '443443'
-                },
-                {
-                    url:          '<value>',
-                    referer:      'http://example.com:80',
-                    expectedHost: 'example.com',
-                    expectedPort: ''
-                },
-                {
-                    url:          '<value>',
-                    referer:      'http://example.com:8080',
-                    expectedHost: 'example.com:8080',
-                    expectedPort: '8080'
-                },
-                {
-                    url:          '<value>',
-                    referer:      'https://example.com:443',
-                    expectedHost: 'example.com',
-                    expectedPort: ''
-                },
-                {
-                    url:          '<value>',
-                    referer:      'https://example.com:443443',
-                    expectedHost: 'example.com:443443',
-                    expectedPort: '443443'
+                    url:             'https://example.com:44344',
+                    expectedHost:    'example.com:44344',
+                    expectedPort:    '44344',
+                    referer:         'https://1.example.com:44344',
+                    expectedReferer: 'https://1.example.com:44344',
                 }
             ];
             const req = {
@@ -3257,6 +3241,7 @@ describe('Proxy', () => {
 
                 expect(ctx.dest.host).eql(testCase.expectedHost);
                 expect(ctx.dest.port).eql(testCase.expectedPort);
+                expect(ctx.dest.referer).eql(testCase.expectedReferer);
             }
         });
 


### PR DESCRIPTION
Changes:
* remove `RequestPipelineContent.__getDestFromReferer` function
* refix #738 because of the `referer` header was not corrected now.
* small refactoring