### PR TITLE
correct server processing the `form` element with target=iframe

### DIFF
--- a/src/processing/dom/base-dom-adapter.ts
+++ b/src/processing/dom/base-dom-adapter.ts
@@ -36,5 +36,5 @@ export default abstract class BaseDomAdapter {
     abstract isTopParentIframe (el: HTMLElement | ASTNode): boolean;
     abstract sameOriginCheck (destUrl: string, resourceUrl: string): boolean;
     abstract getClassName (el: HTMLElement | ASTNode): string;
-    abstract isExistingTarget (target: string): boolean;
+    abstract isExistingTarget (target: string, el: ASTNode | void): boolean;
 }

--- a/src/processing/dom/base-dom-adapter.ts
+++ b/src/processing/dom/base-dom-adapter.ts
@@ -36,5 +36,5 @@ export default abstract class BaseDomAdapter {
     abstract isTopParentIframe (el: HTMLElement | ASTNode): boolean;
     abstract sameOriginCheck (destUrl: string, resourceUrl: string): boolean;
     abstract getClassName (el: HTMLElement | ASTNode): string;
-    abstract isExistingTarget (target: string, el: ASTNode | void): boolean;
+    abstract isExistingTarget (target: string, el?: ASTNode): boolean;
 }

--- a/src/processing/dom/index.ts
+++ b/src/processing/dom/index.ts
@@ -319,7 +319,7 @@ export default class DomProcessor {
             if (target === '_parent')
                 return mustProcessTag && !this.adapter.isTopParentIframe(el);
 
-            if (mustProcessTag && (this.adapter.hasIframeParent(el) || isNameTarget && this.adapter.isExistingTarget(target)))
+            if (mustProcessTag && (this.adapter.hasIframeParent(el) || isNameTarget && this.adapter.isExistingTarget(target, el)))
                 return true;
         }
 

--- a/src/processing/dom/parse5-dom-adapter.ts
+++ b/src/processing/dom/parse5-dom-adapter.ts
@@ -110,7 +110,12 @@ export default class Parse5DomAdapter extends BaseDomAdapter {
         return urlUtils.sameOriginCheck(location, checkedUrl);
     }
 
-    isExistingTarget (): boolean {
-        return false;
+    isExistingTarget (target: string, el: ASTNode): boolean {
+        while (el.parentNode)
+            el = el.parentNode;
+
+        return parse5Utils.findElement(el, e => {
+            return this.getAttr(e, 'name') === target;
+        });
     }
 }

--- a/src/processing/dom/parse5-dom-adapter.ts
+++ b/src/processing/dom/parse5-dom-adapter.ts
@@ -114,8 +114,6 @@ export default class Parse5DomAdapter extends BaseDomAdapter {
         while (el.parentNode)
             el = el.parentNode;
 
-        return parse5Utils.findElement(el, e => {
-            return this.getAttr(e, 'name') === target;
-        });
+        return parse5Utils.findElement(el, e => this.getAttr(e, 'name') === target);
     }
 }

--- a/src/utils/parse5.ts
+++ b/src/utils/parse5.ts
@@ -82,18 +82,18 @@ export function findElementsByTagNames (root: ASTNode, tagNames: string[]): any 
     return elements;
 }
 
