### PR TITLE
Improve formatting for unhandled rejection error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
  include:
    - node_js: "stable"
      env: GULP_TASK="test-server"
-   - node_js: "8"
+   - node_js: "10"
      env: GULP_TASK="test-server"
    - node_js: "stable"
      env: GULP_TASK="test-client-travis"

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -324,10 +324,11 @@ class NativeMethods {
     Uint16Array: typeof Uint16Array;
     Uint32Array: typeof Uint32Array;
     DataView: any;
-    Blob: any;
+    Blob: Window['Blob'];
     XMLHttpRequest: any;
     Image: any;
     Function: any;
+    Error: any;
     functionToString: any;
     FontFace: any;
     StorageEvent: any;
@@ -1016,6 +1017,7 @@ class NativeMethods {
         this.Image            = win.Image;
         this.Function         = win.Function;
         this.functionToString = win.Function.toString;
+        this.Error            = win.Error;
         this.FontFace         = win.FontFace;
         this.StorageEvent     = win.StorageEvent;
         this.MutationObserver = win.MutationObserver;

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -82,7 +82,8 @@ const IS_PROXY_OBJECT_INTERNAL_PROP_VALUE = 'hammerhead|is-proxy-object|internal
 
 const PROXY_HANDLER_FLAG = 'hammerhead|proxy-handler-flag';
 
-const NO_STACK_TRACE_AVAILABLE_MESSAGE = 'No stack trace available';
+const NO_STACK_TRACE_AVAILABLE_MESSAGE        = 'No stack trace available';
+const DEFAULT_UNHANDLED_REJECTION_REASON_NAME = 'Error';
 
 const TRACKED_EVENTS = ['error', 'unhandledrejection', 'hashchange'];
 
@@ -197,12 +198,13 @@ export default class WindowSandbox extends SandboxBase {
 
     static _formatUnhandledRejectionReason (reason: any): string {
         if (!isPrimitiveType(reason)) {
-            const reasonStr = nativeMethods.objectToString.call(reason);
+            if (reason instanceof (nativeMethods.Error as any)) {
+                const name = reason.name || DEFAULT_UNHANDLED_REJECTION_REASON_NAME;
 
-            if (reasonStr === '[object Error]')
-                return reason.message;
+                return `${name}: ${reason.message}`;
+            }
 
-            return reasonStr;
+            return nativeMethods.objectToString.call(reason);
         }
 
         return String(reason);

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -129,7 +129,7 @@ export default class WindowSandbox extends SandboxBase {
         if (!stack || stack.indexOf(msg) === -1) {
             stack = stack || `    ${NO_STACK_TRACE_AVAILABLE_MESSAGE}`;
 
-            return `${msg}:\n${stack}`;
+            return `${msg}\n${stack}`;
         }
 
         return stack;

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -157,12 +157,17 @@ if (nativeMethods.winOnUnhandledRejectionSetter) {
                     return testMsg(new Error('error message'));
                 })
                 .then(function (msg) {
-                    strictEqual(msg, 'error message');
+                    strictEqual(msg, 'Error: error message');
+
+                    return testMsg(new DOMException('You cannot use function', 'SecurityError'));
+                })
+                .then(function (msg) {
+                    strictEqual(msg, 'SecurityError: You cannot use function');
 
                     return testMsg(new TypeError('type error'));
                 })
                 .then(function (msg) {
-                    strictEqual(msg, 'type error');
+                    strictEqual(msg, 'TypeError: type error');
 
                     return testMsg({ a: 1 });
                 })

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -345,7 +345,7 @@ test('UNCAUGHT_JS_ERROR_EVENT', function () {
                     stack:   void 0
                 },
             },
-            expectedStack: 'undefined:\n    No stack trace available'
+            expectedStack: 'undefined\n    No stack trace available'
         },
         {
             event: {
@@ -354,23 +354,23 @@ test('UNCAUGHT_JS_ERROR_EVENT', function () {
                     stack:   '    line 1\n    line2'
                 },
             },
-            expectedStack: 'test message:\n    line 1\n    line2'
+            expectedStack: 'test message\n    line 1\n    line2'
         },
         {
             event: {
                 error: {
                     message: 'test message',
-                    stack:   'Error: test message:\n    line1\n    line2'
+                    stack:   'Error: test message\n    line1\n    line2'
                 },
             },
-            expectedStack: 'Error: test message:\n    line1\n    line2'
+            expectedStack: 'Error: test message\n    line1\n    line2'
         },
         {
             event: {
                 error:   null,
                 message: 'test message'
             },
-            expectedStack: 'test message:\n    No stack trace available'
+            expectedStack: 'test message\n    No stack trace available'
         }
     ];
 
@@ -395,20 +395,30 @@ test('UNCAUGHT_JS_ERROR_EVENT', function () {
 
 if (nativeMethods.winOnUnhandledRejectionSetter) {
     test('UNHANDLED_REJECTION_EVENT', function () {
-        var error = new Error('test');
+        var error = new Error('bla bla bla');
+
+        function prepareStackForError () {
+            // NOTE: Firefox does not include an error message in a stack trace (unlike other browsers)
+            const stack = error.stack;
+
+            if (stack.indexOf(error.message) === -1)
+                return 'Error: bla bla bla\n' + stack;
+
+            return stack;
+        }
 
         var testCases = [
             {
                 reason:        'test reason',
-                expectedStack: 'test reason:\n    No stack trace available'
+                expectedStack: 'test reason\n    No stack trace available'
             },
             {
                 reason:        null,
-                expectedStack: '[object Null]:\n    No stack trace available'
+                expectedStack: '[object Null]\n    No stack trace available'
             },
             {
                 reason:        error,
-                expectedStack: error.stack
+                expectedStack: prepareStackForError(error)
             }
         ];
 


### PR DESCRIPTION
Normalize displayed stack trace messages for the `UnhandledRejection` event.
Now, it has the following format:
```js
<Error type>: error message
    stack line 1..
    stack line 2..
    stack line 2..
```

Before

![image](https://user-images.githubusercontent.com/4133518/78790090-b374b380-79b6-11ea-9c4b-f90ad834d2fd.png)

After
![image](https://user-images.githubusercontent.com/4133518/78879627-d22d8580-7a5c-11ea-9f81-3bd10003f560.png)

