### PR TITLE
fix MutationObserver - MutationRecord nextSibling and previousSibling, fixes #2321

### DIFF
--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -1433,7 +1433,7 @@ export default class WindowSandbox extends SandboxBase {
             getter: function () {
                 const originNextSibling = nativeMethods.mutationRecordNextSiblingGetter.call(this);
 
-                return windowSandbox.shadowUI.getNextSibling(originNextSibling);
+                return windowSandbox.shadowUI.getMutationRecordNextSibling(originNextSibling);
             }
         });
 
@@ -1441,7 +1441,7 @@ export default class WindowSandbox extends SandboxBase {
             getter: function () {
                 const originPrevSibling = nativeMethods.mutationRecordPrevSiblingGetter.call(this);
 
-                return windowSandbox.shadowUI.getPrevSibling(originPrevSibling);
+                return windowSandbox.shadowUI.getMutationRecordPrevSibling(originPrevSibling);
             }
         });
 

--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -506,6 +506,26 @@ export default class ShadowUI extends SandboxBase {
         return el;
     }
 
+    getMutationRecordNextSibling (el) {
+        if (!el)
+            return el;
+
+        while (el && domUtils.isShadowUIElement(el))
+            el = nativeMethods.nodeNextSiblingGetter.call(el);
+
+        return el;
+    }
+
+    getMutationRecordPrevSibling (el) {
+        if (!el)
+            return el;
+
+        while (el && domUtils.isShadowUIElement(el))
+            el = nativeMethods.nodePrevSiblingGetter.call(el);
+
+        return el;
+    }
+
     getNextElementSibling (el) {
         do
             el = nativeMethods.elementNextElementSiblingGetter.call(el);

--- a/test/client/fixtures/sandbox/shadow-ui-test.js
+++ b/test/client/fixtures/sandbox/shadow-ui-test.js
@@ -179,7 +179,7 @@ if (window.MutationObserver) {
             document.body.appendChild(el);
         });
 
-        asyncTest('nextSibling', function () {
+        asyncTest('nextSibling shadow element', function () {
             var shadowUIEl   = document.createElement('div');
             var el           = document.createElement('div');
             var shadowUIRoot = shadowUI.getRoot();
@@ -202,7 +202,32 @@ if (window.MutationObserver) {
             document.body.appendChild(el);
         });
 
-        asyncTest('prevSibling', function () {
+        asyncTest('nextSibling dom element', function () {
+            createTestIframe()
+                .then(function (iframe) {
+                    var iframeDocument = iframe.contentDocument;
+
+                    var scriptEl1 = iframeDocument.createElement('script');
+                    var scriptEl2 = iframeDocument.createElement('script');
+
+                    iframeDocument.head.appendChild(scriptEl1);
+
+                    var observer = new MutationObserver(function (mutations) {
+                        strictEqual(mutations[0].nextSibling, scriptEl1);
+
+                        observer.disconnect();
+                        scriptEl1.parentNode.removeChild(scriptEl1);
+                        scriptEl2.parentNode.removeChild(scriptEl2);
+
+                        start();
+                    });
+
+                    observer.observe(iframeDocument.head, { childList: true });
+                    iframeDocument.head.insertBefore(scriptEl2, scriptEl1);
+                });
+        });
+
+        asyncTest('prevSibling shadow element', function () {
             createTestIframe()
                 .then(function (iframe) {
                     var iframeDocument = iframe.contentDocument;
@@ -224,6 +249,31 @@ if (window.MutationObserver) {
 
                     observer.observe(iframeDocument.head, { childList: true });
                     iframeDocument.head.insertBefore(scriptEl, iframeDocument.head.firstChild);
+                });
+        });
+
+        asyncTest('prevSibling dom element', function () {
+            createTestIframe()
+                .then(function (iframe) {
+                    var iframeDocument = iframe.contentDocument;
+
+                    var scriptEl1 = iframeDocument.createElement('script');
+                    var scriptEl2 = iframeDocument.createElement('script');
+
+                    iframeDocument.head.appendChild(scriptEl1);
+
+                    var observer = new MutationObserver(function (mutations) {
+                        strictEqual(mutations[0].previousSibling, scriptEl1);
+
+                        observer.disconnect();
+                        scriptEl1.parentNode.removeChild(scriptEl1);
+                        scriptEl2.parentNode.removeChild(scriptEl2);
+
+                        start();
+                    });
+
+                    observer.observe(iframeDocument.head, { childList: true });
+                    iframeDocument.head.appendChild(scriptEl2);
                 });
         });
 


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

fixes #2321 

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
MutationObserver - MutationRecord nextSibling and previousSibling properties should correctly return previous and next sibling node

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

## References
https://github.com/tomas/testcafe-hammerhead/issues/2321

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
