### PR TITLE
Fix Safari XMLHttpRequest case

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -61,12 +61,16 @@ const CLIENT_TESTS_BROWSERS = [
         browserName: 'internet explorer',
         version:     '11.0'
     },
-    // NOTE: Temporary disable because of https://github.com/webdriverio/webdriverio/issues/3754#issuecomment-475876500
-    /*{
+    {
         browserName: 'safari',
         platform:    'macOS 10.14',
         version:     '12.0'
-    },*/
+    },
+    {
+        browserName: 'safari',
+        platform:    'macOS 10.15',
+        version:     '13.0'
+    },
     {
         browserName:     'Safari',
         deviceName:      'iPhone 7 Plus Simulator',

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -69,7 +69,7 @@ const CLIENT_TESTS_BROWSERS = [
     {
         browserName: 'safari',
         platform:    'macOS 10.15',
-        version:     '13.0'
+        version:     'latest'
     },
     {
         browserName:     'Safari',


### PR DESCRIPTION
Fix https://github.com/DevExpress/testcafe-hammerhead/issues/2254

### Changes
1. `emitXhrCompletedEvent` is called on `loadend` instead of `DONE` (async case).
2. The "macOS 10.15 Safari **latest**" test configuration was added.

### '"XHR_COMPLETED_EVENT" should be raised when xhr is prevented (GH-1283)'

<details>
<summary>src/client/sandbox/xhr.ts</summary>

```diff
const emitXhrCompletedEventIfNecessary = function () {
    if (this.readyState === this.DONE) {
+        console.log('emitXhrCompletedEventIfNecessary this.readyState === this.DONE')
        const nativeRemoveEventListener = nativeMethods.xhrRemoveEventListener || nativeMethods.removeEventListener;

        xhrSandbox.emit(xhrSandbox.XHR_COMPLETED_EVENT, { xhr: this });
        nativeRemoveEventListener.call(this, 'readystatechange', emitXhrCompletedEventIfNecessary);
    }
};
```
</details>

<details>
<summary>test/client/fixtures/sandbox/xhr-test.js</summary>

```diff
asyncTest('"XHR_COMPLETED_EVENT" should be raised when xhr is prevented (GH-1283)', function () {
    var xhr       = new XMLHttpRequest();
    var timeoutId = null;
    var testDone  = function (eventObj) {
+        console.log('TEST: testDone');
        xhrSandbox.off(xhrSandbox.XHR_COMPLETED_EVENT, testDone);
        clearTimeout(timeoutId);
        ok(!!eventObj);
        start();
    };

    var readyStateChangeHandler = function (e) {
        if (this.readyState === this.DONE) {
+            console.log('readyStateChangeHandler this.readyState === this.DONE e.stopImmediatePropagation()');
            e.stopImmediatePropagation();
        }
    };
```
</details>

<details>
<summary>`master` branch result</summary>

Chrome (**success**):
```
emitXhrCompletedEventIfNecessary this.readyState === this.DONE
TEST: testDone
readyStateChangeHandler this.readyState === this.DONE e.stopImmediatePropagation()
```

Safari (**assertion failure**):
```
readyStateChangeHandler this.readyState === this.DONE e.stopImmediatePropagation()
TEST: testDone // !!! by timeout (timeoutId = setTimeout(testDone, 2000);)
```
</details>
