### PR TITLE
Fix `Use new File() intead of the Blob constructor in FileListWrapper (non-IE11 case)`

### DIFF
--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -334,6 +334,7 @@ class NativeMethods {
     Uint32Array: typeof Uint32Array;
     DataView: any;
     Blob: Window['Blob'];
+    File: any;
     XMLHttpRequest: any;
     Image: any;
     Function: any;
@@ -1053,6 +1054,10 @@ class NativeMethods {
         this.HTMLCollection   = win.HTMLCollection;
         this.NodeList         = win.NodeList;
         this.Node             = win.Node;
+
+        // NOTE: non-IE11 case. window.File in IE11 is not constructable.
+        if (win.File && typeof win.File === 'function')
+            this.File = win.File;
 
         if (win.Proxy)
             this.Proxy = win.Proxy;

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -549,7 +549,7 @@ export default class WindowSandbox extends SandboxBase {
         }
 
         // NOTE: non-IE11 case. window.File in IE11 is not constructable.
-        if (window.File && typeof window.File === 'function') {
+        if (nativeMethods.File) {
             window.File = function (array, fileName, opts) {
                 if (arguments.length === 0)
                     return new nativeMethods.File();

--- a/src/client/sandbox/upload/file-list-wrapper.ts
+++ b/src/client/sandbox/upload/file-list-wrapper.ts
@@ -14,8 +14,9 @@ export default class FileListWrapper {
         this.item = index => this[index];
     }
 
-    static _base64ToBlob (base64Data, fileName: string, mimeType: string, sliceSize?: number) {
-        mimeType  = mimeType || '';
+    static _base64ToBlob (base64Data, fileInfo, sliceSize?: number) {
+        const mimeType = fileInfo.info.type || '';
+
         sliceSize = sliceSize || 512;
 
         const byteCharacters = atob(base64Data);
@@ -33,7 +34,7 @@ export default class FileListWrapper {
 
         // NOTE: window.File in IE11 is not constructable.
         return nativeMethods.File
-            ? new File(byteArrays, fileName, { type: mimeType })
+            ? new File(byteArrays, fileInfo.info.name, { type: mimeType, lastModified: fileInfo.info.lastModified })
             : new Blob(byteArrays, { type: mimeType });
     }
 
@@ -49,15 +50,18 @@ export default class FileListWrapper {
         else if (fileInfo.blob) {
             // NOTE: window.File in IE11 is not constructable.
             wrapper = nativeMethods.File
-                ? new File([fileInfo.blob], fileInfo.info.name, {type: fileInfo.info.type})
+                ? new File([fileInfo.blob], fileInfo.info.name, {type: fileInfo.info.type, lastModified: fileInfo.info.lastModified})
                 : new Blob([fileInfo.blob], {type: fileInfo.info.type});
         }
         else
-            wrapper = FileListWrapper._base64ToBlob(fileInfo.data, fileInfo.info.name, fileInfo.info.type);
+            wrapper = FileListWrapper._base64ToBlob(fileInfo.data, fileInfo);
 
-        wrapper.name             = fileInfo.info.name;
-        wrapper.lastModifiedDate = new Date(fileInfo.info.lastModifiedDate);
-        wrapper.base64           = fileInfo.data;
+        wrapper.name = fileInfo.info.name;
+
+        if (fileInfo.info.lastModifiedDate)
+            wrapper.lastModifiedDate = fileInfo.info.lastModifiedDate;
+
+        wrapper.base64 = fileInfo.data;
 
         return wrapper;
     }

--- a/src/client/sandbox/upload/file-list-wrapper.ts
+++ b/src/client/sandbox/upload/file-list-wrapper.ts
@@ -32,7 +32,7 @@ export default class FileListWrapper {
         }
 
         // NOTE: window.File in IE11 is not constructable.
-        return !!nativeMethods.File
+        return nativeMethods.File
             ? new File(byteArrays, fileName, { type: mimeType })
             : new Blob(byteArrays, { type: mimeType });
     }
@@ -48,9 +48,9 @@ export default class FileListWrapper {
         }
         else if (fileInfo.blob) {
             // NOTE: window.File in IE11 is not constructable.
-            wrapper = !!nativeMethods.File
+            wrapper = nativeMethods.File
                 ? new File([fileInfo.blob], fileInfo.info.name, {type: fileInfo.info.type})
-                : wrapper = new Blob([fileInfo.blob], {type: fileInfo.info.type});
+                : new Blob([fileInfo.blob], {type: fileInfo.info.type});
         }
         else
             wrapper = FileListWrapper._base64ToBlob(fileInfo.data, fileInfo.info.name, fileInfo.info.type);

--- a/src/client/sandbox/upload/info-manager.ts
+++ b/src/client/sandbox/upload/info-manager.ts
@@ -135,14 +135,21 @@ export default class UploadInfoManager {
             let file          = fileList[index];
 
             fileReader.addEventListener('load', (e: any) => {
+                const info: any = {
+                    type: file.type,
+                    name: file.name
+                };
+
+                if (typeof file.lastModified === 'number')
+                    info.lastModified = file.lastModified;
+
+                if (file.lastModifiedDate)
+                    info.lastModifiedDate = file.lastModifiedDate;
+
                 readedFiles.push({
                     data: e.target.result.substr(e.target.result.indexOf(',') + 1),
                     blob: file.slice(0, file.size),
-                    info: {
-                        type:             file.type,
-                        name:             file.name,
-                        lastModifiedDate: file.lastModifiedDate
-                    }
+                    info
                 });
 
                 if (fileList[++index]) {
@@ -152,6 +159,7 @@ export default class UploadInfoManager {
                 else
                     resolve(new FileListWrapper(readedFiles));
             });
+
             fileReader.readAsDataURL(file);
         });
     }

--- a/src/upload/storage.ts
+++ b/src/upload/storage.ts
@@ -140,6 +140,7 @@ export default class UploadStorage {
                     data: fileContent.toString('base64'),
                     info: {
                         lastModifiedDate: fileStats.mtime,
+                        lastModified:     fileStats.mtimeMs,
                         name:             path.basename(resolvedPath),
                         type:             mime.lookup(resolvedPath)
                     }

--- a/test/client/fixtures/sandbox/node/classes-test.js
+++ b/test/client/fixtures/sandbox/node/classes-test.js
@@ -741,7 +741,10 @@ if (window.FormData) {
                 type: 'text/plain',
                 name: 'correctName.txt'
             },
-            blob: new Blob(['text'], { type: 'text/plain' })
+            // NOTE: window.File in IE11 is not constructable.
+            blob: nativeMethods.File
+                ? new File(['text'], 'correctName.txt', { type: 'text/plain' })
+                : new Blob(['text'], { type: 'text/plain' })
         }));
         formData.append(INTERNAL_ATTRS.uploadInfoHiddenInputName, '[]');
 

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -120,7 +120,7 @@ function getInputMock (fileNames) {
     var fileListWrapper = fileNames.map(function (name) {
         // NOTE: window.File in IE11 is not constructable.
         var file = nativeMethods.File
-            ? new File(['123'], name, { type: 'image/png', modifiedDate: Date.now() })
+            ? new File(['123'], name, { type: 'image/png', lastModified: Date.now() })
             : new Blob(['123'], { type: 'image/png' });
 
         file.name = name;

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -118,7 +118,10 @@ function getInputMock (fileNames) {
     var value = fileNames.join(',');
 
     var fileListWrapper = fileNames.map(function (name) {
-        var file = new Blob(['123'], { type: 'image/png' });
+        // NOTE: window.File in IE11 is not constructable.
+        var file = nativeMethods.File
+            ? new File(['123'], name, { type: 'image/png' })
+            : new Blob(['123'], { type: 'image/png' });
 
         file.name             = name;
         file.lastModifiedDate = Date.now();

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -31,7 +31,7 @@ var files = [
         file:  {
             data: 'dGVzdA==',
             info: {
-                lastModifiedDate: Date.now(),
+                lastModifiedDate: new Date(Date.now()),
                 name:             'file.txt',
                 type:             'text/plain'
             }
@@ -42,7 +42,7 @@ var files = [
         file:  {
             data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAadEVYdFNvZnR3YXJlAFBhaW50Lk5FVCB2My41LjEwMPRyoQAAAAxJREFUGFdj+L99OwAFJgJueSUNaAAAAABJRU5ErkJggg==',
             info: {
-                lastModifiedDate: Date.now(),
+                lastModifiedDate: new Date(Date.now()),
                 name:             'file.png',
                 type:             'image/png'
             }
@@ -120,11 +120,13 @@ function getInputMock (fileNames) {
     var fileListWrapper = fileNames.map(function (name) {
         // NOTE: window.File in IE11 is not constructable.
         var file = nativeMethods.File
-            ? new File(['123'], name, { type: 'image/png' })
+            ? new File(['123'], name, { type: 'image/png', modifiedDate: Date.now() })
             : new Blob(['123'], { type: 'image/png' });
 
-        file.name             = name;
-        file.lastModifiedDate = Date.now();
+        file.name = name;
+
+        if (!nativeMethods.File)
+            file.lastModifiedDate = new Date(Date.now());
 
         return file;
     });

--- a/test/server/upload-test.js
+++ b/test/server/upload-test.js
@@ -252,6 +252,7 @@ describe('Upload', () => {
             expect(fileInfo.info.name).eql(fileName);
             expect(fileInfo.info.type).eql(mime.lookup(filePath));
             expect(fileInfo.info.lastModifiedDate).eql(fs.statSync(filePath).mtime);
+            expect(fileInfo.info.lastModified).eql(fs.statSync(filePath).mtimeMs);
         }
 
         it('Should store and get file', () => {


### PR DESCRIPTION
Fix https://github.com/DevExpress/testcafe-hammerhead/issues/2338, https://github.com/DevExpress/testcafe-hammerhead/issues/1831

### Changes
1. `new File()` was used in `FileListWrapper` (insted of `new Blob()`) (non-IE11 case).
2. `window.File` constructor was overridden (non-IE11 case).
3. `lastModified` was added to wrapped `File` objects (if `File` is constructable) and `UploadStorage`.

### Note
window.File in IE11 is not constructable:
```
> window.File
< [object File]{prototype: FilePrototype {...}}
```

### Example (#2338)
```html
<!doctype html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport"
          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
    <meta http-equiv="X-UA-Compatible" content="ie=edge">
    <title>Document</title>
</head>
<body>
<form id="form">
    <input id="file-input" type="file">
    <br>
</form>

<script>
    var fileInput = document.getElementById('file-input');

    fileInput.addEventListener('change', function (e) {
        console.log(e.target.files[0]);

        console.log('name:', e.target.files[0].name);
        console.log('size:', e.target.files[0].size);
        console.log('type:', e.target.files[0].type);
        console.log('lastModifiedDate:', e.target.files[0].lastModifiedDate);
        console.log('lastModified:', e.target.files[0].lastModified);
    })
</script>

<p id="log"></p>
</body>
</html>
```
```js
import { Selector} from 'testcafe';

fixture `Fixture`
    .page `localhost:8080`;

test('upload', async t => {
    await t
        .debug()
        .setFilesToUpload(Selector('input[type="file"]'), 'C://path/1.txt')
        .expect(true).ok()
        .debug();
});
```