### PR TITLE
Overrode appendData() to insert hammerhead styles

### DIFF
--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -454,6 +454,12 @@ export default class ElementSandbox extends SandboxBase {
         const sandbox = this;
 
         this.overriddenMethods = {
+            appendData (...args) {
+                this.data += args[0];
+
+                ElementSandbox._processTextNodeContent(this, nativeMethods.nodeParentNodeGetter.call(this));
+            },
+            
             insertRow () {
                 const nativeMeth = domUtils.isTableElement(this)
                     ? nativeMethods.insertTableRow
@@ -815,6 +821,7 @@ export default class ElementSandbox extends SandboxBase {
         window.HTMLTableRowElement.prototype.insertCell    = this.overriddenMethods.insertCell;
         window.HTMLFormElement.prototype.submit            = this.overriddenMethods.formSubmit;
         window.HTMLAnchorElement.prototype.toString        = this.overriddenMethods.anchorToString;
+        window.CharacterData.prototype.appendData          = this.overriddenMethods.appendData;
 
         if (window.Document.prototype.registerElement)
             window.Document.prototype.registerElement = this.overriddenMethods.registerElement;

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -455,7 +455,7 @@ export default class ElementSandbox extends SandboxBase {
 
         this.overriddenMethods = {
             appendData (...args) {
-                this.data += args[0];
+                nativeMethods.nodeTextContentSetter.call(this, nativeMethods.nodeTextContentGetter.call(this) + args[0]);
 
                 ElementSandbox._processTextNodeContent(this, nativeMethods.nodeParentNodeGetter.call(this));
             },

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -457,7 +457,8 @@ export default class ElementSandbox extends SandboxBase {
             appendData (...args) {
                 nativeMethods.nodeTextContentSetter.call(this, nativeMethods.nodeTextContentGetter.call(this) + args[0]);
 
-                ElementSandbox._processTextNodeContent(this, nativeMethods.nodeParentNodeGetter.call(this));
+                if (nativeMethods.nodeParentNodeGetter.call(this))
+                    ElementSandbox._processTextNodeContent(this, nativeMethods.nodeParentNodeGetter.call(this));
             },
             
             insertRow () {

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -454,8 +454,8 @@ export default class ElementSandbox extends SandboxBase {
         const sandbox = this;
 
         this.overriddenMethods = {
-            appendData (...args) {
-                nativeMethods.nodeTextContentSetter.call(this, nativeMethods.nodeTextContentGetter.call(this) + args[0]);
+            appendData (text) {
+                nativeMethods.nodeTextContentSetter.call(this, nativeMethods.nodeTextContentGetter.call(this) + text);
 
                 if (nativeMethods.nodeParentNodeGetter.call(this))
                     ElementSandbox._processTextNodeContent(this, nativeMethods.nodeParentNodeGetter.call(this));

--- a/test/client/fixtures/sandbox/style-test.js
+++ b/test/client/fixtures/sandbox/style-test.js
@@ -153,3 +153,22 @@ test('the getAttribute function should return cleaned style (GH-1922)', function
         ? 'display: none; background-color: green;'
         : 'background-color: green; display: none;');
 });
+
+test('the appendData function should append processed text (TC-3830)', function () {
+    const style    = document.createElement('style');
+    const textNode = document.createTextNode('');
+
+    style.appendChild(textNode);
+
+    textNode.appendData('\n.class:hover{}\n');
+
+    strictEqual(textNode.data, '\n.class[data-hammerhead-hovered]{}\n');
+});
+
+test('the appendData function does not break if there is no parent element (TC-3830)', function () {
+    const textNode = document.createTextNode('');
+
+    textNode.appendData('\n.class:hover{}\n');
+
+    strictEqual(textNode.data, '\n.class:hover{}\n');
+});


### PR DESCRIPTION
## Purpose
Hover did not work on styled-components Devexpress/testcafe#3830 because `window.CharacterData.prototype.appendData` was not overriden to inject hammerhead styles

## Approach
`window.CharacterData.prototype.appendData` now calls `ElementSandbox._processTextNodeContent()` if the element has a parent.

## References
Closes Devexpress/testcafe#3830

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
