### PR TITLE
Store the current storages state in compressed form

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "iconv-lite": "0.4.11",
     "lodash": "^4.17.13",
     "lru-cache": "2.6.3",
+    "lz-string": "^1.4.4",
     "match-url-wildcard": "0.0.4",
     "merge-stream": "^1.0.1",
     "mime": "~1.4.1",

--- a/test/client/fixtures/sandbox/storages-test.js
+++ b/test/client/fixtures/sandbox/storages-test.js
@@ -35,6 +35,13 @@ function waitStorageEvent (window, action) {
     });
 }
 
+var compressedStorageStates = {
+    '[["key1"],["value1"]]':  '᭸ᄦ塉䅜࣪̈ͦüѐ۠坫悤䀠 ',
+    '[["key2"],["value2"]]':  '᭸ᄦ塉䅜Ӫ̈ͦüѐ۠坫悤䀠 ',
+    '[["key11"],["value1"]]': '᭸ᄦ塉䅜࣫倷›ᠦ灁䁖˚⃥ठ ',
+    '[["key12"],["value2"]]': '᭸ᄦ塉䅜࣠♰ீസΐრᬢ嵈䥄䀠 '
+};
+
 module('storage sandbox API');
 
 test('clear', function () {
@@ -48,8 +55,8 @@ test('clear', function () {
 
     storageSandbox._unloadSandbox.emit(storageSandbox._unloadSandbox.BEFORE_UNLOAD_EVENT);
 
-    strictEqual(nativeLocalStorage.getItem(localStorage.nativeStorageKey), '[["key11"],["value1"]]');
-    strictEqual(nativeSessionStorage.getItem(sessionStorage.nativeStorageKey), '[["key12"],["value2"]]');
+    strictEqual(nativeLocalStorage.getItem(localStorage.nativeStorageKey), compressedStorageStates['[["key11"],["value1"]]']);
+    strictEqual(nativeSessionStorage.getItem(sessionStorage.nativeStorageKey), compressedStorageStates['[["key12"],["value2"]]']);
 
     storageSandbox.clear();
 
@@ -230,8 +237,8 @@ test('iframe with empty src', function () {
 module('sync state with native');
 
 test('storages load their state from native', function () {
-    nativeLocalStorage[storageWrapperKey]   = '[[ "key1" ],[ "value1" ]]';
-    nativeSessionStorage[storageWrapperKey] = '[[ "key2" ],[ "value2" ]]';
+    nativeLocalStorage[storageWrapperKey]   = compressedStorageStates['[["key1"],["value1"]]'];
+    nativeSessionStorage[storageWrapperKey] = compressedStorageStates['[["key2"],["value2"]]'];
 
     var localSandboxWrapper   = new StorageWrapper(window, nativeLocalStorage, storageWrapperKey, hammerhead.sandbox.event.listeners);
     var sessionSandboxWrapper = new StorageWrapper(window, nativeSessionStorage, storageWrapperKey, hammerhead.sandbox.event.listeners);
@@ -250,8 +257,8 @@ test('storages save their state on the beforeunload event', function () {
     // NOTE: Simulate page leaving
     hammerhead.sandbox.event.unload._emitBeforeUnloadEvent();
 
-    strictEqual(nativeLocalStorage[storageWrapperKey], JSON.stringify([['key1'], ['value1']]));
-    strictEqual(nativeSessionStorage[storageWrapperKey], JSON.stringify([['key2'], ['value2']]));
+    strictEqual(nativeLocalStorage[storageWrapperKey], compressedStorageStates['[["key1"],["value1"]]']);
+    strictEqual(nativeSessionStorage[storageWrapperKey], compressedStorageStates['[["key2"],["value2"]]']);
 });
 
 module('storage changed event');


### PR DESCRIPTION
### TODO
- [ ] Fix functional tests

https://pieroxy.net/blog/pages/lz-string/guide.html:
> Storing compressed data into localStorage
On Firefox and IE, localStorage cannot contain invalid UTF16 characters. So you will need the following:
```js
var string = "This is my compression test.";
alert("Size of sample is: " + string.length);
var compressed = LZString.compressToUTF16(string);
alert("Size of compressed sample is: " + compressed.length);
localStorage.setItem("myData",compressed);
(...)
string = LZString.decompressFromUTF16(localStorage.getItem("myData"));
alert("Sample is: " + string);
```


<details>
 <summary>Example index.html</summary>

```html
<html>
<head></head>
<body>
<script>
    window.onerror = function(e) {
        console.log(e);

        debugger;
    };

    function clearLocalStorage () {
        localStorage.clear();

        console.log('localStorage length:', localStorage.length);
    }

    function addItemToLocalStorage() {
        localStorage.setItem('3key_' + Math.floor(Math.random() * (10000 - 1)) + 1, 'test');

        console.log('localStorage length:', localStorage.length);
    }

    window.sizeof = function(object, pretty) {
        function format(bytes) {
            if (bytes < 1024)
                return bytes + "B";
            else if (bytes < 1048576)
                return (bytes / 1024).toFixed(3) + "K";
            else if (bytes < 1073741824)
                return (bytes / 1048576).toFixed(3) + "M";
            else
                return (bytes / 1073741824).toFixed(3) + "G";
        }

        var objectList = [];
        var stack = [object];
        var bytes = 0;

        while (stack.length) {
            var value = stack.pop();

            if (typeof value === 'boolean')
                bytes += 4;
            else if (typeof value === 'string')
                bytes += value.length * 2;
            else if (typeof value === 'number')
                bytes += 8;
            else if (typeof value === 'object' && objectList.indexOf(value) === -1) {
                objectList.push(value);

                // if the object is not an array, add the sizes of the keys
                if (Object.prototype.toString.call(value) != '[object Array]') {
                    for (var key in value)
                        bytes += 2 * key.length;
                }

                for (var key in value)
                    stack.push(value[key]);
            }
        }

        return format(bytes);
    }
</script>
<input id="addItemBtn" type="button" onclick="addItemToLocalStorage()" value="add a random item to localStorage">
<input id="clearLocalStorageBtn" type="button" onclick="clearLocalStorage()" value="clear localStorage">
<br>
<script>
    console.log('localStorage length:', localStorage.length);

    window.localStorageState = {};

    for (var i = 0; i < 12814; i++) // 12814 (maximum for "add state prop to localStorage") 12628 (maximum for "add each prop to localStorage")
        window.localStorageState['1key_' + i] = 'testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest';

    for (var i = 0; i < 21; i++) // native maximum: 21 + 2
        window.localStorageState['2key_' + i] = 'test';

    function addEachPropToStorage () {
        console.log('size of object with properties (window.localStorageState):', window.sizeof(window.localStorageState));
        console.log('JSON.stringify(window.localStorageState).length:', JSON.stringify(window.localStorageState).length);

        var t0 = performance.now();

        for (var prop in window.localStorageState)
            localStorage.setItem(prop, window.localStorageState[prop]);

        var t1 = performance.now();

        console.log((t1 - t0) + " milliseconds.");

        console.log('localStorage length:', localStorage.length);
    }

    function addStatePropToStorage () {
        var tmpValue = [[], []];

        for (var prop in window.localStorageState) {
            tmpValue[0].push(prop);
            tmpValue[1].push(window.localStorageState[prop]);
        }

        var tmpValue = JSON.stringify(tmpValue);

        console.log('size of string storage (tmpValue):', window.sizeof(tmpValue));
        console.log('JSON.stringify(tmpValue).length:', JSON.stringify(tmpValue).length);

        localStorage.setItem('hammerhead|storage-wrapper|sessionId|localhost:8080', tmpValue);
    }

</script>
<br>
<input id="addEachPropToStorage" type="button" onclick="addEachPropToStorage()" value="add each prop to localStorage">
<input id="addStatePropToStorage" type="button" onclick="addStatePropToStorage()" value="add state prop to localStorage">
</body>
</html>

```
</details>