### PR TITLE
Correct instantiation of LocationWrapper (closes #2417)

### DIFF
--- a/src/client/sandbox/code-instrumentation/location/wrapper.ts
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.ts
@@ -36,7 +36,7 @@ function getLocationUrl (window: Window): string | undefined {
 }
 
 export default class LocationWrapper {
-    constructor (window: Window, messageSandbox?: MessageSandbox, onChanged?: Function) {
+    constructor (window: Window, messageSandbox: MessageSandbox, onChanged: Function) {
         const parsedLocation         = parseProxyUrl(getLocationUrl(window) as string);
         const locationResourceType   = parsedLocation ? parsedLocation.resourceType : '';
         const parsedResourceType     = parseResourceType(locationResourceType);

--- a/src/client/sandbox/code-instrumentation/properties/index.ts
+++ b/src/client/sandbox/code-instrumentation/properties/index.ts
@@ -14,6 +14,7 @@ import settings from '../../../settings';
 import { isIE } from '../../../utils/browser';
 import WindowSandbox from '../../node/window';
 import ShadowUISandbox from '../../shadow-ui';
+import noop from '../../../utils/noop';
 
 export default class PropertyAccessorsInstrumentation extends SandboxBase {
     // NOTE: Isolate throw statements into a separate function because the
@@ -83,7 +84,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
 
                     const wnd = domUtils.isWindow(owner) ? owner : owner.defaultView;
 
-                    return new LocationWrapper(wnd);
+                    return new LocationWrapper(wnd, null, noop);
                 },
 
                 set: (owner: Window | Document, location: Location) => {

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -776,3 +776,26 @@ test('set a relative url to a cross-domain location', function () {
             checkLocation(iframes[1].contentWindow.location);
         });
 });
+
+
+test('location.replace should not throw an error when called by iframe added dynamically (GH-2417)', function () {
+    const iframe = document.createElement('iframe');
+
+    iframe.id  = 'test001';
+
+    document.body.appendChild(iframe);
+
+    let err = null;
+
+    try {
+        eval(processScript('iframe.contentDocument.location.replace("./index.html");'));
+    }
+    catch (e) {
+        err = e;
+    }
+    finally {
+        ok(!err, err);
+
+        document.body.removeChild(iframe);
+    }
+});


### PR DESCRIPTION
## Purpose

This PR fixes a bug which occurs when dynamically (from script on page) added IFrame tried to call `replace` method of `location` object in Firefox browser. In more general case, affected all overwritten properties of `location` object in `LocationWrapper` class (href, search, assign, replace, etc).

The real cause of the problem, is in the instantiation of `LocationWrapper` class with only one argument instead of three. This incorrect instantiation happened only in Firefox. Most probably because of different processing of IFrame `complete` state than other browsers have.

## Approach

Instantiation was corrected. Typings for LocationWrapper class was changed because initially third argument (`onChanged` function) was marked as optional despite the fact that it was called anyway.

## References
#2417

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