-export function findElement (el: ASTNode, predicate: Function) {
+export function findElement (el: ASTNode, predicate: (el: ASTNode) => boolean) {
     if (isElementNode(el) && predicate(el))
         return el;
 
     if (!el.childNodes)
         return null;
 
-    for (let i = 0; i < el.childNodes.length; i++) {
-        const child = findElement(el.childNodes[i], predicate);
+    for (let child of el.childNodes) {
+        const result = findElement(child, predicate);
 
-        if (child)
-            return child;
+        if (result)
+            return result;
     }
 
     return null;

--- a/src/utils/parse5.ts
+++ b/src/utils/parse5.ts
@@ -3,6 +3,13 @@ import { ASTAttribute, ASTNode } from 'parse5';
 
 const ATTR_NAMESPACE_LOCAL_NAME_SEPARATOR = ':';
 
+function isElementNode (el: ASTNode) {
+    return el.nodeName !== '#document' &&
+        el.nodeName !== '#text' &&
+        el.nodeName !== '#documentType' &&
+        el.nodeName !== '#comment';
+}
+
 function getAttrName (attr: ASTAttribute) {
     return attr.prefix ? attr.prefix + ATTR_NAMESPACE_LOCAL_NAME_SEPARATOR + attr.name : attr.name;
 }
@@ -75,9 +82,25 @@ export function findElementsByTagNames (root: ASTNode, tagNames: string[]): any 
     return elements;
 }
 
+export function findElement (el: ASTNode, predicate: Function) {
+    if (isElementNode(el) && predicate(el))
+        return el;
+
+    if (!el.childNodes)
+        return null;
+
+    for (let i = 0; i < el.childNodes.length; i++) {
+        const child = findElement(el.childNodes[i], predicate);
+
+        if (child)
+            return child;
+    }
+
+    return null;
+}
+
 export function walkElements (el: ASTNode, processor: Function): void {
-    if (el.nodeName !== '#document' && el.nodeName !== '#text' &&
-        el.nodeName !== '#documentType' && el.nodeName !== '#comment')
+    if (isElementNode(el))
         processor(el);
 
     if (el.childNodes)

--- a/test/server/dom-processor-test.js
+++ b/test/server/dom-processor-test.js
@@ -145,17 +145,26 @@ describe('DOM processor', () => {
     });
 
     it('Should process target attribute for the elements in <iframe>', () => {
-        const root = process('<a id="a" href="http://example.com"></a>' +
-                           '<form id="form" action="http://example.com"></form>' +
-                           '<a id="a_target_top" href="http://example.com" target="_top"></a>' +
-                           '<a id="a_target_parent" href="http://example.com" target="_parent"></a>', true);
+        let root = process('<a id="a" href="http://example.com"></a>' +
+                             '<form id="form_simple" action="http://example.com"></form>' +
+                             '<a id="a_target_top" href="http://example.com" target="_top"></a>' +
+                             '<a id="a_target_parent" href="http://example.com" target="_parent"></a>', true);
 
-        const elements = parse5Utils.findElementsByTagNames(root, ['a', 'form']);
+        let elements = parse5Utils.findElementsByTagNames(root, ['a', 'form']);
 
         expect(urlUtils.parseProxyUrl(domAdapter.getAttr(elements.a[0], 'href')).resourceType).eql('i');
         expect(urlUtils.parseProxyUrl(domAdapter.getAttr(elements.form[0], 'action')).resourceType).eql('if');
         expect(urlUtils.parseProxyUrl(domAdapter.getAttr(elements.a[1], 'href')).resourceType).to.be.null;
         expect(domAdapter.getAttr(elements.a[2], 'href')).eql('http://example.com');
+
+        root = process('<form id="form" action="http://example.com"></form>' +
+                       '<form id="form_target_iframe" target="custom_iframe" action="http://example.com"></form>' +
+                       '<iframe name="custom_iframe"></iframe>', false);
+
+        elements = parse5Utils.findElementsByTagNames(root, ['form']);
+
+        expect(urlUtils.parseProxyUrl(domAdapter.getAttr(elements.form[0], 'action')).resourceType).eql('f');
+        expect(urlUtils.parseProxyUrl(domAdapter.getAttr(elements.form[1], 'action')).resourceType).eql('if');
     });
 
     it('Should process <iframe> with src without protocol', () => {


### PR DESCRIPTION
The situation:
- we have form with target  = 'framename'
- we submit the form using `form.submit`
- swithingToIframe
- click/expect/any command in iframe leads to error

The cause that iframe window is reloaded after form submit, because of incomplete hh server processing.

**I checked two original cases and they work as expected**