### PR TITLE
Fix `IE breaks with TypeError: Invalid calling object in _processChildren() and getFirstChild()`. Bump eslint-plugin-hammerhead (v0.3.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "del-cli": "^1.1.0",
     "endpoint-utils": "^1.0.1",
     "eslint": "4.18.2",
-    "eslint-plugin-hammerhead": "0.3.0",
+    "eslint-plugin-hammerhead": "0.3.1",
     "express": "4.16.3",
     "express-ntlm": "2.1.5",
     "gulp": "^4.0.0",

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -224,6 +224,7 @@ class NativeMethods {
     htmlCollectionLengthGetter: any;
     nodeListLengthGetter: any;
     nodeParentNodeGetter: any;
+    nodeChildNodesGetter: any;
     elementChildElementCountGetter: any;
     inputFilesGetter: any;
     styleSheetHrefGetter: any;
@@ -897,6 +898,7 @@ class NativeMethods {
         this.nodeNextSiblingGetter           = win.Object.getOwnPropertyDescriptor(win.Node.prototype, 'nextSibling').get;
         this.nodePrevSiblingGetter           = win.Object.getOwnPropertyDescriptor(win.Node.prototype, 'previousSibling').get;
         this.nodeParentNodeGetter            = win.Object.getOwnPropertyDescriptor(win.Node.prototype, 'parentNode').get;
+        this.nodeChildNodesGetter            = win.Object.getOwnPropertyDescriptor(win.Node.prototype, 'childNodes').get;
         this.elementFirstElementChildGetter  = win.Object.getOwnPropertyDescriptor(win.Element.prototype, 'firstElementChild').get;
         this.elementLastElementChildGetter   = win.Object.getOwnPropertyDescriptor(win.Element.prototype, 'lastElementChild').get;
         this.elementNextElementSiblingGetter = win.Object.getOwnPropertyDescriptor(win.Element.prototype, 'nextElementSibling').get;

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -417,8 +417,11 @@ export default class ElementSandbox extends SandboxBase {
         let result          = null;
         let childNodesArray = null;
 
-        if (domUtils.isDocumentFragmentNode(newNode))
-            childNodesArray = domUtils.nodeListToArray(newNode.childNodes);
+        if (domUtils.isDocumentFragmentNode(newNode)) {
+            const childNodes = nativeMethods.nodeChildNodesGetter.call(newNode);
+
+            childNodesArray = domUtils.nodeListToArray(childNodes);
+        }
 
         // NOTE: Before the page's <body> is processed and added to DOM,
         // some javascript frameworks create their own body element, perform

--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -218,7 +218,7 @@ export default class ShadowUI extends SandboxBase {
     _markShadowUIContainerAndCollections (containerEl) {
         ShadowUI._markAsShadowContainer(containerEl);
         ShadowUI.markAsShadowContainerCollection(containerEl.children);
-        ShadowUI.markAsShadowContainerCollection(containerEl.childNodes);
+        ShadowUI.markAsShadowContainerCollection(nativeMethods.nodeChildNodesGetter.call(containerEl));
     }
 
     markShadowUIContainers (head, body) {
@@ -455,8 +455,9 @@ export default class ShadowUI extends SandboxBase {
 
     // Accessors
     getFirstChild (el) {
-        const length        = nativeMethods.nodeListLengthGetter.call(el.childNodes);
-        const filteredNodes = this._filterNodeList(el.childNodes, length);
+        const childNodes    = nativeMethods.nodeChildNodesGetter.call(el);
+        const length        = nativeMethods.nodeListLengthGetter.call(childNodes);
+        const filteredNodes = this._filterNodeList(childNodes, length);
 
         return filteredNodes[0] || null;
     }
@@ -469,9 +470,10 @@ export default class ShadowUI extends SandboxBase {
     }
 
     getLastChild (el) {
-        const length        = nativeMethods.nodeListLengthGetter.call(el.childNodes);
-        const filteredNodes = this._filterNodeList(el.childNodes, length);
-        const index         = el.childNodes === filteredNodes ? length - 1 : filteredNodes.length - 1;
+        const childNodes    = nativeMethods.nodeChildNodesGetter.call(el);
+        const length        = nativeMethods.nodeListLengthGetter.call(childNodes);
+        const filteredNodes = this._filterNodeList(childNodes, length);
+        const index         = childNodes === filteredNodes ? length - 1 : filteredNodes.length - 1;
 
         return index >= 0 ? filteredNodes[index] : null;
     }
@@ -741,7 +743,10 @@ export default class ShadowUI extends SandboxBase {
         ShadowUI._markAsShadowContainer(form);
         ShadowUI.markAsShadowContainerCollection(form.elements);
         ShadowUI.markAsShadowContainerCollection(form.children);
-        ShadowUI.markAsShadowContainerCollection(form.childNodes);
+
+        const childNodes = nativeMethods.nodeChildNodesGetter.call(form);
+
+        ShadowUI.markAsShadowContainerCollection(childNodes);
     }
 
     static markElementAndChildrenAsShadow (el) {


### PR DESCRIPTION
Fix #2236