### PR TITLE
Update body mutation tracking when adding the body to the document

### DIFF
--- a/src/client/sandbox/node/index.ts
+++ b/src/client/sandbox/node/index.ts
@@ -19,6 +19,7 @@ import CookieSandbox from '../cookie';
 import * as browserUtils from '../../utils/browser';
 import ChildWindowSandbox from '../child-window';
 import DocumentTitleStorage from './document/title-storage';
+import domMutationTracker from './live-node-list/dom-mutation-tracker';
 
 const ATTRIBUTE_SELECTOR_REG_EX          = /\[([\w-]+)(\^?=.+?)]/g;
 const ATTRIBUTE_OPERATOR_WITH_HASH_VALUE = /^\W+\s*#/;
@@ -59,6 +60,10 @@ export default class NodeSandbox extends SandboxBase {
     private _onBodyCreated (): void {
         this._eventSandbox.listeners.initDocumentBodyListening(this.document);
         this.mutation.onBodyCreated(this.document.body as HTMLBodyElement);
+
+        // NOTE: This call updates the 'body' tag in the dom-mutation-tracker.
+        // We need it in case document.getElementsByTagName('body') was called before the body was created.
+        domMutationTracker.onElementChanged(this.document.body);
     }
 
     private _processElement (el: HTMLElement): void {

--- a/src/client/sandbox/node/index.ts
+++ b/src/client/sandbox/node/index.ts
@@ -19,7 +19,7 @@ import CookieSandbox from '../cookie';
 import * as browserUtils from '../../utils/browser';
 import ChildWindowSandbox from '../child-window';
 import DocumentTitleStorage from './document/title-storage';
-import domMutationTracker from './live-node-list/dom-mutation-tracker';
+import DOMMutationTracker from './live-node-list/dom-mutation-tracker';
 
 const ATTRIBUTE_SELECTOR_REG_EX          = /\[([\w-]+)(\^?=.+?)]/g;
 const ATTRIBUTE_OPERATOR_WITH_HASH_VALUE = /^\W+\s*#/;
@@ -182,7 +182,7 @@ export default class NodeSandbox extends SandboxBase {
     private _updateBodyMutationTracking (mutationsList) {
         for (let mutation of mutationsList) {
             if (mutation[MUTATION_ADDED_NODES_NAME][0] && domUtils.isBodyElement(mutation[MUTATION_ADDED_NODES_NAME][0]))
-                domMutationTracker.onElementChanged(mutation[MUTATION_ADDED_NODES_NAME][0]);
+                DOMMutationTracker.onElementChanged(mutation[MUTATION_ADDED_NODES_NAME][0]);
         }
     }
 

--- a/src/client/sandbox/node/live-node-list/dom-mutation-tracker.ts
+++ b/src/client/sandbox/node/live-node-list/dom-mutation-tracker.ts
@@ -12,7 +12,7 @@ class DOMMutationTracker {
         this._isDomContentLoaded = false;
 
         nativeMethods.addEventListener.call(document, 'DOMContentLoaded', () => {
-            for (const tagName of Object.keys(this._mutations))
+            for (const tagName of nativeMethods.objectKeys(this._mutations))
                 this._updateVersion(tagName);
 
             this._isDomContentLoaded = true;

--- a/src/client/sandbox/node/live-node-list/dom-mutation-tracker.ts
+++ b/src/client/sandbox/node/live-node-list/dom-mutation-tracker.ts
@@ -12,6 +12,9 @@ class DOMMutationTracker {
         this._isDomContentLoaded = false;
 
         nativeMethods.addEventListener.call(document, 'DOMContentLoaded', () => {
+            for (const tagName of Object.keys(this._mutations))
+                this._updateVersion(tagName);
+
             this._isDomContentLoaded = true;
         });
     }

--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -177,6 +177,9 @@ export default class ShadowUI extends SandboxBase {
                         return nativeCollection;
 
                     if (!nativeCollection[HTML_COLLECTION_WRAPPER])
+                        // NOTE: This changes how the native method behaves. The returned collection will have this wrapper attached
+                        // if the method was called with the same tagName parameter.
+                        // This allows skipping the search if the DOM tree has not changed since the last call.
                         nativeCollection[HTML_COLLECTION_WRAPPER] = new HTMLCollectionWrapper(nativeCollection, tagName);
                     else
                         nativeCollection[HTML_COLLECTION_WRAPPER]._refreshCollection();

--- a/test/client/data/live-node-list/getBodyByTagName.html
+++ b/test/client/data/live-node-list/getBodyByTagName.html
@@ -14,13 +14,13 @@
             hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
             hammerhead.start({ crossDomainProxyPort: 2000 });
 
-            window.top.bodyExistsBeforeAttachingBody = bodyExists();
+            window.bodyExistsBeforeAttachingBody = bodyExists();
         </script>
     </head>
     <body>
         <script>
             document.addEventListener('DOMContentLoaded', function () {
-                window.top.bodyExistsAfterAttachingBody = bodyExists();
+                window.bodyExistsAfterAttachingBody = bodyExists();
             });
         </script>
     </body>

--- a/test/client/data/live-node-list/getBodyByTagName.html
+++ b/test/client/data/live-node-list/getBodyByTagName.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Title</title>
+        <script src="/hammerhead.js" class="script-hammerhead-shadow-ui"></script>
+        <script>
+            function bodyExists () {
+                return document.getElementsByTagName('body').length === 1;
+            }
+
+            const hammerhead = window['%hammerhead%'];
+
+            hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+            hammerhead.start({ crossDomainProxyPort: 2000 });
+
+            window.top.bodyExistsBeforeAttachingBody = bodyExists();
+        </script>
+    </head>
+    <body>
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                window.top.bodyExistsAfterAttachingBody = bodyExists();
+            });
+        </script>
+    </body>
+</html>

--- a/test/client/data/live-node-list/getElementsByTagName.html
+++ b/test/client/data/live-node-list/getElementsByTagName.html
@@ -5,24 +5,22 @@
     <title>Title</title>
     <script src="/hammerhead.js" class="script-hammerhead-shadow-ui"></script>
     <script>
-        function findBody() {
-            return Object.assign({}, document.getElementsByTagName('body'));
+        function bodyExists () {
+            return document.getElementsByTagName('body').length === 1;
         }
 
-        const hammerhead = window['%hammerhead%'];
+        window.top.hammerhead = window['%hammerhead%'];
 
-        hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
-        hammerhead.start({ crossDomainProxyPort: 2000 });
+        window.top.hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+        window.top.hammerhead.start({ crossDomainProxyPort: 2000 });
 
-        window.top.resultWithoutBody = findBody();
-
-        document.addEventListener('DOMContentLoaded', () => {
-            window.top.resultWithBody = findBody();
-        });
+        window.top.bodyExistsBeforeAttachingBody = bodyExists();
     </script>
 </head>
 <body>
 <script>
+    window.top.bodyExistsAfterAttachingBody = bodyExists();
+    
     var domContentLoadedIsRaised = false;
     var refreshCollectionCount   = 0;
     var assertions               = [];
@@ -31,18 +29,18 @@
         domContentLoadedIsRaised = true;
     });
 
-    var DOMMutationTrackerProto = Object.getPrototypeOf(hammerhead.get('./sandbox/node/live-node-list/dom-mutation-tracker'));
+    var DOMMutationTrackerProto = Object.getPrototypeOf(window.top.hammerhead.get('./sandbox/node/live-node-list/dom-mutation-tracker'));
 
     var testDiv = document.createElement('div');
 
     document.body.appendChild(testDiv);
 
-    var root      = hammerhead.shadowUI.getRoot();
+    var root      = window.top.hammerhead.shadowUI.getRoot();
     var textarea1 = document.createElement('textarea');
     var textarea2 = document.createElement('textarea');
     var textarea3 = document.createElement('textarea');
 
-    hammerhead.shadowUI.addClass(textarea3, 'el');
+    window.top.hammerhead.shadowUI.addClass(textarea3, 'el');
     root.appendChild(textarea3);
     testDiv.appendChild(textarea1);
     testDiv.appendChild(textarea2);

--- a/test/client/data/live-node-list/getElementsByTagName.html
+++ b/test/client/data/live-node-list/getElementsByTagName.html
@@ -4,6 +4,22 @@
     <meta charset="UTF-8">
     <title>Title</title>
     <script src="/hammerhead.js" class="script-hammerhead-shadow-ui"></script>
+    <script>
+        function findBody() {
+            return Object.assign({}, document.getElementsByTagName('body'));
+        }
+
+        const hammerhead = window['%hammerhead%'];
+
+        hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+        hammerhead.start({ crossDomainProxyPort: 2000 });
+
+        window.top.resultWithoutBody = findBody();
+
+        document.addEventListener('DOMContentLoaded', () => {
+            window.top.resultWithBody = findBody();
+        });
+    </script>
 </head>
 <body>
 <script>
@@ -14,11 +30,6 @@
     document.addEventListener('DOMContentLoaded', function () {
         domContentLoadedIsRaised = true;
     });
-
-    var hammerhead = window['%hammerhead%'];
-
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
-    hammerhead.start({ crossDomainProxyPort: 2000 });
 
     var DOMMutationTrackerProto = Object.getPrototypeOf(hammerhead.get('./sandbox/node/live-node-list/dom-mutation-tracker'));
 

--- a/test/client/data/live-node-list/getElementsByTagName.html
+++ b/test/client/data/live-node-list/getElementsByTagName.html
@@ -4,23 +4,9 @@
     <meta charset="UTF-8">
     <title>Title</title>
     <script src="/hammerhead.js" class="script-hammerhead-shadow-ui"></script>
-    <script>
-        function bodyExists () {
-            return document.getElementsByTagName('body').length === 1;
-        }
-
-        window.top.hammerhead = window['%hammerhead%'];
-
-        window.top.hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
-        window.top.hammerhead.start({ crossDomainProxyPort: 2000 });
-
-        window.top.bodyExistsBeforeAttachingBody = bodyExists();
-    </script>
 </head>
 <body>
 <script>
-    window.top.bodyExistsAfterAttachingBody = bodyExists();
-    
     var domContentLoadedIsRaised = false;
     var refreshCollectionCount   = 0;
     var assertions               = [];
@@ -29,18 +15,23 @@
         domContentLoadedIsRaised = true;
     });
 
-    var DOMMutationTrackerProto = Object.getPrototypeOf(window.top.hammerhead.get('./sandbox/node/live-node-list/dom-mutation-tracker'));
+    var hammerhead = window['%hammerhead%'];
+
+    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.start({ crossDomainProxyPort: 2000 });
+
+    var DOMMutationTrackerProto = Object.getPrototypeOf(hammerhead.get('./sandbox/node/live-node-list/dom-mutation-tracker'));
 
     var testDiv = document.createElement('div');
 
     document.body.appendChild(testDiv);
 
-    var root      = window.top.hammerhead.shadowUI.getRoot();
+    var root      = hammerhead.shadowUI.getRoot();
     var textarea1 = document.createElement('textarea');
     var textarea2 = document.createElement('textarea');
     var textarea3 = document.createElement('textarea');
 
-    window.top.hammerhead.shadowUI.addClass(textarea3, 'el');
+    hammerhead.shadowUI.addClass(textarea3, 'el');
     root.appendChild(textarea3);
     testDiv.appendChild(textarea1);
     testDiv.appendChild(textarea2);

--- a/test/client/fixtures/sandbox/node/html-collection-wrapper-test.js
+++ b/test/client/fixtures/sandbox/node/html-collection-wrapper-test.js
@@ -447,12 +447,8 @@ module('getElementsByTagName', function () {
         test('getElementsByTagName(\'body\') updates correctly GH-5322', function () {
             return createTestIframe({ src: getSameDomainPageUrl('../../../data/live-node-list/getBodyByTagName.html') })
                 .then(function (iframe) {
-                    const assertions = [];
-
-                    assertions.push([!iframe.contentWindow.bodyExistsBeforeAttachingBody, true, 'getElementsByTagName(\'body\') returned an empty collection before the body was created']);
-                    assertions.push([iframe.contentWindow.bodyExistsAfterAttachingBody, true, 'getElementsByTagName(\'body\') returned a non-empty collection after the body was created']);
-
-                    checkAssertions(assertions);
+                    ok(!iframe.contentWindow.bodyExistsBeforeAttachingBody);
+                    ok(iframe.contentWindow.bodyExistsAfterAttachingBody);
                 });
         });
     });

--- a/test/client/fixtures/sandbox/node/html-collection-wrapper-test.js
+++ b/test/client/fixtures/sandbox/node/html-collection-wrapper-test.js
@@ -445,7 +445,7 @@ module('getElementsByTagName', function () {
         });
 
         test('getElementsByTagName(\'body\') updates correctly GH-5322', function () {
-            return createTestIframe({ src: getSameDomainPageUrl('../../../data/live-node-list/getElementsByTagName.html') })
+            return createTestIframe({ src: getSameDomainPageUrl('../../../data/live-node-list/getBodyByTagName.html') })
                 .then(function () {
                     const assertions = [];
 

--- a/test/client/fixtures/sandbox/node/html-collection-wrapper-test.js
+++ b/test/client/fixtures/sandbox/node/html-collection-wrapper-test.js
@@ -449,8 +449,8 @@ module('getElementsByTagName', function () {
                 .then(function () {
                     const assertions = [];
 
-                    assertions.push([Object.keys(window.top.resultWithoutBody).length === 0, true, 'getElementsByTagName(\'body\') returned an empty collection before the body was created']);
-                    assertions.push([Object.keys(window.top.resultWithBody).length === 1, true, 'getElementsByTagName(\'body\') returned a non-empty collection after the body was created']);
+                    assertions.push([!window.top.bodyExistsBeforeAttachingBody, true, 'getElementsByTagName(\'body\') returned an empty collection before the body was created']);
+                    assertions.push([window.top.bodyExistsAfterAttachingBody, true, 'getElementsByTagName(\'body\') returned a non-empty collection after the body was created']);
 
                     checkAssertions(assertions);
                 });

--- a/test/client/fixtures/sandbox/node/html-collection-wrapper-test.js
+++ b/test/client/fixtures/sandbox/node/html-collection-wrapper-test.js
@@ -446,11 +446,11 @@ module('getElementsByTagName', function () {
 
         test('getElementsByTagName(\'body\') updates correctly GH-5322', function () {
             return createTestIframe({ src: getSameDomainPageUrl('../../../data/live-node-list/getBodyByTagName.html') })
-                .then(function () {
+                .then(function (iframe) {
                     const assertions = [];
 
-                    assertions.push([!window.top.bodyExistsBeforeAttachingBody, true, 'getElementsByTagName(\'body\') returned an empty collection before the body was created']);
-                    assertions.push([window.top.bodyExistsAfterAttachingBody, true, 'getElementsByTagName(\'body\') returned a non-empty collection after the body was created']);
+                    assertions.push([!iframe.contentWindow.bodyExistsBeforeAttachingBody, true, 'getElementsByTagName(\'body\') returned an empty collection before the body was created']);
+                    assertions.push([iframe.contentWindow.bodyExistsAfterAttachingBody, true, 'getElementsByTagName(\'body\') returned a non-empty collection after the body was created']);
 
                     checkAssertions(assertions);
                 });

--- a/test/client/fixtures/sandbox/node/html-collection-wrapper-test.js
+++ b/test/client/fixtures/sandbox/node/html-collection-wrapper-test.js
@@ -444,7 +444,7 @@ module('getElementsByTagName', function () {
             DOMMutationTrackerProto.getVersion = storedGetVersion;
         });
 
-        test('getElementsByTagName(\'body\') updates correctly GH-5322', function () {
+        test('getElementsByTagName("body") updates correctly GH-5322', function () {
             return createTestIframe({ src: getSameDomainPageUrl('../../../data/live-node-list/getBodyByTagName.html') })
                 .then(function (iframe) {
                     ok(!iframe.contentWindow.bodyExistsBeforeAttachingBody);

--- a/test/client/fixtures/sandbox/node/html-collection-wrapper-test.js
+++ b/test/client/fixtures/sandbox/node/html-collection-wrapper-test.js
@@ -443,5 +443,17 @@ module('getElementsByTagName', function () {
 
             DOMMutationTrackerProto.getVersion = storedGetVersion;
         });
+
+        test('getElementsByTagName(\'body\') updates correctly GH-5322', function () {
+            return createTestIframe({ src: getSameDomainPageUrl('../../../data/live-node-list/getElementsByTagName.html') })
+                .then(function () {
+                    const assertions = [];
+
+                    assertions.push([Object.keys(window.top.resultWithoutBody).length === 0, true, 'getElementsByTagName(\'body\') returned an empty collection before the body was created']);
+                    assertions.push([Object.keys(window.top.resultWithBody).length === 1, true, 'getElementsByTagName(\'body\') returned a non-empty collection after the body was created']);
+
+                    checkAssertions(assertions);
+                });
+        });
     });
 });


### PR DESCRIPTION
## Purpose
We are overriding `document.getElementsByTagName()` and adding a `'hammerhead|shadow-ui|html-collection-wrapper'` property to the native function's results. It's implemented for optimization purposes - we store an element list returned by the first function call and update it only if the DOM tree updated. (the version of the `DOMMutationTracker` for this tag should be higher than the `'hammerhead|shadow-ui|html-collection-wrapper'` version)

This works for elements that trigger `element._onElementAdded` which calls `DOMMutationTracker.onElementChanged` that updates the version. However, the <body> element does not trigger it.

That means it's possible to call the `document.getElementsByTagName('body')` before the <body> element gets added to the page. This makes any subsequent `document.getElementsByTagName('body')` calls return the stored empty collection as the `DOMMutationTracker` does not get updated when the <body> element is added.

## Approach
I'm updating the tracked tag versions in `DOMMutationTracker` on the `DOMContentLoaded` event.

## References
Closes Devexpress/testcafe#5322

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
