### PR TITLE
Remove duplicated upload roots

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "16.2.4",
+  "version": "16.2.5",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/upload/storage.ts
+++ b/src/upload/storage.ts
@@ -1,4 +1,4 @@
-import { castArray } from 'lodash';
+import { chain } from 'lodash';
 import mime from 'mime';
 import path from 'path';
 import { format } from 'util';
@@ -24,7 +24,7 @@ export default class UploadStorage {
     uploadRoots: string[];
 
     constructor (uploadRoots: string[]) {
-        this.uploadRoots = castArray(uploadRoots);
+        this.uploadRoots = chain(uploadRoots).castArray().uniq().value();
     }
 
     static async _getFilesToCopy (files: CopiedFileInfo[]): Promise<{ filesToCopy: CopiedFileInfo[]; errs: CopyingError[] }> {

--- a/test/server/upload-test.js
+++ b/test/server/upload-test.js
@@ -428,6 +428,14 @@ describe('Upload', () => {
                     fs.unlinkSync(copiedFilePath);
                 });
         });
+
+        it('Should remove duplicated upload roots', () => {
+            const storage = new UploadStorage(['/folder/1', '/folder/2', '/folder/1']);
+
+            expect(storage.uploadRoots.length).eql(2);
+            expect(storage.uploadRoots[0]).eql('/folder/1');
+            expect(storage.uploadRoots[1]).eql('/folder/2');
+        });
     });
 
     it('Should inject uploads', () => {


### PR DESCRIPTION
This change is necessary to avoid displaying duplicates for the `Scanned file paths` section for the updated `Can't find the uploaded file(s)` (https://github.com/devexpress/testcafe/issues/4860#issuecomment-615273760)