### PR TITLE
Fix `Failed to execute 'postMessage' on 'Window': Invalid target origin 'about://:50335/' in a call to 'postMessage'`

### DIFF
--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -178,18 +178,20 @@ export default class MessageSandbox extends SandboxBase {
     postMessage (contentWindow: Window, args) {
         const targetUrl = args[1] || destLocation.getOriginHeader();
 
-        if (isCrossDomainWindows(this.window, contentWindow))
-            args[1] = getCrossDomainProxyUrl();
-        else if (!isSupportedProtocol(contentWindow.location.toString()) ||
-                 !isSupportedProtocol(this.window.location.toString()))
-            args[1] = '*';
-        else {
-            args[1] = formatUrl({
-                /*eslint-disable no-restricted-properties*/
-                protocol: this.window.location.protocol,
-                host:     this.window.location.host
-                /*eslint-enable no-restricted-properties*/
-            });
+        if (args[1] !== '*') {
+            if (isCrossDomainWindows(this.window, contentWindow))
+                args[1] = getCrossDomainProxyUrl();
+            else if (!isSupportedProtocol(contentWindow.location.toString()) ||
+                !isSupportedProtocol(this.window.location.toString()))
+                args[1] = '*';
+            else {
+                args[1] = formatUrl({
+                    /*eslint-disable no-restricted-properties*/
+                    protocol: this.window.location.protocol,
+                    host: this.window.location.host
+                    /*eslint-enable no-restricted-properties*/
+                });
+            }
         }
 
         args[0] = MessageSandbox._wrapMessage(MessageType.User, args[0], targetUrl);

--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -2,7 +2,7 @@ import Promise from 'pinkie';
 import SandboxBase from '../base';
 import nativeMethods from '../native-methods';
 import * as destLocation from '../../utils/destination-location';
-import { formatUrl, getCrossDomainProxyUrl, isSupportedProtocol } from '../../utils/url';
+import { formatUrl } from '../../utils/url';
 // @ts-ignore
 import { parse as parseJSON, stringify as stringifyJSON } from 'json-hammerhead';
 import { isCrossDomainWindows, getTopSameDomainWindow, isWindow, isMessageEvent } from '../../utils/dom';
@@ -178,22 +178,9 @@ export default class MessageSandbox extends SandboxBase {
     postMessage (contentWindow: Window, args) {
         const targetUrl = args[1] || destLocation.getOriginHeader();
 
-        if (args[1] !== '*') {
-            if (isCrossDomainWindows(this.window, contentWindow))
-                args[1] = getCrossDomainProxyUrl();
-            else if (!isSupportedProtocol(contentWindow.location.toString()) ||
-                !isSupportedProtocol(this.window.location.toString()))
-                args[1] = '*';
-            else {
-                args[1] = formatUrl({
-                    /*eslint-disable no-restricted-properties*/
-                    protocol: this.window.location.protocol,
-                    host: this.window.location.host
-                    /*eslint-enable no-restricted-properties*/
-                });
-            }
-        }
-
+        // NOTE: Here, we pass all messages as "no preference" ("*").
+        // We do an origin check in "_onWindowMessage" to access the target origin.
+        args[1] = '*';
         args[0] = MessageSandbox._wrapMessage(MessageType.User, args[0], targetUrl);
 
 

--- a/src/client/utils/url.ts
+++ b/src/client/utils/url.ts
@@ -191,11 +191,6 @@ export function getCrossDomainProxyPort (proxyPort: string) {
         : settings.get().crossDomainProxyPort;
 }
 
-export function getCrossDomainProxyUrl () {
-    // eslint-disable-next-line no-restricted-properties
-    return location.protocol + '//' + location.hostname + ':' + settings.get().crossDomainProxyPort + '/';
-}
-
 export function resolveUrlAsDest (url: string) {
     return sharedUrlUtils.resolveUrlAsDest(url, getProxyUrl);
 }

--- a/test/client/data/cross-domain/no-preference-message-to-top.html
+++ b/test/client/data/cross-domain/no-preference-message-to-top.html
@@ -23,12 +23,6 @@
 
     iframe.src = 'about:blank';
 
-    // TODO: check the Firefox case
-    // if (browserUtils.isFirefox)
-    //     setTimeout(test, 300);
-    // else
-    //     iframe.addEventListener('load', test);
-
     iframe.addEventListener('load', test);
 
     document.body.appendChild(iframe);

--- a/test/client/data/cross-domain/no-preference-message-to-top.html
+++ b/test/client/data/cross-domain/no-preference-message-to-top.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+    <meta charset="utf-8">
+    <script src="/hammerhead.js" class="script-hammerhead-shadow-ui"></script>
+
+
+</head>
+<body>
+<script type="text/javascript">
+    var hammerhead = window['%hammerhead%'];
+
+    var iframe        = document.createElement('iframe');
+    var domUtils      = hammerhead.utils.dom;
+    var browserUtils  = hammerhead.utils.browser;
+    var hhPostMessage = hammerhead.sandbox.event.message.postMessage;
+    var test          = function () {
+        var winWithSrc;
+
+        hhPostMessage(top, ['GH-2165', '*']);
+    };
+
+    iframe.src = 'about:blank';
+
+    // TODO: check the Firefox case
+    // if (browserUtils.isFirefox)
+    //     setTimeout(test, 300);
+    // else
+    //     iframe.addEventListener('load', test);
+
+    iframe.addEventListener('load', test);
+
+    document.body.appendChild(iframe);
+</script>
+</body>
+</html>

--- a/test/client/data/cross-domain/targetorigin-message-to-top.html
+++ b/test/client/data/cross-domain/targetorigin-message-to-top.html
@@ -14,9 +14,11 @@
     var iframe        = document.createElement('iframe');
     var hhPostMessage = hammerhead.sandbox.event.message.postMessage;
     var test          = function () {
-        hhPostMessage(top, ['GH-2165: wrong targetOrigin', 'https://wrong-target-origin.com/']);
-        hhPostMessage(top, ['GH-2165: correct targetOrigin', 'https://example.com/']);
-        hhPostMessage(top, ['GH-2165: no targetOrigin preference', '*']);
+        hhPostMessage(top, ['Should not pass an origin check: no targetOrigin parameter']);
+        hhPostMessage(top, ['Should not pass an origin check: wrong targetOrigin', 'https://wrong-target-origin.com/']);
+
+        hhPostMessage(top, ['Should pass an origin check: correct targetOrigin', 'https://example.com/']);
+        hhPostMessage(top, ['Should pass an origin check: no targetOrigin preference ("*")', '*']);
     };
 
     iframe.src = 'about:blank';

--- a/test/client/data/cross-domain/targetorigin-message-to-top.html
+++ b/test/client/data/cross-domain/targetorigin-message-to-top.html
@@ -12,13 +12,11 @@
     var hammerhead = window['%hammerhead%'];
 
     var iframe        = document.createElement('iframe');
-    var domUtils      = hammerhead.utils.dom;
-    var browserUtils  = hammerhead.utils.browser;
     var hhPostMessage = hammerhead.sandbox.event.message.postMessage;
     var test          = function () {
-        var winWithSrc;
-
-        hhPostMessage(top, ['GH-2165', '*']);
+        hhPostMessage(top, ['GH-2165: wrong targetOrigin', 'https://wrong-target-origin.com/']);
+        hhPostMessage(top, ['GH-2165: correct targetOrigin', 'https://example.com/']);
+        hhPostMessage(top, ['GH-2165: no targetOrigin preference', '*']);
     };
 
     iframe.src = 'about:blank';

--- a/test/client/fixtures/cross-domain-test.js
+++ b/test/client/fixtures/cross-domain-test.js
@@ -26,7 +26,7 @@ asyncTest('cross domain messaging between windows', function () {
         if (nativeMessageCounter === 5) {
             nativeRemoveEventListener.call(window, 'message', nativeHandler);
             iframe.parentNode.removeChild(iframe);
-            window.onmessage = null;
+            window.onmessage = void 0;
             deepEqual(results.sort(), ['*', 'same origin']);
             start();
         }

--- a/test/client/fixtures/sandbox/event/message-test.js
+++ b/test/client/fixtures/sandbox/event/message-test.js
@@ -62,7 +62,7 @@ asyncTest('onmessage event', function () {
         });
 });
 
-asyncTest('cross domain postMessage from iframe with "about:blank" src and no "targetOrigin" preference ("*") to "top" (GH-2165)', function () {
+asyncTest('cross domain message from iframe with "about:blank" src and no "targetOrigin" preference ("*") to "top" (GH-2165)', function () {
     var onMessageHandler = function (evt) {
         strictEqual(evt.data, 'GH-2165');
 

--- a/test/client/fixtures/sandbox/event/message-test.js
+++ b/test/client/fixtures/sandbox/event/message-test.js
@@ -61,6 +61,20 @@ asyncTest('onmessage event', function () {
         });
 });
 
+asyncTest('cross domain postMessage with no preference ("*") to "top" (GH-2165)', function () {
+    var onMessageHandler = function (evt) {
+        strictEqual(evt.data, 'GH-2165');
+
+        window.removeEventListener('message', onMessageHandler);
+
+        start();
+    };
+
+    window.addEventListener('message', onMessageHandler);
+
+    createTestIframe({ src: getCrossDomainPageUrl('../../../data/cross-domain/no-preference-message-to-top.html') });
+});
+
 test('message types', function () {
     var checkValue = function (value, test) {
         return new Promise(function (resolve) {

--- a/test/client/fixtures/sandbox/event/message-test.js
+++ b/test/client/fixtures/sandbox/event/message-test.js
@@ -49,6 +49,7 @@ asyncTest('onmessage event', function () {
 
         if (count === 4) {
             window.removeEventListener('message', onMessageHandler);
+            window.onmessage = void 0;
             start();
         }
     };
@@ -61,7 +62,7 @@ asyncTest('onmessage event', function () {
         });
 });
 
-asyncTest('cross domain postMessage with no preference ("*") to "top" (GH-2165)', function () {
+asyncTest('cross domain postMessage from iframe with "about:blank" src and no "targetOrigin" preference ("*") to "top" (GH-2165)', function () {
     var onMessageHandler = function (evt) {
         strictEqual(evt.data, 'GH-2165');
 
@@ -294,7 +295,7 @@ asyncTest('send message from iframe with "about:blank" src (GH-1026)', function 
             return;
 
         iframe.parentNode.removeChild(iframe);
-        window.onmessage = null;
+        window.onmessage = void 0;
         ok(true);
         start();
     };

--- a/test/client/fixtures/sandbox/event/message-test.js
+++ b/test/client/fixtures/sandbox/event/message-test.js
@@ -62,18 +62,23 @@ asyncTest('onmessage event', function () {
         });
 });
 
-asyncTest('cross domain message from iframe with "about:blank" src and no "targetOrigin" preference ("*") to "top" (GH-2165)', function () {
+asyncTest('cross domain messages should follow the "targetOrigin" rule (GH-2165)', function () {
+    var recievedMessages = [];
+
     var onMessageHandler = function (evt) {
-        strictEqual(evt.data, 'GH-2165');
+        if (recievedMessages.push(evt.data) === 2) {
+            ok(recievedMessages.indexOf('GH-2165: correct targetOrigin') > -1, 'https://example.com/');
+            ok(recievedMessages.indexOf('GH-2165: no targetOrigin preference') > -1, '*');
 
-        window.removeEventListener('message', onMessageHandler);
+            window.removeEventListener('message', onMessageHandler);
 
-        start();
+            start();
+        }
     };
 
     window.addEventListener('message', onMessageHandler);
 
-    createTestIframe({ src: getCrossDomainPageUrl('../../../data/cross-domain/no-preference-message-to-top.html') });
+    createTestIframe({ src: getCrossDomainPageUrl('../../../data/cross-domain/targetorigin-message-to-top.html') });
 });
 
 test('message types', function () {

--- a/test/client/fixtures/sandbox/event/message-test.js
+++ b/test/client/fixtures/sandbox/event/message-test.js
@@ -67,8 +67,8 @@ asyncTest('cross domain messages should follow the "targetOrigin" rule (GH-2165)
 
     var onMessageHandler = function (evt) {
         if (recievedMessages.push(evt.data) === 2) {
-            ok(recievedMessages.indexOf('GH-2165: correct targetOrigin') > -1, 'https://example.com/');
-            ok(recievedMessages.indexOf('GH-2165: no targetOrigin preference') > -1, '*');
+            ok(recievedMessages.indexOf('Should pass an origin check: correct targetOrigin') > -1, 'https://example.com/');
+            ok(recievedMessages.indexOf('Should pass an origin check: no targetOrigin preference ("*")') > -1, '*');
 
             window.removeEventListener('message', onMessageHandler);
 

--- a/test/client/fixtures/utils/url-test.js
+++ b/test/client/fixtures/utils/url-test.js
@@ -23,16 +23,6 @@ function getProxyUrl (url, resourceType, protocol, windowId) {
     });
 }
 
-test('getCrossDomainProxyUrl', function () {
-    var storedCrossDomainport = settings.get().crossDomainProxyPort;
-
-    settings.get().crossDomainProxyPort = '5555';
-
-    strictEqual(urlUtils.getCrossDomainProxyUrl(), 'http://' + location.hostname + ':5555/');
-
-    settings.get().crossDomainProxyPort = storedCrossDomainport;
-});
-
 test('getCrossDomainIframeProxyUrl (GH-749)', function () {
     var destUrl               = 'test.html';
     var storedCrossDomainport = settings.get().crossDomainProxyPort;


### PR DESCRIPTION
Fix https://github.com/DevExpress/testcafe-hammerhead/issues/2165

### Changes
1. The `postMessage` logic is fixed.
2. The `window.onmessage` handler is removed correctly in the "onmessage event" test.