### PR TITLE
scroll to element that is in shadow root (required for #4222 in TestCafe)

### DIFF
--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -754,21 +754,25 @@ export function parseDocumentCharset () {
 }
 
 export function getParents (el, selector?) {
-    // eslint-disable-next-line no-restricted-properties
-    let parent = nativeMethods.nodeParentNodeGetter.call(el) || el.host;
-
     const parents = [];
 
+    let parent = getParent(el);
+
     while (parent) {
-        if (!selector && isElementNode(parent) ||
-            selector && matches(parent, selector))
+        if (!selector && isElementNode(parent) || selector && matches(parent, selector))
             parents.push(parent);
 
-        // eslint-disable-next-line no-restricted-properties
-        parent = nativeMethods.nodeParentNodeGetter.call(parent) || parent.host;
+        parent = getParent(parent);
     }
 
     return parents;
+}
+
+function getParent (el) {
+    el = el.assignedSlot || el;
+
+    // eslint-disable-next-line no-restricted-properties
+    return nativeMethods.nodeParentNodeGetter.call(el) || el.host;
 }
 
 export function findParent (node, includeSelf = false, predicate) {

--- a/test/client/fixtures/utils/dom-test.js
+++ b/test/client/fixtures/utils/dom-test.js
@@ -969,6 +969,38 @@ test('isInputWithNativeDialog', function () {
         expect(0);
 });
 
+test('should return active element inside shadow DOM', function () {
+    var template = document.createElement('template');
+
+    template.innerHTML = '<div class=\'slot-parent\'><slot name=\'slot-name\'></slot></div>';
+
+    customElements.define('custom-test-element', class extends HTMLElement {
+        constructor () {
+            super();
+
+            var templateContent = template.content;
+
+            this.attachShadow({ mode: 'open' }).appendChild(templateContent.cloneNode(true));
+        }
+    });
+
+    var custom = document.createElement('custom-test-element');
+    var button = document.createElement('button');
+
+    custom.innerHTML = '<div class="div-slot" slot="slot-name"></div>';
+    button.innerHTML = 'Click me';
+
+    var slotParent   = custom.shadowRoot.querySelector('div.slot-parent');
+    var slotContent  = custom.querySelector('div.div-slot');
+
+    slotContent.appendChild(button);
+    document.body.appendChild(custom);
+
+    deepEqual(domUtils.getParents(button), [slotContent, slotParent, custom, document.body, document.documentElement]);
+
+    document.body.removeChild(custom);
+});
+
 if (browserUtils.isChrome) {
     test('should return active element inside shadow DOM', function () {
         var host  = document.createElement('div');

--- a/test/client/fixtures/utils/dom-test.js
+++ b/test/client/fixtures/utils/dom-test.js
@@ -969,38 +969,6 @@ test('isInputWithNativeDialog', function () {
         expect(0);
 });
 
-test('should return active element inside shadow DOM', function () {
-    var template = document.createElement('template');
-
-    template.innerHTML = '<div class=\'slot-parent\'><slot name=\'slot-name\'></slot></div>';
-
-    customElements.define('custom-test-element', class extends HTMLElement {
-        constructor () {
-            super();
-
-            var templateContent = template.content;
-
-            this.attachShadow({ mode: 'open' }).appendChild(templateContent.cloneNode(true));
-        }
-    });
-
-    var custom = document.createElement('custom-test-element');
-    var button = document.createElement('button');
-
-    custom.innerHTML = '<div class="div-slot" slot="slot-name"></div>';
-    button.innerHTML = 'Click me';
-
-    var slotParent   = custom.shadowRoot.querySelector('div.slot-parent');
-    var slotContent  = custom.querySelector('div.div-slot');
-
-    slotContent.appendChild(button);
-    document.body.appendChild(custom);
-
-    deepEqual(domUtils.getParents(button), [slotContent, slotParent, custom, document.body, document.documentElement]);
-
-    document.body.removeChild(custom);
-});
-
 if (browserUtils.isChrome) {
     test('should return active element inside shadow DOM', function () {
         var host  = document.createElement('div');
@@ -1059,6 +1027,38 @@ if (window.HTMLElement.prototype.createShadowRoot) {
 
         deepEqual(parents, [div, host, document.body, document.documentElement]);
         document.body.removeChild(host);
+    });
+
+    test('"getParents" should work property for elements with slots/templates', function () {
+        var template = document.createElement('template');
+
+        template.innerHTML = '<div class=\'slot-parent\'><slot name=\'slot-name\'></slot></div>';
+
+        customElements.define('custom-test-element', class extends HTMLElement {
+            constructor () {
+                super();
+
+                var templateContent = template.content;
+
+                this.attachShadow({ mode: 'open' }).appendChild(templateContent.cloneNode(true));
+            }
+        });
+
+        var custom = document.createElement('custom-test-element');
+        var button = document.createElement('button');
+
+        custom.innerHTML = '<div class="div-slot" slot="slot-name"></div>';
+        button.innerHTML = 'Click me';
+
+        var slotParent  = custom.shadowRoot.querySelector('div.slot-parent');
+        var slotContent = custom.querySelector('div.div-slot');
+
+        slotContent.appendChild(button);
+        document.body.appendChild(custom);
+
+        deepEqual(domUtils.getParents(button), [slotContent, slotParent, custom, document.body, document.documentElement]);
+
+        document.body.removeChild(custom);
     });
 }
 

--- a/test/client/fixtures/utils/dom-test.js
+++ b/test/client/fixtures/utils/dom-test.js
@@ -1034,15 +1034,16 @@ if (window.HTMLElement.prototype.createShadowRoot) {
 
         template.innerHTML = '<div class=\'slot-parent\'><slot name=\'slot-name\'></slot></div>';
 
-        customElements.define('custom-test-element', class extends HTMLElement {
-            constructor () {
-                super();
-
-                var templateContent = template.content;
-
-                this.attachShadow({ mode: 'open' }).appendChild(templateContent.cloneNode(true));
-            }
-        });
+        // NOTE: bypass IE syntax validation
+        customElements.define('custom-test-element', eval(
+            '(class El extends HTMLElement { ' +
+            'constructor () { ' +
+            '   super(); ' +
+            '   var templateContent = template.content; ' +
+            '   this.attachShadow({ mode: \'open\' }).appendChild(templateContent.cloneNode(true)); ' +
+            '} ' +
+        '})'
+        ));
 
         var custom = document.createElement('custom-test-element');
         var button = document.createElement('button');


### PR DESCRIPTION
the `getParent` method of `element` with the `assignedSlot` property defined should return the parent of `assignedSlot`. This means that `element.parentNode` !== `element.assignedSlot.parentNode`

Here is corresponding PR in the TestCafe repo: https://github.com/DevExpress/testcafe/pull/4397