### PR TITLE
Fix the expected "border-top-width" values

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -73,13 +73,12 @@ const CLIENT_TESTS_BROWSERS = [
         platformVersion: '11.3',
         platformName:    'iOS'
     },
-    // NOTE: Temporarily disabled, see https://github.com/DevExpress/testcafe-hammerhead/pull/2224
-    /*{
+    {
         deviceName:      'Android GoogleAPI Emulator',
         browserName:     'Chrome',
         platformVersion: '7.1',
         platformName:    'Android'
-    },*/
+    },
     {
         browserName: 'chrome',
         platform:    'OS X 10.11'

--- a/test/client/fixtures/utils/style-test.js
+++ b/test/client/fixtures/utils/style-test.js
@@ -10,7 +10,7 @@ test('getBordersWidth', function () {
     };
     var initCssStr = 'border-color: black; border-style: solid';
 
-    function nativeSetMediumBorderTopWidth (el) {
+    function setMediumBorderTopWidthNatively (el) {
         var elStyle = nativeMethods.htmlElementStyleGetter.call(el);
 
         return nativeMethods.styleSetProperty.call(elStyle, 'border-top-width', 'medium');
@@ -25,13 +25,16 @@ test('getBordersWidth', function () {
 
         var defaultValue = styleUtils.getBordersWidth(nativeDiv).top;
 
-        nativeSetMediumBorderTopWidth(nativeDiv);
+        setMediumBorderTopWidthNatively(nativeDiv);
 
         var mediumValue = styleUtils.getBordersWidth(nativeDiv).top;
 
         nativeMethods.removeChild.call(document.body, nativeDiv);
 
-        return { defaultValue: defaultValue, mediumValue: mediumValue };
+        return {
+            defaultValue: defaultValue,
+            mediumValue:  mediumValue
+        };
     }
 
     var nativeWidth = getNativeBorderTopWidthConstants();

--- a/test/client/fixtures/utils/style-test.js
+++ b/test/client/fixtures/utils/style-test.js
@@ -1,22 +1,49 @@
 var styleUtils       = hammerhead.utils.style;
 var browserUtils     = hammerhead.utils.browser;
 var featureDetection = hammerhead.utils.featureDetection;
+var nativeMethods    = hammerhead.nativeMethods;
 
 test('getBordersWidth', function () {
+    var initCssObj = {
+        'border-color': 'black',
+        'border-style': 'solid'
+    };
+    var initCssStr = 'border-color: black; border-style: solid';
+
+    function nativeSetMediumBorderTopWidth (el) {
+        var elStyle = nativeMethods.htmlElementStyleGetter.call(el);
+
+        return nativeMethods.styleSetProperty.call(elStyle, 'border-top-width', 'medium');
+    }
+
+    function getNativeBorderTopWidthConstants () {
+        var nativeDiv = nativeMethods.createElement.call(document, 'div');
+
+        nativeDiv.style.cssText = initCssStr;
+
+        nativeMethods.appendChild.call(document.body, nativeDiv);
+
+        var defaultValue = styleUtils.getBordersWidth(nativeDiv).top;
+
+        nativeSetMediumBorderTopWidth(nativeDiv);
+
+        var mediumValue = styleUtils.getBordersWidth(nativeDiv).top;
+
+        nativeMethods.removeChild.call(document.body, nativeDiv);
+
+        return { defaultValue: defaultValue, mediumValue: mediumValue };
+    }
+
+    var nativeWidth = getNativeBorderTopWidthConstants();
+
     var $el = $('<div>')
-        .css({
-            'border-color': 'black',
-            'border-style': 'solid'
-        })
+        .css(initCssObj)
         .appendTo('body');
 
-    var defaultBrowserBorderWidthValue   = 3;
-    var browserBorderWidthValueForMedium = 3;
-
-    strictEqual(styleUtils.getBordersWidth($el[0]).top, defaultBrowserBorderWidthValue);
+    strictEqual(styleUtils.getBordersWidth($el[0]).top, nativeWidth.defaultValue);
 
     $el.css('borderTopWidth', 'medium');
-    strictEqual(styleUtils.getBordersWidth($el[0]).top, browserBorderWidthValueForMedium);
+    strictEqual(styleUtils.getBordersWidth($el[0]).top, nativeWidth.mediumValue);
 
     $el.css('borderTopWidth', '10px');
     strictEqual(styleUtils.getBordersWidth($el[0]).top, 10);

--- a/test/client/fixtures/utils/style-test.js
+++ b/test/client/fixtures/utils/style-test.js
@@ -3,11 +3,7 @@ var browserUtils     = hammerhead.utils.browser;
 var featureDetection = hammerhead.utils.featureDetection;
 var nativeMethods    = hammerhead.nativeMethods;
 
-test('getBordersWidth', function () {
-    var initCssObj = {
-        'border-color': 'black',
-        'border-style': 'solid'
-    };
+test('getBordersWidth (border-top-width)', function () {
     var initCssStr = 'border-color: black; border-style: solid';
 
     function setMediumBorderTopWidthNatively (el) {
@@ -38,21 +34,22 @@ test('getBordersWidth', function () {
     }
 
     var nativeWidth = getNativeBorderTopWidthConstants();
+    var div         = document.createElement('div');
 
-    var $el = $('<div>')
-        .css(initCssObj)
-        .appendTo('body');
+    div.style.cssText = initCssStr;
 
-    strictEqual(styleUtils.getBordersWidth($el[0]).top, nativeWidth.defaultValue);
+    document.body.appendChild(div);
 
-    $el.css('borderTopWidth', 'medium');
-    strictEqual(styleUtils.getBordersWidth($el[0]).top, nativeWidth.mediumValue);
+    strictEqual(styleUtils.getBordersWidth(div).top, nativeWidth.defaultValue);
 
-    $el.css('borderTopWidth', '10px');
-    strictEqual(styleUtils.getBordersWidth($el[0]).top, 10);
+    div.style.setProperty('border-top-width', 'medium');
+    strictEqual(styleUtils.getBordersWidth(div).top, nativeWidth.mediumValue);
+
+    div.style.borderTopWidth = '10px';
+    strictEqual(styleUtils.getBordersWidth(div).top, 10);
     strictEqual(styleUtils.getBordersWidth(document.documentElement).top, 0);
 
-    $el.remove();
+    div.parentNode.removeChild(div);
 });
 
 test('getHeight', function () {


### PR DESCRIPTION
### Changes
1. The native expected `border-top-width` values was used from the unprocessed `div` element.

### The "test/client/fixtures/utils/style-test.js" test result (Android 7.1, 8.1 and 10.0)
See https://github.com/DevExpress/testcafe-hammerhead/pull/2229#issuecomment-584145787:
```
OK: Windows 10 chrome  Total: 1 Failed: 0 (https://saucelabs.com/jobs/9fdb05bbec644d888664f680028ca18f)
OK: Windows 10 MicrosoftEdge  Total: 1 Failed: 0 (https://saucelabs.com/jobs/01efac4666a744988f3cd911884ddfac)
OK: Windows 10 internet explorer 11.0 Total: 1 Failed: 0 (https://saucelabs.com/jobs/5372d516b7be439abaf3facf6bb6f120)
OK: Windows 10 firefox  Total: 1 Failed: 0 (https://saucelabs.com/jobs/662563f918794899a33a3ea2192b3d8e)
OK: OS X 10.11 chrome  Total: 1 Failed: 0 (https://saucelabs.com/jobs/90883afadab54ae082c6cf69459a16f4)
OK: iOS Safari 11.3 Total: 1 Failed: 0 (https://saucelabs.com/jobs/4bdabae4bde54583a3607d9eba20fcbd)
OK: Android Chrome 7.1 Total: 1 Failed: 0 (https://saucelabs.com/jobs/42e9faf3caf14e16930f355662299049)
OK: Android Chrome 8.1 Total: 1 Failed: 0 (https://saucelabs.com/jobs/1bfee0081cf94e9191b8d000aab033a8)
OK: OS X 10.11 firefox  Total: 1 Failed: 0 (https://saucelabs.com/jobs/5b251d272375463893c3654bebc8ce0d)
OK: Android Chrome 10.0 Total: 1 Failed: 0 (https://saucelabs.com/jobs/2840665f791c4d528fb85a2960b136c2)

```