### PR TITLE
Fire mouse events on custom elements with a 'disabled' attribute

### DIFF
--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -593,6 +593,16 @@ export default class EventSimulator {
         this._raiseDispatchEvent(el, pointEvent);
     }
 
+    _isDisableableHTMLElement (el): boolean {
+        for (const isDisableableHTMLElementType of DISABLEABLE_HTML_ELEMENT_TYPE_CHECKERS) {
+            if (isDisableableHTMLElementType(el)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     _dispatchMouseRelatedEvents (el, args, userOptions = {}) {
         if (args.type !== 'mouseover' && args.type !== 'mouseenter' && shouldIgnoreMouseEventInsideIframe(el, args.clientX, args.clientY))
             return true;
@@ -620,16 +630,7 @@ export default class EventSimulator {
 
     _dispatchMouseEvent (el, args, { dataTransfer, timeStamp }: any) {
         const disabledParent = domUtils.findParent(el, true, node => {
-            let disableable = false;
-
-            for (const isDisableableHTMLElementType of DISABLEABLE_HTML_ELEMENT_TYPE_CHECKERS) {
-                if (isDisableableHTMLElementType(node)) {
-                    disableable = true;
-                    break;
-                }
-            }
-            
-            return disableable && node.hasAttribute && nativeMethods.hasAttribute.call(node, 'disabled');
+            return this._isDisableableHTMLElement(node) && node.hasAttribute && nativeMethods.hasAttribute.call(node, 'disabled');
         });
 
         if (disabledParent)

--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -55,7 +55,7 @@ const DISABLEABLE_HTML_ELEMENT_TYPE_CHECKERS = [
     domUtils.isOptionElement,
     domUtils.isSelectElement,
     domUtils.isTextAreaElement
-]
+];
 
 export default class EventSimulator {
     DISPATCHED_EVENT_FLAG: string = 'hammerhead|dispatched-event';
@@ -623,8 +623,10 @@ export default class EventSimulator {
             let disableable = false;
 
             for (const isDisableableHTMLElementType of DISABLEABLE_HTML_ELEMENT_TYPE_CHECKERS) {
-                if (isDisableableHTMLElementType(node))
+                if (isDisableableHTMLElementType(node)) {
                     disableable = true;
+                    break;
+                }
             }
             
             return disableable && node.hasAttribute && nativeMethods.hasAttribute.call(node, 'disabled');

--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -47,14 +47,14 @@ const TOUCH_TO_POINTER_EVENT_TYPE_MAP = {
     touchmove:  'pointermove'
 };
 
-const DISABLEABLE_HTML_ELEMENT_CLASSES = [
-    HTMLButtonElement,
-    HTMLFieldSetElement,
-    HTMLInputElement,
-    HTMLOptGroupElement,
-    HTMLOptionElement,
-    HTMLSelectElement,
-    HTMLTextAreaElement
+const DISABLEABLE_HTML_ELEMENT_TYPE_CHECKERS = [
+    domUtils.isButtonElement,
+    domUtils.isFieldSetElement,
+    domUtils.isInputElement,
+    domUtils.isOptGroupElement,
+    domUtils.isOptionElement,
+    domUtils.isSelectElement,
+    domUtils.isTextAreaElement
 ]
 
 export default class EventSimulator {
@@ -622,8 +622,8 @@ export default class EventSimulator {
         const disabledParent = domUtils.findParent(el, true, node => {
             let disableable = false;
 
-            for (const disableableHTMLElementClass of DISABLEABLE_HTML_ELEMENT_CLASSES) {
-                if (node instanceof disableableHTMLElementClass)
+            for (const isDisableableHTMLElementType of DISABLEABLE_HTML_ELEMENT_TYPE_CHECKERS) {
+                if (isDisableableHTMLElementType(node))
                     disableable = true;
             }
             

--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -47,6 +47,16 @@ const TOUCH_TO_POINTER_EVENT_TYPE_MAP = {
     touchmove:  'pointermove'
 };
 
+const DISABLEABLE_HTML_ELEMENT_CLASSES = [
+    HTMLButtonElement,
+    HTMLFieldSetElement,
+    HTMLInputElement,
+    HTMLOptGroupElement,
+    HTMLOptionElement,
+    HTMLSelectElement,
+    HTMLTextAreaElement
+]
+
 export default class EventSimulator {
     DISPATCHED_EVENT_FLAG: string = 'hammerhead|dispatched-event';
 
@@ -610,15 +620,14 @@ export default class EventSimulator {
 
     _dispatchMouseEvent (el, args, { dataTransfer, timeStamp }: any) {
         const disabledParent = domUtils.findParent(el, true, node => {
-            let constructorAttributes;
+            let disableable = false;
 
-            if (node.__proto__.constructor.observedAttributes) {
-                constructorAttributes = node.__proto__.constructor.observedAttributes;
-            } else {
-                constructorAttributes = [];
+            for (const disableableHTMLElementClass of DISABLEABLE_HTML_ELEMENT_CLASSES) {
+                if (node instanceof disableableHTMLElementClass)
+                    disableable = true;
             }
             
-            return node.hasAttribute && nativeMethods.hasAttribute.call(node, 'disabled') && (constructorAttributes.indexOf('disabled') === -1);
+            return disableable && node.hasAttribute && nativeMethods.hasAttribute.call(node, 'disabled');
         });
 
         if (disabledParent)

--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -610,7 +610,15 @@ export default class EventSimulator {
 
     _dispatchMouseEvent (el, args, { dataTransfer, timeStamp }: any) {
         const disabledParent = domUtils.findParent(el, true, node => {
-            return node.hasAttribute && nativeMethods.hasAttribute.call(node, 'disabled');
+            let constructorAttributes;
+
+            if (node.__proto__.constructor.observedAttributes) {
+                constructorAttributes = node.__proto__.constructor.observedAttributes;
+            } else {
+                constructorAttributes = [];
+            }
+            
+            return node.hasAttribute && nativeMethods.hasAttribute.call(node, 'disabled') && (constructorAttributes.indexOf('disabled') === -1);
         });
 
         if (disabledParent)

--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -593,9 +593,9 @@ export default class EventSimulator {
         this._raiseDispatchEvent(el, pointEvent);
     }
 
-    _isDisableableHTMLElement (el): boolean {
-        for (const isDisableableHTMLElementType of DISABLEABLE_HTML_ELEMENT_TYPE_CHECKERS) {
-            if (isDisableableHTMLElementType(el)) {
+    _elementCanBeDisabled (el): boolean {
+        for (const elementCanBeDisabled of DISABLEABLE_HTML_ELEMENT_TYPE_CHECKERS) {
+            if (elementCanBeDisabled(el)) {
                 return true;
             }
         }
@@ -630,7 +630,7 @@ export default class EventSimulator {
 
     _dispatchMouseEvent (el, args, { dataTransfer, timeStamp }: any) {
         const disabledParent = domUtils.findParent(el, true, node => {
-            return this._isDisableableHTMLElement(node) && node.hasAttribute && nativeMethods.hasAttribute.call(node, 'disabled');
+            return this._elementCanBeDisabled(node) && node.hasAttribute && nativeMethods.hasAttribute.call(node, 'disabled');
         });
 
         if (disabledParent)

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -410,6 +410,14 @@ export function isButtonElement (el: any): el is HTMLButtonElement {
     return instanceToString(el) === '[object HTMLButtonElement]';
 }
 
+export function isFieldSetElement (el: any): el is HTMLFieldSetElement {
+    return instanceToString(el) === '[object HTMLFieldSetElement]';
+}
+
+export function isOptGroupElement (el: any): el is HTMLOptGroupElement {
+    return instanceToString(el) === '[object HTMLOptGroupElement]';
+}
+
 export function isHtmlElement (el: any): el is HTMLHtmlElement {
     return instanceToString(el) === '[object HTMLHtmlElement]';
 }

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -735,15 +735,16 @@ if (!browserUtils.isIE) {
             return Reflect.construct(HTMLElement, [], this.constructor);
         }
 
-        DisabledCustomElement.prototype = Object.create(HTMLElement.prototype);
+        DisabledCustomElement.prototype             = Object.create(HTMLElement.prototype);
         DisabledCustomElement.prototype.constructor = DisabledCustomElement;
+
         Object.setPrototypeOf(DisabledCustomElement, HTMLElement);
 
         customElements.define('disabled-cutsom-element', DisabledCustomElement);
 
-        var disabledCustomElement   = document.createElement('disabled-cutsom-element');
-        var span     = document.createElement('span');
-        var eventLog = [];
+        var disabledCustomElement = document.createElement('disabled-cutsom-element');
+        var span                  = document.createElement('span');
+        var eventLog              = [];
 
         document.body.appendChild(disabledCustomElement);
         disabledCustomElement.appendChild(span);

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -729,40 +729,44 @@ test('mouse events on disabled elements', function () {
     document.body.removeChild(div);
 });
 
-test('mouse events on custom elements with "disabled" property should still work (GH-2346)', function () {
-    class DisabledCustomElement extends HTMLElement {
-        constructor () {
-            super();
+if (!browserUtils.isIE) {
+    test('mouse events on custom elements with "disabled" property should still work (GH-2346)', function () {
+        function DisabledCustomElement () {
+            return Reflect.construct(HTMLElement, [], this.constructor);
         }
-    }
 
-    customElements.define('disabled-cutsom-element', DisabledCustomElement);
+        DisabledCustomElement.prototype = Object.create(HTMLElement.prototype);
+        DisabledCustomElement.prototype.constructor = DisabledCustomElement;
+        Object.setPrototypeOf(DisabledCustomElement, HTMLElement);
 
-    var disabledCustomElement   = document.createElement('disabled-cutsom-element');
-    var span     = document.createElement('span');
-    var eventLog = [];
+        customElements.define('disabled-cutsom-element', DisabledCustomElement);
 
-    document.body.appendChild(disabledCustomElement);
-    disabledCustomElement.appendChild(span);
+        var disabledCustomElement   = document.createElement('disabled-cutsom-element');
+        var span     = document.createElement('span');
+        var eventLog = [];
 
-    var mouseEventHandler = function (event) {
-        eventLog.push(event.type);
-    };
+        document.body.appendChild(disabledCustomElement);
+        disabledCustomElement.appendChild(span);
 
-    disabledCustomElement.setAttribute('disabled', true);
+        var mouseEventHandler = function (event) {
+            eventLog.push(event.type);
+        };
 
-    span.addEventListener('mousedown', mouseEventHandler);
-    span.addEventListener('mouseup', mouseEventHandler);
-    span.addEventListener('click', mouseEventHandler);
+        disabledCustomElement.setAttribute('disabled', true);
 
-    eventSimulator.mousedown(span);
-    eventSimulator.click(span);
-    eventSimulator.mouseup(span);
+        span.addEventListener('mousedown', mouseEventHandler);
+        span.addEventListener('mouseup', mouseEventHandler);
+        span.addEventListener('click', mouseEventHandler);
 
-    deepEqual(eventLog, ['mousedown', 'click', 'mouseup']);
+        eventSimulator.mousedown(span);
+        eventSimulator.click(span);
+        eventSimulator.mouseup(span);
 
-    document.body.removeChild(disabledCustomElement);
-});
+        deepEqual(eventLog, ['mousedown', 'click', 'mouseup']);
+
+        document.body.removeChild(disabledCustomElement);
+    });
+}
 
 module('regression');
 

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -729,6 +729,41 @@ test('mouse events on disabled elements', function () {
     document.body.removeChild(div);
 });
 
+test('mouse events on custom elements with "disabled" property should still work (GH-2346)', function () {
+    class DisabledCustomElement extends HTMLElement {
+        constructor () {
+            super();
+        }
+    }
+
+    customElements.define('disabled-cutsom-element', DisabledCustomElement);
+
+    var disabledCustomElement   = document.createElement('disabled-cutsom-element');
+    var span     = document.createElement('span');
+    var eventLog = [];
+
+    document.body.appendChild(disabledCustomElement);
+    disabledCustomElement.appendChild(span);
+
+    var mouseEventHandler = function (event) {
+        eventLog.push(event.type);
+    };
+
+    disabledCustomElement.setAttribute('disabled', true);
+
+    span.addEventListener('mousedown', mouseEventHandler);
+    span.addEventListener('mouseup', mouseEventHandler);
+    span.addEventListener('click', mouseEventHandler);
+
+    eventSimulator.mousedown(span);
+    eventSimulator.click(span);
+    eventSimulator.mouseup(span);
+
+    deepEqual(eventLog, ['mousedown', 'click', 'mouseup']);
+
+    document.body.removeChild(disabledCustomElement);
+});
+
 module('regression');
 
 if (browserUtils.isIE) {


### PR DESCRIPTION
## Purpose
_dispatchMouseEvent does not fire an event if the target element has a 'disabled' attribute even if this attribute is not native. This causes issues when using custom HTML elements (for example Ionic in DevExpress/testcafe#5141).

## Approach
I check if the element is an instance of any of the natively disableable HTML element classes and prevent the event from dispatching if it is. (May not be the best solution, open for feedback)

## References
DevExpress/testcafe#5141

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
