### PR TITLE
add the `composed` property to events (closes #4739 in TestCafe)

### DIFF
--- a/src/client/utils/event.ts
+++ b/src/client/utils/event.ts
@@ -1,5 +1,22 @@
 import nativeMethods from '../sandbox/native-methods';
 
+const COMPOSED_EVENTS = [
+    'blur',
+    'focus',
+    'focusin',
+    'focusout',
+    'click',
+    'dblclick',
+    'mousedown',
+    'mousemove',
+    'mouseout',
+    'mouseover',
+    'mouseup',
+    'beforeinput',
+    'input',
+    'keydown',
+    'keyup'
+];
 
 export const BUTTON = {
     left:   0,
@@ -72,6 +89,10 @@ export function callEventListener (ctx, listener, e) {
         return listener.handleEvent.call(listener, e);
 
     return listener.call(ctx, e);
+}
+
+export function isComposedEvent (event) {
+    return COMPOSED_EVENTS.indexOf(event) !== -1;
 }
 
 export const hasPointerEvents = !!(nativeMethods.WindowPointerEvent || nativeMethods.WindowMSPointerEvent);

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -947,3 +947,65 @@ test('wrong type of the blur event (GH-947)', function () {
     ok(raised);
 });
 
+if (!browserUtils.isIE) {
+    test('specific events has the `composed: true` property', function () {
+        var log = {};
+
+        var expectedLog = {
+            'blur':        true,
+            'focus':       true,
+            'focusin':     true,
+            'focusout':    true,
+            'click':       true,
+            'dblclick':    true,
+            'mousedown':   true,
+            'mousemove':   true,
+            'mouseout':    true,
+            'mouseover':   true,
+            'mouseup':     true,
+            'beforeinput': true,
+            'input':       true,
+            'keydown':     true,
+            'keyup':       true
+        };
+
+        function handler (e) {
+            log[e.type] = e.composed;
+        }
+
+        domElement.addEventListener('blur', handler);
+        domElement.addEventListener('focus', handler);
+        domElement.addEventListener('focusin', handler);
+        domElement.addEventListener('focusout', handler);
+        domElement.addEventListener('click', handler);
+        domElement.addEventListener('dblclick', handler);
+        domElement.addEventListener('mousedown', handler);
+        domElement.addEventListener('mousemove', handler);
+        domElement.addEventListener('mouseout', handler);
+        domElement.addEventListener('mouseover', handler);
+        domElement.addEventListener('mouseup', handler);
+        domElement.addEventListener('beforeinput', handler);
+        domElement.addEventListener('input', handler);
+        domElement.addEventListener('keyup', handler);
+        domElement.addEventListener('keydown', handler);
+        domElement.addEventListener('keyup', handler);
+
+        eventSimulator.blur(domElement);
+        eventSimulator.focus(domElement);
+        eventSimulator.focusin(domElement);
+        eventSimulator.focusout(domElement);
+        eventSimulator.click(domElement);
+        eventSimulator.dblclick(domElement);
+        eventSimulator.mousedown(domElement);
+        eventSimulator.mousemove(domElement);
+        eventSimulator.mouseout(domElement);
+        eventSimulator.mouseover(domElement);
+        eventSimulator.mouseup(domElement);
+        eventSimulator.beforeInput(domElement);
+        eventSimulator.input(domElement);
+        eventSimulator.keydown(domElement);
+        eventSimulator.keyup(domElement);
+
+        deepEqual(log, expectedLog);
+    });
+}


### PR DESCRIPTION
This is the fix for https://github.com/DevExpress/testcafe/issues/4739

The click event should propaganate throught shadowDom boundaries, but it does not, since we do not mark our events as `composed` .

Here is the explanation from MDN:

> The read-only composed property of the Event interface returns a Boolean which indicates whether or not the event will propagate across the shadow DOM boundary into the standard DOM.

https://developer.mozilla.org/en-US/docs/Web/API/Event/composed

I prepared the list of `composed` events from the specs:
https://www.w3.org/TR/uievents/

I cheched all events from the list, that they really bubbles through the shadowDom