### PR TITLE
element is disabled only if has 'disabled' attribute(closes #2234)

### DIFF
--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -605,7 +605,9 @@ export default class EventSimulator {
     }
 
     _dispatchMouseEvent (el, args, { dataTransfer, timeStamp }: any) {
-        const disabledParent = domUtils.findParent(el, true, node => node.disabled);
+        const disabledParent = domUtils.findParent(el, true, node => {
+            return domUtils.isElementNode(node) && nativeMethods.hasAttribute.call(node, 'disabled');
+        });
 
         if (disabledParent)
             return null;

--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -606,7 +606,7 @@ export default class EventSimulator {
 
     _dispatchMouseEvent (el, args, { dataTransfer, timeStamp }: any) {
         const disabledParent = domUtils.findParent(el, true, node => {
-            return domUtils.isElementNode(node) && nativeMethods.hasAttribute.call(node, 'disabled');
+            return node.hasAttribute && nativeMethods.hasAttribute.call(node, 'disabled');
         });
 
         if (disabledParent)

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -709,6 +709,8 @@ test('mouse events on disabled elements', function () {
 
     deepEqual(eventLog, []);
 
+    document.body.removeChild(button);
+
     div.addEventListener('mousedown', mouseEventHandler);
     div.addEventListener('mouseup', mouseEventHandler);
     div.addEventListener('click', mouseEventHandler);
@@ -717,9 +719,13 @@ test('mouse events on disabled elements', function () {
     eventSimulator.click(div);
     eventSimulator.mouseup(div);
 
-    deepEqual(eventLog, ['mousedown', 'click', 'mouseup']);
+    // NOTE: it's possible to disable the 'div' element in IE
+    if (browserUtils.isIE11)
+        deepEqual(eventLog, []);
+    else
+        deepEqual(eventLog, ['mousedown', 'click', 'mouseup']);
 
-    document.body.removeChild(button);
+
     document.body.removeChild(div);
 });
 

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -682,32 +682,45 @@ if (!browserUtils.isIE) {
 }
 
 test('mouse events on disabled elements', function () {
-    var button           = document.createElement('button');
-    var span             = document.createElement('span');
-    var mouseEventRaised = false;
+    var button   = document.createElement('button');
+    var span     = document.createElement('span');
+    var div      = document.createElement('div');
+    var eventLog = [];
 
     document.body.appendChild(button);
+    document.body.appendChild(div);
     button.appendChild(span);
 
-    var mouseEventHandler = function () {
-        mouseEventRaised = true;
+    var mouseEventHandler = function (event) {
+        eventLog.push(event.type);
     };
 
     button.disabled = true;
+    div.disabled    = true;
+    div.innerText   = 'text';
 
     span.addEventListener('mousedown', mouseEventHandler);
     span.addEventListener('mouseup', mouseEventHandler);
     span.addEventListener('click', mouseEventHandler);
-    span.addEventListener('mouseover', mouseEventHandler);
-    span.addEventListener('mouseout', mouseEventHandler);
 
     eventSimulator.mousedown(span);
     eventSimulator.click(span);
     eventSimulator.mouseup(span);
 
-    notOk(mouseEventRaised);
+    deepEqual(eventLog, []);
+
+    div.addEventListener('mousedown', mouseEventHandler);
+    div.addEventListener('mouseup', mouseEventHandler);
+    div.addEventListener('click', mouseEventHandler);
+
+    eventSimulator.mousedown(div);
+    eventSimulator.click(div);
+    eventSimulator.mouseup(div);
+
+    deepEqual(eventLog, ['mousedown', 'click', 'mouseup']);
 
     document.body.removeChild(button);
+    document.body.removeChild(div);
 });
 
 module('regression');


### PR DESCRIPTION
check the element `disabled` property is not enough
element is truly disabled only if it has attribute 'disabled'
example:
```JS
var div = document.querySelector('div')
div.disabled = true;
div.hasAttribute('disabled') === false
```
because div is not supposed to be disabled.
Oppositely:
```JS
var button = document.querySelector('button')
button.disabled = true;
button.hasAttribute('disabled') === true
```
because button is supposed to be disabled.

**This works for all browser except IE
In IE even div can be disabled by property.**