### PR TITLE
Fix string representation of native func wrappers

### DIFF
--- a/src/client/sandbox/code-instrumentation/index.ts
+++ b/src/client/sandbox/code-instrumentation/index.ts
@@ -37,7 +37,6 @@ export default class CodeInstrumentation extends SandboxBase {
         // NOTE: GH-260
         nativeMethods.objectDefineProperty(window, INSTRUCTION.getEval, {
             value: (evalFn: Function) => {
-                // @ts-ignore
                 if (evalFn !== window.eval)
                     return evalFn;
 

--- a/src/client/sandbox/code-instrumentation/location/ancestor-origins-wrapper.ts
+++ b/src/client/sandbox/code-instrumentation/location/ancestor-origins-wrapper.ts
@@ -1,6 +1,6 @@
 import nativeMethods from '../../native-methods';
 import LocationAccessorsInstrumentation from './index';
-import { createOverriddenDescriptor } from '../../../utils/property-overriding';
+import { createOverriddenDescriptor } from '../../../utils/overriding';
 
 const lengthWeakMap = new WeakMap<DOMStringListWrapper, number>();
 

--- a/src/client/sandbox/code-instrumentation/location/wrapper.ts
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.ts
@@ -20,7 +20,7 @@ import urlResolver from '../../../utils/url-resolver';
 import DomProcessor from '../../../../processing/dom';
 import DOMStringListWrapper from './ancestor-origins-wrapper';
 import IntegerIdGenerator from '../../../utils/integer-id-generator';
-import { createOverriddenDescriptor } from '../../../utils/property-overriding';
+import { createOverriddenDescriptor } from '../../../utils/overriding';
 import MessageSandbox from '../../event/message';
 
 const GET_ORIGIN_CMD      = 'hammerhead|command|get-origin';

--- a/src/client/sandbox/console.ts
+++ b/src/client/sandbox/console.ts
@@ -2,7 +2,7 @@ import SandboxBase from './base';
 import { isCrossDomainWindows } from '../utils/dom';
 import nativeMethods from '../sandbox/native-methods';
 import MessageSandbox from './event/message';
-import { overrideFunction } from '../utils/property-overriding';
+import { overrideFunction } from '../utils/overriding';
 
 export default class ConsoleSandbox extends SandboxBase {
     CONSOLE_METH_CALLED_EVENT = 'hammerhead|event|console-meth-called';

--- a/src/client/sandbox/console.ts
+++ b/src/client/sandbox/console.ts
@@ -27,7 +27,7 @@ export default class ConsoleSandbox extends SandboxBase {
         }
     }
 
-    private _proxyConsoleMeth (meth: string): void {
+    private _proxyConsoleMeth (meth: keyof Console): void {
         const consoleMethWrapper = (...args: any[]) => {
             if (!isCrossDomainWindows(window, window.top)) {
                 const sendToTopWindow = window !== window.top;
@@ -44,7 +44,7 @@ export default class ConsoleSandbox extends SandboxBase {
             this.nativeMethods.consoleMeths[meth].apply(this.nativeMethods.console, args);
         };
 
-        overrideFunction((this.window as any).console, meth, consoleMethWrapper);
+        overrideFunction(this.window.console, meth, consoleMethWrapper);
     }
 
     attach (window: Window & typeof globalThis) {

--- a/src/client/sandbox/console.ts
+++ b/src/client/sandbox/console.ts
@@ -28,7 +28,7 @@ export default class ConsoleSandbox extends SandboxBase {
     }
 
     private _proxyConsoleMeth (meth: keyof Console): void {
-        const consoleMethWrapper = (...args: any[]) => {
+        overrideFunction(this.window.console, meth, (...args: any[]) => {
             if (!isCrossDomainWindows(window, window.top)) {
                 const sendToTopWindow = window !== window.top;
                 const line            = nativeMethods.arrayMap.call(args, this._toString).join(' ');
@@ -42,9 +42,7 @@ export default class ConsoleSandbox extends SandboxBase {
             }
 
             this.nativeMethods.consoleMeths[meth].apply(this.nativeMethods.console, args);
-        };
-
-        overrideFunction(this.window.console, meth, consoleMethWrapper);
+        });
     }
 
     attach (window: Window & typeof globalThis) {

--- a/src/client/sandbox/electron.ts
+++ b/src/client/sandbox/electron.ts
@@ -1,6 +1,7 @@
 import SandboxBase from './base';
 import { processScript } from '../../processing/script';
 import * as destinationLocation from '../utils/destination-location';
+import { overrideFunction } from '../utils/property-overriding';
 
 export default class ElectronSandbox extends SandboxBase {
     static _createFnWrapper (vm, nativeFn) {
@@ -50,11 +51,11 @@ export default class ElectronSandbox extends SandboxBase {
         const nativeMethods = this.nativeMethods;
 
         if (nativeMethods.refreshElectronMeths(vm)) {
-            vm.createScript      = ElectronSandbox._createFnWrapper(vm, nativeMethods.createScript);
-            vm.runInDebugContext = ElectronSandbox._createFnWrapper(vm, nativeMethods.runInDebugContext);
-            vm.runInContext      = ElectronSandbox._createFnWrapper(vm, nativeMethods.runInContext);
-            vm.runInNewContext   = ElectronSandbox._createFnWrapper(vm, nativeMethods.runInNewContext);
-            vm.runInThisContext  = ElectronSandbox._createFnWrapper(vm, nativeMethods.runInThisContext);
+            overrideFunction(vm, 'createScript', ElectronSandbox._createFnWrapper(vm, nativeMethods.createScript));
+            overrideFunction(vm, 'runInDebugContext', ElectronSandbox._createFnWrapper(vm, nativeMethods.runInDebugContext));
+            overrideFunction(vm, 'runInContext', ElectronSandbox._createFnWrapper(vm, nativeMethods.runInContext));
+            overrideFunction(vm, 'runInNewContext', ElectronSandbox._createFnWrapper(vm, nativeMethods.runInNewContext));
+            overrideFunction(vm, 'runInThisContext', ElectronSandbox._createFnWrapper(vm, nativeMethods.runInThisContext));
 
             ElectronSandbox._overrideElectronModulePaths(window);
         }

--- a/src/client/sandbox/electron.ts
+++ b/src/client/sandbox/electron.ts
@@ -1,7 +1,7 @@
 import SandboxBase from './base';
 import { processScript } from '../../processing/script';
 import * as destinationLocation from '../utils/destination-location';
-import { overrideFunction } from '../utils/property-overriding';
+import { overrideFunction } from '../utils/overriding';
 
 export default class ElectronSandbox extends SandboxBase {
     static _createFnWrapper (vm, nativeFn) {

--- a/src/client/sandbox/event/index.ts
+++ b/src/client/sandbox/event/index.ts
@@ -15,7 +15,7 @@ import UnloadSandbox from './unload';
 import MessageSandbox from './message';
 import ShadowUI from '../shadow-ui';
 import TimersSandbox from '../timers';
-import { overrideFunction, overrideStringRepresentation } from '../../utils/property-overriding';
+import { overrideFunction, overrideStringRepresentation } from '../../utils/overriding';
 
 export default class EventSandbox extends SandboxBase {
     EVENT_PREVENTED_EVENT: string = 'hammerhead|event|event-prevented';

--- a/src/client/sandbox/event/index.ts
+++ b/src/client/sandbox/event/index.ts
@@ -194,16 +194,14 @@ export default class EventSandbox extends SandboxBase {
         // @ts-ignore Window constructor has no the focus method
         window.Window.focus = this._overriddenMethods.focus;
 
-        // NOTE:
-        // we cannot use 'overrideFunction' here since the focus method may not exist
+        // NOTE: we cannot use 'overrideFunction' here since the focus method may not exist
         // @ts-ignore Window constructor has no the focus method
         overrideStringRepresentation(window.Window.focus, nativeMethods.focus);
 
         // @ts-ignore Window constructor has no the blur method
         window.Window.blur  = this._overriddenMethods.blur;
 
-        // NOTE:
-        // we cannot use 'overrideFunction' here since the blur method may not exist
+        // NOTE: we cannot use 'overrideFunction' here since the blur method may not exist
         // @ts-ignore Window constructor has no the blur method
         overrideStringRepresentation(window.Window.blur, nativeMethods.blur);
 

--- a/src/client/sandbox/event/index.ts
+++ b/src/client/sandbox/event/index.ts
@@ -15,6 +15,7 @@ import UnloadSandbox from './unload';
 import MessageSandbox from './message';
 import ShadowUI from '../shadow-ui';
 import TimersSandbox from '../timers';
+import { overrideFunction, overrideStringRepresentation } from '../../utils/property-overriding';
 
 export default class EventSandbox extends SandboxBase {
     EVENT_PREVENTED_EVENT: string = 'hammerhead|event|event-prevented';
@@ -171,33 +172,39 @@ export default class EventSandbox extends SandboxBase {
     attach (window: Window & typeof globalThis): void {
         super.attach(window);
 
-        window.HTMLInputElement.prototype.setSelectionRange    = this._overriddenMethods.setSelectionRange;
-        window.HTMLTextAreaElement.prototype.setSelectionRange = this._overriddenMethods.setSelectionRange;
+        overrideFunction(window.HTMLInputElement.prototype, 'setSelectionRange', this._overriddenMethods.setSelectionRange, );
+        overrideFunction(window.HTMLTextAreaElement.prototype, 'setSelectionRange', this._overriddenMethods.setSelectionRange);
 
         if (isIE11) {
-            window.Window.prototype.dispatchEvent      = this._overriddenMethods.dispatchEvent;
-            window.Document.prototype.dispatchEvent    = this._overriddenMethods.dispatchEvent;
-            window.HTMLElement.prototype.dispatchEvent = this._overriddenMethods.dispatchEvent;
-            window.SVGElement.prototype.dispatchEvent  = this._overriddenMethods.dispatchEvent;
+            overrideFunction(window.Window.prototype, 'dispatchEvent', this._overriddenMethods.dispatchEvent);
+            overrideFunction(window.Document.prototype, 'dispatchEvent', this._overriddenMethods.dispatchEvent);
+            overrideFunction(window.HTMLElement.prototype, 'dispatchEvent', this._overriddenMethods.dispatchEvent);
+            overrideFunction(window.SVGElement.prototype, 'dispatchEvent', this._overriddenMethods.dispatchEvent);
         }
-        else
-            window.EventTarget.prototype.dispatchEvent = this._overriddenMethods.dispatchEvent;
+        else {
+            overrideFunction(window.EventTarget.prototype, 'dispatchEvent', this._overriddenMethods.dispatchEvent);
+        }
 
-        window.HTMLElement.prototype.focus    = this._overriddenMethods.focus;
-        window.HTMLElement.prototype.blur     = this._overriddenMethods.blur;
-        window.HTMLElement.prototype.click    = this._overriddenMethods.click;
-        window.Event.prototype.preventDefault = this._overriddenMethods.preventDefault;
+        overrideFunction(window.HTMLElement.prototype, 'focus', this._overriddenMethods.focus);
+        overrideFunction(window.HTMLElement.prototype, 'blur', this._overriddenMethods.blur);
+        overrideFunction(window.HTMLElement.prototype, 'click', this._overriddenMethods.click);
+
+        overrideFunction(window.Event.prototype, 'preventDefault', this._overriddenMethods.preventDefault);
 
         // @ts-ignore Window constructor has no the focus method
         window.Window.focus = this._overriddenMethods.focus;
+        // @ts-ignore Window constructor has no the focus method
+        overrideStringRepresentation(window.Window.focus, nativeMethods.focus);
+
         // @ts-ignore Window constructor has no the blur method
         window.Window.blur  = this._overriddenMethods.blur;
+        // @ts-ignore Window constructor has no the blur method
+        overrideStringRepresentation(window.Window.blur, nativeMethods.blur);
 
         // @ts-ignore TextRange exists only in IE
-        if (window.TextRange && window.TextRange.prototype.select) {
+        if (window.TextRange && window.TextRange.prototype.select)
             // @ts-ignore TextRange exists only in IE
-            window.TextRange.prototype.select = this._overriddenMethods.select;
-        }
+            overrideFunction(window.TextRange.prototype, 'select', this._overriddenMethods.select);
 
         this.listeners.initElementListening(document, DOM_EVENTS);
         this.listeners.initElementListening(window, DOM_EVENTS.concat(['load', 'beforeunload', 'pagehide', 'unload', 'message']));

--- a/src/client/sandbox/event/index.ts
+++ b/src/client/sandbox/event/index.ts
@@ -172,7 +172,7 @@ export default class EventSandbox extends SandboxBase {
     attach (window: Window & typeof globalThis): void {
         super.attach(window);
 
-        overrideFunction(window.HTMLInputElement.prototype, 'setSelectionRange', this._overriddenMethods.setSelectionRange, );
+        overrideFunction(window.HTMLInputElement.prototype, 'setSelectionRange', this._overriddenMethods.setSelectionRange);
         overrideFunction(window.HTMLTextAreaElement.prototype, 'setSelectionRange', this._overriddenMethods.setSelectionRange);
 
         if (isIE11) {
@@ -193,11 +193,17 @@ export default class EventSandbox extends SandboxBase {
 
         // @ts-ignore Window constructor has no the focus method
         window.Window.focus = this._overriddenMethods.focus;
+
+        // NOTE:
+        // we cannot use 'overrideFunction' here since the focus method may not exist
         // @ts-ignore Window constructor has no the focus method
         overrideStringRepresentation(window.Window.focus, nativeMethods.focus);
 
         // @ts-ignore Window constructor has no the blur method
         window.Window.blur  = this._overriddenMethods.blur;
+
+        // NOTE:
+        // we cannot use 'overrideFunction' here since the blur method may not exist
         // @ts-ignore Window constructor has no the blur method
         overrideStringRepresentation(window.Window.blur, nativeMethods.blur);
 

--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -5,6 +5,7 @@ import * as listeningCtx from './listening-context';
 import { preventDefault, stopPropagation, DOM_EVENTS, isValidEventListener, callEventListener } from '../../utils/event';
 import { isWindow } from '../../utils/dom';
 import { isIE11 } from '../../utils/browser';
+import { overrideStringRepresentation } from '../../utils/property-overriding';
 
 const LISTENED_EVENTS = [
     'click', 'mousedown', 'mouseup', 'dblclick', 'contextmenu', 'mousemove', 'mouseover', 'mouseout',
@@ -213,6 +214,9 @@ export default class Listeners extends EventEmitter {
 
                 el.addEventListener    = overriddenMethods.addEventListener;
                 el.removeEventListener = overriddenMethods.removeEventListener;
+
+                overrideStringRepresentation(el.addEventListener, nativeAddEventListener);
+                overrideStringRepresentation(el.removeEventListener, Listeners._getNativeRemoveEventListener(el));
             }
         }
     }

--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -5,7 +5,7 @@ import * as listeningCtx from './listening-context';
 import { preventDefault, stopPropagation, DOM_EVENTS, isValidEventListener, callEventListener } from '../../utils/event';
 import { isWindow } from '../../utils/dom';
 import { isIE11 } from '../../utils/browser';
-import { overrideStringRepresentation } from '../../utils/property-overriding';
+import { overrideFunction } from '../../utils/property-overriding';
 
 const LISTENED_EVENTS = [
     'click', 'mousedown', 'mouseup', 'dblclick', 'contextmenu', 'mousemove', 'mouseover', 'mouseout',
@@ -211,12 +211,9 @@ export default class Listeners extends EventEmitter {
         if (isIE11) {
             if (!el.addEventListener || nativeMethods.isNativeCode(el.addEventListener)) {
                 const overriddenMethods = this.createOverriddenMethods();
-
-                el.addEventListener    = overriddenMethods.addEventListener;
-                el.removeEventListener = overriddenMethods.removeEventListener;
-
-                overrideStringRepresentation(el.addEventListener, nativeAddEventListener);
-                overrideStringRepresentation(el.removeEventListener, Listeners._getNativeRemoveEventListener(el));
+                
+                overrideFunction(el, 'addEventListener', overriddenMethods.addEventListener);
+                overrideFunction(el, 'removeEventListener', overriddenMethods.removeEventListener);
             }
         }
     }

--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -5,7 +5,7 @@ import * as listeningCtx from './listening-context';
 import { preventDefault, stopPropagation, DOM_EVENTS, isValidEventListener, callEventListener } from '../../utils/event';
 import { isWindow } from '../../utils/dom';
 import { isIE11 } from '../../utils/browser';
-import { isNativeFunction, overrideFunction, overrideStringRepresentation } from '../../utils/property-overriding';
+import { isNativeFunction, overrideFunction, overrideStringRepresentation } from '../../utils/overriding';
 
 const LISTENED_EVENTS = [
     'click', 'mousedown', 'mouseup', 'dblclick', 'contextmenu', 'mousemove', 'mouseover', 'mouseout',

--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -212,8 +212,7 @@ export default class Listeners extends EventEmitter {
             const overriddenMethods = this.createOverriddenMethods();
 
             if (!el.addEventListener) {
-                // NOTE:
-                // we cannot use 'overrideFunction' here since the functions may not exist
+                // NOTE: we cannot use 'overrideFunction' here since the functions may not exist
                 el.addEventListener    = overriddenMethods.addEventListener;
                 el.removeEventListener = overriddenMethods.removeEventListener;
 

--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -5,7 +5,7 @@ import * as listeningCtx from './listening-context';
 import { preventDefault, stopPropagation, DOM_EVENTS, isValidEventListener, callEventListener } from '../../utils/event';
 import { isWindow } from '../../utils/dom';
 import { isIE11 } from '../../utils/browser';
-// import { isNativeFunction, overrideFunction } from '../../utils/property-overriding';
+import { isNativeFunction, overrideFunction, overrideStringRepresentation } from '../../utils/property-overriding';
 
 const LISTENED_EVENTS = [
     'click', 'mousedown', 'mouseup', 'dblclick', 'contextmenu', 'mousemove', 'mouseover', 'mouseout',
@@ -209,14 +209,18 @@ export default class Listeners extends EventEmitter {
         this.listeningCtx.addListeningElement(el, events);
 
         if (isIE11) {
-            if (!el.addEventListener || nativeMethods.isNativeCode(el.addEventListener)) {
-                const overriddenMethods = this.createOverriddenMethods();
-                
+            const overriddenMethods = this.createOverriddenMethods();
+
+            if (!el.addEventListener) {
                 el.addEventListener    = overriddenMethods.addEventListener;
                 el.removeEventListener = overriddenMethods.removeEventListener;
-                
-                // overrideFunction(el, 'addEventListener', overriddenMethods.addEventListener);
-                // overrideFunction(el, 'removeEventListener', overriddenMethods.removeEventListener);
+
+                overrideStringRepresentation(el.addEventListener, nativeMethods.addEventListener);
+                overrideStringRepresentation(el.removeEventListener, nativeMethods.removeEventListener);
+            }
+            else if (isNativeFunction(el.addEventListener)) {
+                overrideFunction(el, 'addEventListener', overriddenMethods.addEventListener);
+                overrideFunction(el, 'removeEventListener', overriddenMethods.removeEventListener);
             }
         }
     }
@@ -227,11 +231,8 @@ export default class Listeners extends EventEmitter {
         if (isIE11) {
             const overriddenMethods = this.createOverriddenMethods();
 
-            doc.body.addEventListener    = overriddenMethods.addEventListener;
-            doc.body.removeEventListener = overriddenMethods.removeEventListener;
-
-            // overrideFunction(doc.body, 'addEventListener', overriddenMethods.addEventListener);
-            // overrideFunction(doc.body, 'removeEventListener', overriddenMethods.removeEventListener);
+            overrideFunction(doc.body, 'addEventListener', overriddenMethods.addEventListener);
+            overrideFunction(doc.body, 'removeEventListener', overriddenMethods.removeEventListener);
         }
     }
 

--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -5,7 +5,7 @@ import * as listeningCtx from './listening-context';
 import { preventDefault, stopPropagation, DOM_EVENTS, isValidEventListener, callEventListener } from '../../utils/event';
 import { isWindow } from '../../utils/dom';
 import { isIE11 } from '../../utils/browser';
-import { overrideFunction } from '../../utils/property-overriding';
+// import { isNativeFunction, overrideFunction } from '../../utils/property-overriding';
 
 const LISTENED_EVENTS = [
     'click', 'mousedown', 'mouseup', 'dblclick', 'contextmenu', 'mousemove', 'mouseover', 'mouseout',
@@ -212,8 +212,11 @@ export default class Listeners extends EventEmitter {
             if (!el.addEventListener || nativeMethods.isNativeCode(el.addEventListener)) {
                 const overriddenMethods = this.createOverriddenMethods();
                 
-                overrideFunction(el, 'addEventListener', overriddenMethods.addEventListener);
-                overrideFunction(el, 'removeEventListener', overriddenMethods.removeEventListener);
+                el.addEventListener    = overriddenMethods.addEventListener;
+                el.removeEventListener = overriddenMethods.removeEventListener;
+                
+                // overrideFunction(el, 'addEventListener', overriddenMethods.addEventListener);
+                // overrideFunction(el, 'removeEventListener', overriddenMethods.removeEventListener);
             }
         }
     }
@@ -226,6 +229,9 @@ export default class Listeners extends EventEmitter {
 
             doc.body.addEventListener    = overriddenMethods.addEventListener;
             doc.body.removeEventListener = overriddenMethods.removeEventListener;
+
+            // overrideFunction(doc.body, 'addEventListener', overriddenMethods.addEventListener);
+            // overrideFunction(doc.body, 'removeEventListener', overriddenMethods.removeEventListener);
         }
     }
 

--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -212,6 +212,8 @@ export default class Listeners extends EventEmitter {
             const overriddenMethods = this.createOverriddenMethods();
 
             if (!el.addEventListener) {
+                // NOTE:
+                // we cannot use 'overrideFunction' here since the functions may not exist
                 el.addEventListener    = overriddenMethods.addEventListener;
                 el.removeEventListener = overriddenMethods.removeEventListener;
 

--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -7,7 +7,7 @@ import { parse as parseJSON, stringify as stringifyJSON } from 'json-hammerhead'
 import { isCrossDomainWindows, getTopSameDomainWindow, isWindow, isMessageEvent } from '../../utils/dom';
 import { callEventListener } from '../../utils/event';
 import fastApply from '../../utils/fast-apply';
-import { overrideDescriptor } from '../../utils/property-overriding';
+import { overrideDescriptor } from '../../utils/overriding';
 import Listeners from './listeners';
 import UnloadSandbox from './unload';
 

--- a/src/client/sandbox/event/unload.ts
+++ b/src/client/sandbox/event/unload.ts
@@ -2,7 +2,7 @@ import SandboxBase from '../base';
 import nativeMethods from '../native-methods';
 import createPropertyDesc from '../../utils/create-property-desc.js';
 import { isFirefox, isIOS } from '../../utils/browser';
-import { overrideDescriptor } from '../../utils/property-overriding';
+import { overrideDescriptor } from '../../utils/overriding';
 import Listeners from './listeners';
 
 export default class UnloadSandbox extends SandboxBase {

--- a/src/client/sandbox/fetch.ts
+++ b/src/client/sandbox/fetch.ts
@@ -181,7 +181,6 @@ export default class FetchSandbox extends SandboxBase {
                 FetchSandbox._processArguments(args);
             }
             catch (e) {
-                // @ts-ignore
                 return nativeMethods.promiseReject.call(sandbox.window.Promise, e);
             }
 

--- a/src/client/sandbox/fetch.ts
+++ b/src/client/sandbox/fetch.ts
@@ -6,7 +6,7 @@ import { getProxyUrl, getDestinationUrl } from '../utils/url';
 import { getOriginHeader, sameOriginCheck, get as getDestLocation } from '../utils/destination-location';
 import { isFetchHeaders, isFetchRequest } from '../utils/dom';
 import SAME_ORIGIN_CHECK_FAILED_STATUS_CODE from '../../request-pipeline/xhr/same-origin-check-failed-status-code';
-import { overrideConstructor, overrideDescriptor, overrideFunction } from '../utils/property-overriding';
+import { overrideConstructor, overrideDescriptor, overrideFunction } from '../utils/overriding';
 import * as browserUtils from '../utils/browser';
 import { transformHeaderNameToBuiltin, transformHeaderNameToInternal } from '../utils/headers';
 import CookieSandbox from './cookie';

--- a/src/client/sandbox/iframe.ts
+++ b/src/client/sandbox/iframe.ts
@@ -8,6 +8,7 @@ import { isFirefox, isWebKit, isIE } from '../utils/browser';
 import * as JSON from 'json-hammerhead';
 import NodeMutation from './node/mutation';
 import CookieSandbox from './cookie';
+import { isNativeFunction } from '../utils/property-overriding';
 
 const IFRAME_WINDOW_INITED = 'hammerhead|iframe-window-inited';
 
@@ -98,7 +99,7 @@ export default class IframeSandbox extends SandboxBase {
             // NOTE: Even if iframe is not loaded (iframe.contentDocument.documentElement does not exist), we
             // still need to override the document.write method without initializing Hammerhead. This method can
             // be called before iframe is fully loaded, we should override it now.
-            if (contentDocument.write.toString() === this.nativeMethods.documentWrite.toString())
+            if (isNativeFunction(contentDocument.write))
                 this.emit(this.IFRAME_DOCUMENT_CREATED_EVENT, { iframe });
         }
         else if (!contentWindow[IFRAME_WINDOW_INITED] && !contentWindow[INTERNAL_PROPS.hammerhead]) {

--- a/src/client/sandbox/iframe.ts
+++ b/src/client/sandbox/iframe.ts
@@ -8,7 +8,7 @@ import { isFirefox, isWebKit, isIE } from '../utils/browser';
 import * as JSON from 'json-hammerhead';
 import NodeMutation from './node/mutation';
 import CookieSandbox from './cookie';
-import { isNativeFunction } from '../utils/property-overriding';
+import { isNativeFunction } from '../utils/overriding';
 
 const IFRAME_WINDOW_INITED = 'hammerhead|iframe-window-inited';
 

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -968,7 +968,7 @@ class NativeMethods {
 
         // Event
         // NOTE: IE11 has no EventTarget so we should save "Event" methods separately
-        if (!win.EventLisener) {
+        if (!win.EventTarget) {
             this.windowAddEventListener    = win.addEventListener || winProto.addEventListener;
             this.windowRemoveEventListener = win.removeEventListener || winProto.removeEventListener;
             this.windowDispatchEvent       = win.dispatchEvent;

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -347,7 +347,7 @@ class NativeMethods {
     Image: any;
     Function: any;
     Error: any;
-    funcProtoToString: Function;
+    functionToString: Function;
     FontFace: any;
     StorageEvent: any;
     MutationObserver: any;
@@ -370,9 +370,6 @@ class NativeMethods {
     crypto: Crypto;
     cryptoGetRandomValues: Function;
     URL: typeof URL;
-    workerProtoCtor: Function;
-    xmlHttpRequestProtoCtor: Function;
-    functionProtoCtor: Function;
 
     constructor (doc?: Document, win?: Window & typeof globalThis) {
         const globalCtx = getGlobalContextInfo();
@@ -1089,7 +1086,7 @@ class NativeMethods {
         this.XMLHttpRequest       = win.XMLHttpRequest;
         this.Image                = win.Image;
         this.Function             = win.Function;
-        this.funcProtoToString    = win.Function.prototype.toString;
+        this.functionToString     = win.Function.prototype.toString;
         this.Error                = win.Error;
         this.FontFace             = win.FontFace;
         this.StorageEvent         = win.StorageEvent;
@@ -1110,10 +1107,6 @@ class NativeMethods {
         // NOTE: non-IE11 case. window.File in IE11 is not constructable.
         if (win.File && typeof win.File === 'function')
             this.File = win.File;
-
-        this.workerProtoCtor         = win.Worker.prototype.constructor;
-        this.xmlHttpRequestProtoCtor = win.XMLHttpRequest.prototype.constructor;
-        this.functionProtoCtor       = win.Function.prototype.constructor;
     }
 
     refreshElectronMeths (vmModule): boolean {

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -8,6 +8,7 @@ class NativeMethods {
     createDocumentFragment: Document['createDocumentFragment'];
     createElement: Document['createElement'];
     createElementNS: Document['createElementNS'];
+    createTextNode: Document['createTextNode'];
     documentOpenPropOwnerName: string;
     documentClosePropOwnerName: string;
     documentWritePropOwnerName: string;
@@ -68,6 +69,7 @@ class NativeMethods {
     anchorToString: any;
     matches: any;
     closest: any;
+    appendData: any;
     addEventListener: any;
     removeEventListener: any;
     blur: any;
@@ -400,6 +402,7 @@ class NativeMethods {
         this.createDocumentFragment = docPrototype.createDocumentFragment;
         this.createElement          = docPrototype.createElement;
         this.createElementNS        = docPrototype.createElementNS;
+        this.createTextNode         = docPrototype.createTextNode;
 
         this.documentOpenPropOwnerName    = NativeMethods._getDocumentPropOwnerName(docPrototype, 'open');
         this.documentClosePropOwnerName   = NativeMethods._getDocumentPropOwnerName(docPrototype, 'close');
@@ -483,6 +486,9 @@ class NativeMethods {
         const createElement = tagName => this.createElement.call(doc || document, tagName);
         const nativeElement = createElement('div');
 
+        const createTextNode = data => this.createTextNode.call(doc || document, data);
+        const textNode       = createTextNode('text');
+
         // Dom
         this.appendChild                   = nativeElement.appendChild;
         this.replaceChild                  = nativeElement.replaceChild;
@@ -509,6 +515,9 @@ class NativeMethods {
         this.anchorToString                = win.HTMLAnchorElement.prototype.toString;
         this.matches                       = nativeElement.matches || nativeElement.msMatchesSelector;
         this.closest                       = nativeElement.closest;
+
+        // Text node
+        this.appendData = textNode.appendData;
 
         // TODO: remove this condition after the GH-1649 fix
         if (!this.isNativeCode(this.elementGetElementsByTagName)) {

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -347,7 +347,7 @@ class NativeMethods {
     Image: any;
     Function: any;
     Error: any;
-    functionToString: any;
+    funcProtoToString: Function;
     FontFace: any;
     StorageEvent: any;
     MutationObserver: any;
@@ -370,6 +370,9 @@ class NativeMethods {
     crypto: Crypto;
     cryptoGetRandomValues: Function;
     URL: typeof URL;
+    workerProtoCtor: Function;
+    xmlHttpRequestProtoCtor: Function;
+    functionProtoCtor: Function;
 
     constructor (doc?: Document, win?: Window & typeof globalThis) {
         const globalCtx = getGlobalContextInfo();
@@ -1086,7 +1089,7 @@ class NativeMethods {
         this.XMLHttpRequest       = win.XMLHttpRequest;
         this.Image                = win.Image;
         this.Function             = win.Function;
-        this.functionToString     = win.Function.toString;
+        this.funcProtoToString    = win.Function.prototype.toString;
         this.Error                = win.Error;
         this.FontFace             = win.FontFace;
         this.StorageEvent         = win.StorageEvent;
@@ -1107,6 +1110,10 @@ class NativeMethods {
         // NOTE: non-IE11 case. window.File in IE11 is not constructable.
         if (win.File && typeof win.File === 'function')
             this.File = win.File;
+
+        this.workerProtoCtor         = win.Worker.prototype.constructor;
+        this.xmlHttpRequestProtoCtor = win.XMLHttpRequest.prototype.constructor;
+        this.functionProtoCtor       = win.Function.prototype.constructor;
     }
 
     refreshElectronMeths (vmModule): boolean {

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -1,5 +1,6 @@
 /*global Document, Window */
 import getGlobalContextInfo from '../utils/global-context-info';
+import { isNativeFunction } from '../utils/property-overriding';
 
 const NATIVE_CODE_RE = /\[native code]/;
 
@@ -1171,20 +1172,20 @@ class NativeMethods {
 
         const needToRefreshDocumentMethods = tryToExecuteCode(
             () => !doc.createElement ||
-                  this.createElement.toString() === document.createElement.toString()
+                  isNativeFunction(document.createElement)
         );
 
         const needToRefreshElementMethods = tryToExecuteCode(() => {
             const nativeElement = this.createElement.call(doc, 'div');
 
-            return nativeElement.getAttribute.toString() === this.getAttribute.toString();
+            return isNativeFunction(nativeElement.getAttribute);
         });
 
         const needToRefreshWindowMethods = tryToExecuteCode(() => {
             this.setTimeout.call(win, () => void 0, 0);
 
             //@ts-ignore
-            return win.XMLHttpRequest.prototype.open.toString() === this.xhrOpen.toString();
+            return isNativeFunction(win.XMLHttpRequest.prototype.open);
         });
 
         // NOTE: T173709

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -127,6 +127,7 @@ class NativeMethods {
     headersDelete: Headers['delete'];
     headersEntries: Headers['entries'];
     headersForEach: Headers['forEach'];
+    headersValues: Headers['values'];
     windowAddEventListener: any;
     windowRemoveEventListener: any;
     WindowPointerEvent: any;
@@ -963,6 +964,7 @@ class NativeMethods {
             this.headersDelete  = win.Headers.prototype.delete;
             this.headersEntries = win.Headers.prototype.entries;
             this.headersForEach = win.Headers.prototype.forEach;
+            this.headersValues  = win.Headers.prototype.values;
         }
 
         // Event
@@ -1109,7 +1111,7 @@ class NativeMethods {
     }
 
     refreshElectronMeths (vmModule): boolean {
-        if (this.createScript && this.createScript.toString() !== vmModule.createScript.toString())
+        if (this.createScript && isNativeFunction(vmModule.createScript))
             return false;
 
         this.createScript      = vmModule.createScript;

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -1,6 +1,6 @@
 /*global Document, Window */
 import getGlobalContextInfo from '../utils/global-context-info';
-import { isNativeFunction } from '../utils/property-overriding';
+import { isNativeFunction } from '../utils/overriding';
 
 const NATIVE_CODE_RE = /\[native code]/;
 

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -397,7 +397,6 @@ class NativeMethods {
         doc = doc || document;
         win = win || window as Window & typeof globalThis;
 
-        // @ts-ignore
         const docPrototype = win.Document.prototype;
 
         // Dom
@@ -1186,7 +1185,7 @@ class NativeMethods {
         const needToRefreshWindowMethods = tryToExecuteCode(() => {
             this.setTimeout.call(win, () => void 0, 0);
 
-            return isNativeFunction((win as any).XMLHttpRequest.prototype.open);
+            return isNativeFunction(win.XMLHttpRequest.prototype.open);
         });
 
         // NOTE: T173709

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -1184,8 +1184,7 @@ class NativeMethods {
         const needToRefreshWindowMethods = tryToExecuteCode(() => {
             this.setTimeout.call(win, () => void 0, 0);
 
-            //@ts-ignore
-            return isNativeFunction(win.XMLHttpRequest.prototype.open);
+            return isNativeFunction((win as any).XMLHttpRequest.prototype.open);
         });
 
         // NOTE: T173709

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -10,7 +10,7 @@ import DocumentWriter from './writer';
 import ShadowUI from './../../shadow-ui';
 import INTERNAL_PROPS from '../../../../processing/dom/internal-properties';
 import LocationAccessorsInstrumentation from '../../code-instrumentation/location';
-import { overrideDescriptor, createOverriddenDescriptor, overrideFunction } from '../../../utils/property-overriding';
+import { overrideDescriptor, createOverriddenDescriptor, overrideFunction } from '../../../utils/overriding';
 import NodeSandbox from '../index';
 import { getDestinationUrl } from '../../../utils/url';
 import DocumentTitleStorageInitializer from './title-storage-initializer';

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -115,11 +115,6 @@ export default class DocumentSandbox extends SandboxBase {
         return result;
     }
 
-    private static _ensureDocumentMethodOverride (document, overridenMethods, methodName) {
-        if (document[methodName] !== overridenMethods[methodName])
-            document[methodName] = overridenMethods[methodName];
-    }
-
     attach (window, document) {
         if (this._needToUpdateDocumentWriter(window, document)) {
             this.documentWriter = new DocumentWriter(window, document);
@@ -198,25 +193,18 @@ export default class DocumentSandbox extends SandboxBase {
             }
         };
 
-        window[nativeMethods.documentOpenPropOwnerName].prototype.open       = overridenMethods.open;
-        window[nativeMethods.documentClosePropOwnerName].prototype.close     = overridenMethods.close;
-        window[nativeMethods.documentWritePropOwnerName].prototype.write     = overridenMethods.write;
-        window[nativeMethods.documentWriteLnPropOwnerName].prototype.writeln = overridenMethods.writeln;
+        overrideFunction(window[nativeMethods.documentOpenPropOwnerName].prototype, 'open', overridenMethods.open);
+        overrideFunction(window[nativeMethods.documentClosePropOwnerName].prototype, 'close', overridenMethods.close);
+        overrideFunction(window[nativeMethods.documentWritePropOwnerName].prototype, 'write', overridenMethods.write);
+        overrideFunction(window[nativeMethods.documentWriteLnPropOwnerName].prototype, 'writeln', overridenMethods.writeln);
 
-        // overrideFunction(window[nativeMethods.documentOpenPropOwnerName].prototype, 'open', overridenMethods.open);
-        // overrideFunction(window[nativeMethods.documentClosePropOwnerName].prototype, 'close', overridenMethods.close);
-        // overrideFunction(window[nativeMethods.documentWritePropOwnerName].prototype, 'write', overridenMethods.write);
-        // overrideFunction(window[nativeMethods.documentWriteLnPropOwnerName].prototype, 'writeln', overridenMethods.writeln);
-
-        DocumentSandbox._ensureDocumentMethodOverride(document, overridenMethods, 'open');
-        DocumentSandbox._ensureDocumentMethodOverride(document, overridenMethods, 'close');
-        DocumentSandbox._ensureDocumentMethodOverride(document, overridenMethods, 'write');
-        DocumentSandbox._ensureDocumentMethodOverride(document, overridenMethods, 'writeln');
+        overrideFunction(document, 'open', overridenMethods.open);
+        overrideFunction(document, 'close', overridenMethods.close);
+        overrideFunction(document, 'write', overridenMethods.write);
+        overrideFunction(document, 'writeln', overridenMethods.writeln);
 
         if (document.open !== overridenMethods.open)
-            document.open = overridenMethods.open;
-        
-        // overrideFunction(document, 'open', overridenMethods.open);
+            overrideFunction(document, 'open', overridenMethods.open);
         
         const createElementWrapper = function (...args) {
             const el = nativeMethods.createElement.apply(this, args);
@@ -230,8 +218,7 @@ export default class DocumentSandbox extends SandboxBase {
 
         overrideFunction(docPrototype, 'createElement', createElementWrapper);
 
-        // const createElementNSWrapper = 
-        docPrototype.createElementNS = function (...args) {
+        const createElementNSWrapper = function (...args) {
             const el = nativeMethods.createElementNS.apply(this, args);
 
             DocumentSandbox.forceProxySrcForImageIfNecessary(el);
@@ -241,10 +228,9 @@ export default class DocumentSandbox extends SandboxBase {
             return el;
         };
 
-        // overrideFunction(docPrototype, 'createElementNS', createElementNSWrapper);
+        overrideFunction(docPrototype, 'createElementNS', createElementNSWrapper);
 
-        // const createDocumentFragmentWrapper
-        docPrototype.createDocumentFragment = function (...args) {
+        const createDocumentFragmentWrapper = function (...args) {
             const fragment = nativeMethods.createDocumentFragment.apply(this, args);
 
             documentSandbox._nodeSandbox.processNodes(fragment);
@@ -252,7 +238,7 @@ export default class DocumentSandbox extends SandboxBase {
             return fragment;
         };
 
-        // overrideFunction(docPrototype, 'createDocumentFragment', createDocumentFragmentWrapper);
+        overrideFunction(docPrototype, 'createDocumentFragment', createDocumentFragmentWrapper);
 
         const htmlDocPrototype = window.HTMLDocument.prototype;
         let storedDomain       = '';

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -205,8 +205,8 @@ export default class DocumentSandbox extends SandboxBase {
 
         if (document.open !== overridenMethods.open)
             overrideFunction(document, 'open', overridenMethods.open);
-        
-        const createElementWrapper = function (...args) {
+
+        overrideFunction(docPrototype, 'createElement', function (...args) {
             const el = nativeMethods.createElement.apply(this, args);
 
             DocumentSandbox.forceProxySrcForImageIfNecessary(el);
@@ -214,11 +214,9 @@ export default class DocumentSandbox extends SandboxBase {
             documentSandbox._nodeSandbox.processNodes(el);
 
             return el;
-        };
+        });
 
-        overrideFunction(docPrototype, 'createElement', createElementWrapper);
-
-        const createElementNSWrapper = function (...args) {
+        overrideFunction(docPrototype, 'createElementNS', function (...args) {
             const el = nativeMethods.createElementNS.apply(this, args);
 
             DocumentSandbox.forceProxySrcForImageIfNecessary(el);
@@ -226,19 +224,15 @@ export default class DocumentSandbox extends SandboxBase {
             documentSandbox._nodeSandbox.processNodes(el);
 
             return el;
-        };
+        });
 
-        overrideFunction(docPrototype, 'createElementNS', createElementNSWrapper);
-
-        const createDocumentFragmentWrapper = function (...args) {
+        overrideFunction(docPrototype, 'createDocumentFragment', function (...args) {
             const fragment = nativeMethods.createDocumentFragment.apply(this, args);
 
             documentSandbox._nodeSandbox.processNodes(fragment);
 
             return fragment;
-        };
-
-        overrideFunction(docPrototype, 'createDocumentFragment', createDocumentFragmentWrapper);
+        });
 
         const htmlDocPrototype = window.HTMLDocument.prototype;
         let storedDomain       = '';

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -10,7 +10,7 @@ import DocumentWriter from './writer';
 import ShadowUI from './../../shadow-ui';
 import INTERNAL_PROPS from '../../../../processing/dom/internal-properties';
 import LocationAccessorsInstrumentation from '../../code-instrumentation/location';
-import { overrideDescriptor, createOverriddenDescriptor } from '../../../utils/property-overriding';
+import { overrideDescriptor, createOverriddenDescriptor, overrideFunction } from '../../../utils/property-overriding';
 import NodeSandbox from '../index';
 import { getDestinationUrl } from '../../../utils/url';
 import DocumentTitleStorageInitializer from './title-storage-initializer';
@@ -203,6 +203,11 @@ export default class DocumentSandbox extends SandboxBase {
         window[nativeMethods.documentWritePropOwnerName].prototype.write     = overridenMethods.write;
         window[nativeMethods.documentWriteLnPropOwnerName].prototype.writeln = overridenMethods.writeln;
 
+        // overrideFunction(window[nativeMethods.documentOpenPropOwnerName].prototype, 'open', overridenMethods.open);
+        // overrideFunction(window[nativeMethods.documentClosePropOwnerName].prototype, 'close', overridenMethods.close);
+        // overrideFunction(window[nativeMethods.documentWritePropOwnerName].prototype, 'write', overridenMethods.write);
+        // overrideFunction(window[nativeMethods.documentWriteLnPropOwnerName].prototype, 'writeln', overridenMethods.writeln);
+
         DocumentSandbox._ensureDocumentMethodOverride(document, overridenMethods, 'open');
         DocumentSandbox._ensureDocumentMethodOverride(document, overridenMethods, 'close');
         DocumentSandbox._ensureDocumentMethodOverride(document, overridenMethods, 'write');
@@ -210,8 +215,10 @@ export default class DocumentSandbox extends SandboxBase {
 
         if (document.open !== overridenMethods.open)
             document.open = overridenMethods.open;
-
-        docPrototype.createElement = function (...args) {
+        
+        // overrideFunction(document, 'open', overridenMethods.open);
+        
+        const createElementWrapper = function (...args) {
             const el = nativeMethods.createElement.apply(this, args);
 
             DocumentSandbox.forceProxySrcForImageIfNecessary(el);
@@ -221,6 +228,9 @@ export default class DocumentSandbox extends SandboxBase {
             return el;
         };
 
+        overrideFunction(docPrototype, 'createElement', createElementWrapper);
+
+        // const createElementNSWrapper = 
         docPrototype.createElementNS = function (...args) {
             const el = nativeMethods.createElementNS.apply(this, args);
 
@@ -231,6 +241,9 @@ export default class DocumentSandbox extends SandboxBase {
             return el;
         };
 
+        // overrideFunction(docPrototype, 'createElementNS', createElementNSWrapper);
+
+        // const createDocumentFragmentWrapper
         docPrototype.createDocumentFragment = function (...args) {
             const fragment = nativeMethods.createDocumentFragment.apply(this, args);
 
@@ -238,6 +251,8 @@ export default class DocumentSandbox extends SandboxBase {
 
             return fragment;
         };
+
+        // overrideFunction(docPrototype, 'createDocumentFragment', createDocumentFragmentWrapper);
 
         const htmlDocPrototype = window.HTMLDocument.prototype;
         let storedDomain       = '';

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -129,7 +129,7 @@ export default class DocumentSandbox extends SandboxBase {
         const documentSandbox = this;
         const docPrototype    = window.Document.prototype;
 
-        const overridenMethods = {
+        const overriddenMethods = {
             open: function (...args) {
                 const isUninitializedIframe = documentSandbox._isUninitializedIframeWithoutSrc(window);
 
@@ -193,18 +193,18 @@ export default class DocumentSandbox extends SandboxBase {
             }
         };
 
-        overrideFunction(window[nativeMethods.documentOpenPropOwnerName].prototype, 'open', overridenMethods.open);
-        overrideFunction(window[nativeMethods.documentClosePropOwnerName].prototype, 'close', overridenMethods.close);
-        overrideFunction(window[nativeMethods.documentWritePropOwnerName].prototype, 'write', overridenMethods.write);
-        overrideFunction(window[nativeMethods.documentWriteLnPropOwnerName].prototype, 'writeln', overridenMethods.writeln);
+        overrideFunction(window[nativeMethods.documentOpenPropOwnerName].prototype, 'open', overriddenMethods.open);
+        overrideFunction(window[nativeMethods.documentClosePropOwnerName].prototype, 'close', overriddenMethods.close);
+        overrideFunction(window[nativeMethods.documentWritePropOwnerName].prototype, 'write', overriddenMethods.write);
+        overrideFunction(window[nativeMethods.documentWriteLnPropOwnerName].prototype, 'writeln', overriddenMethods.writeln);
 
-        overrideFunction(document, 'open', overridenMethods.open);
-        overrideFunction(document, 'close', overridenMethods.close);
-        overrideFunction(document, 'write', overridenMethods.write);
-        overrideFunction(document, 'writeln', overridenMethods.writeln);
+        overrideFunction(document, 'open', overriddenMethods.open);
+        overrideFunction(document, 'close', overriddenMethods.close);
+        overrideFunction(document, 'write', overriddenMethods.write);
+        overrideFunction(document, 'writeln', overriddenMethods.writeln);
 
-        if (document.open !== overridenMethods.open)
-            overrideFunction(document, 'open', overridenMethods.open);
+        if (document.open !== overriddenMethods.open)
+            overrideFunction(document, 'open', overriddenMethods.open);
 
         overrideFunction(docPrototype, 'createElement', function (...args) {
             const el = nativeMethods.createElement.apply(this, args);

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -22,7 +22,7 @@ import ShadowUI from '../shadow-ui';
 import DOMMutationTracker from './live-node-list/dom-mutation-tracker';
 import { ATTRS_WITH_SPECIAL_PROXYING_LOGIC } from '../../../processing/dom/attributes';
 import settings from '../../settings';
-import { overrideDescriptor, overrideFunction } from '../../utils/property-overriding';
+import { overrideDescriptor, overrideFunction } from '../../utils/overriding';
 import InsertPosition from '../../utils/insert-position';
 import { isFirefox } from '../../utils/browser';
 import UploadSandbox from '../upload';

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -22,7 +22,7 @@ import ShadowUI from '../shadow-ui';
 import DOMMutationTracker from './live-node-list/dom-mutation-tracker';
 import { ATTRS_WITH_SPECIAL_PROXYING_LOGIC } from '../../../processing/dom/attributes';
 import settings from '../../settings';
-import { overrideDescriptor } from '../../utils/property-overriding';
+import { overrideDescriptor, overrideFunction } from '../../utils/property-overriding';
 import InsertPosition from '../../utils/insert-position';
 import { isFirefox } from '../../utils/browser';
 import UploadSandbox from '../upload';
@@ -795,41 +795,49 @@ export default class ElementSandbox extends SandboxBase {
         super.attach(window);
 
         this._createOverriddenMethods();
+        
+        overrideFunction(window.Element.prototype, 'setAttribute', this.overriddenMethods.setAttribute);
+        overrideFunction(window.Element.prototype, 'setAttributeNS', this.overriddenMethods.setAttributeNS);
+        overrideFunction(window.Element.prototype, 'getAttribute', this.overriddenMethods.getAttribute);
+        overrideFunction(window.Element.prototype, 'getAttributeNS', this.overriddenMethods.getAttributeNS);
+        overrideFunction(window.Element.prototype, 'removeAttribute', this.overriddenMethods.removeAttribute);
+        overrideFunction(window.Element.prototype, 'removeAttributeNS', this.overriddenMethods.removeAttributeNS);
+        overrideFunction(window.Element.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
+        overrideFunction(window.Element.prototype, 'querySelector', this.overriddenMethods.querySelector);
+        overrideFunction(window.Element.prototype, 'querySelectorAll', this.overriddenMethods.querySelectorAll);
+        overrideFunction(window.Element.prototype, 'hasAttribute', this.overriddenMethods.hasAttribute);
+        overrideFunction(window.Element.prototype, 'hasAttributeNS', this.overriddenMethods.hasAttributeNS);
+        overrideFunction(window.Element.prototype, 'hasAttributes', this.overriddenMethods.hasAttributes);
 
-        window.Element.prototype.setAttribute              = this.overriddenMethods.setAttribute;
-        window.Element.prototype.setAttributeNS            = this.overriddenMethods.setAttributeNS;
-        window.Element.prototype.getAttribute              = this.overriddenMethods.getAttribute;
-        window.Element.prototype.getAttributeNS            = this.overriddenMethods.getAttributeNS;
-        window.Element.prototype.removeAttribute           = this.overriddenMethods.removeAttribute;
-        window.Element.prototype.removeAttributeNS         = this.overriddenMethods.removeAttributeNS;
-        window.Element.prototype.cloneNode                 = this.overriddenMethods.cloneNode;
-        window.Element.prototype.querySelector             = this.overriddenMethods.querySelector;
-        window.Element.prototype.querySelectorAll          = this.overriddenMethods.querySelectorAll;
-        window.Element.prototype.hasAttribute              = this.overriddenMethods.hasAttribute;
-        window.Element.prototype.hasAttributeNS            = this.overriddenMethods.hasAttributeNS;
-        window.Element.prototype.hasAttributes             = this.overriddenMethods.hasAttributes;
-        window.Node.prototype.cloneNode                    = this.overriddenMethods.cloneNode;
-        window.Node.prototype.appendChild                  = this.overriddenMethods.appendChild;
-        window.Node.prototype.removeChild                  = this.overriddenMethods.removeChild;
-        window.Node.prototype.insertBefore                 = this.overriddenMethods.insertBefore;
-        window.Node.prototype.replaceChild                 = this.overriddenMethods.replaceChild;
-        window.DocumentFragment.prototype.querySelector    = this.overriddenMethods.querySelector;
-        window.DocumentFragment.prototype.querySelectorAll = this.overriddenMethods.querySelectorAll;
-        window.HTMLTableElement.prototype.insertRow        = this.overriddenMethods.insertRow;
-        window.HTMLTableSectionElement.prototype.insertRow = this.overriddenMethods.insertRow;
-        window.HTMLTableRowElement.prototype.insertCell    = this.overriddenMethods.insertCell;
-        window.HTMLFormElement.prototype.submit            = this.overriddenMethods.formSubmit;
-        window.HTMLAnchorElement.prototype.toString        = this.overriddenMethods.anchorToString;
-        window.CharacterData.prototype.appendData          = this.overriddenMethods.appendData;
+        overrideFunction(window.Node.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
+        overrideFunction(window.Node.prototype, 'appendChild', this.overriddenMethods.appendChild);
+        overrideFunction(window.Node.prototype, 'removeChild', this.overriddenMethods.removeChild);
+        overrideFunction(window.Node.prototype, 'insertBefore', this.overriddenMethods.insertBefore);
+        overrideFunction(window.Node.prototype, 'replaceChild', this.overriddenMethods.replaceChild);
+
+        overrideFunction(window.DocumentFragment.prototype, 'querySelector', this.overriddenMethods.querySelector);
+        overrideFunction(window.DocumentFragment.prototype, 'querySelectorAll', this.overriddenMethods.querySelectorAll);
+
+        overrideFunction(window.HTMLTableElement.prototype, 'insertRow', this.overriddenMethods.insertRow);
+
+        overrideFunction(window.HTMLTableSectionElement.prototype, 'insertRow', this.overriddenMethods.insertRow);
+
+        overrideFunction(window.HTMLTableRowElement.prototype, 'insertCell', this.overriddenMethods.insertCell);
+
+        overrideFunction(window.HTMLFormElement.prototype, 'submit', this.overriddenMethods.formSubmit);
+
+        overrideFunction(window.HTMLAnchorElement.prototype, 'toString', this.overriddenMethods.anchorToString);
+
+        overrideFunction(window.CharacterData.prototype, 'appendData', this.overriddenMethods.appendData);
 
         if (window.Document.prototype.registerElement)
-            window.Document.prototype.registerElement = this.overriddenMethods.registerElement;
+            overrideFunction(window.Document.prototype, 'registerElement', this.overriddenMethods.registerElement);
 
         if (window.Element.prototype.insertAdjacentHTML)
-            window.Element.prototype.insertAdjacentHTML = this.overriddenMethods.insertAdjacentHTML;
+            overrideFunction(window.Element.prototype, 'insertAdjacentHTML', this.overriddenMethods.insertAdjacentHTML);
         else if (window.HTMLElement.prototype.insertAdjacentHTML)
-            window.HTMLElement.prototype.insertAdjacentHTML = this.overriddenMethods.insertAdjacentHTML;
-
+            overrideFunction(window.HTMLElement.prototype, 'insertAdjacentHTML', this.overriddenMethods.insertAdjacentHTML);
+        
         this._setValidBrowsingContextOnElementClick(window);
 
         // NOTE: Cookie can be set up for the page by using the request initiated by img.

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -1123,11 +1123,8 @@ export default class WindowSandbox extends SandboxBase {
             getter: function () {
                 let baseVal = nativeMethods.svgAnimStrBaseValGetter.call(this);
 
-                if (this[CONTEXT_SVG_IMAGE_ELEMENT]) {
-                    const parsedHref = parseProxyUrl(baseVal);
-
-                    baseVal = parsedHref ? parsedHref.destUrl : baseVal;
-                }
+                if (this[CONTEXT_SVG_IMAGE_ELEMENT])
+                    baseVal = getDestinationUrl(baseVal);
 
                 return baseVal;
             },
@@ -1149,11 +1146,8 @@ export default class WindowSandbox extends SandboxBase {
             getter: function () {
                 const animVal = nativeMethods.svgAnimStrAnimValGetter.call(this);
 
-                if (this[CONTEXT_SVG_IMAGE_ELEMENT]) {
-                    const parsedAnimVal = parseProxyUrl(animVal);
-
-                    return parsedAnimVal ? parsedAnimVal.destUrl : animVal;
-                }
+                if (this[CONTEXT_SVG_IMAGE_ELEMENT])
+                    return getDestinationUrl(animVal);
 
                 return animVal;
             }
@@ -1169,20 +1163,14 @@ export default class WindowSandbox extends SandboxBase {
 
         overrideDescriptor(window.StyleSheet.prototype, 'href', {
             getter: function () {
-                const href      = nativeMethods.styleSheetHrefGetter.call(this);
-                const parsedUrl = parseProxyUrl(href);
-
-                return parsedUrl ? parsedUrl.destUrl : href;
+                return getDestinationUrl(nativeMethods.styleSheetHrefGetter.call(this));
             }
         });
 
         if (nativeMethods.cssStyleSheetHrefGetter) {
             overrideDescriptor(window.CSSStyleSheet.prototype, 'href', {
                 getter: function () {
-                    const href      = nativeMethods.cssStyleSheetHrefGetter.call(this);
-                    const parsedUrl = parseProxyUrl(href);
-
-                    return parsedUrl ? parsedUrl.destUrl : href;
+                    return getDestinationUrl(nativeMethods.cssStyleSheetHrefGetter.call(this));
                 }
             });
         }
@@ -1190,10 +1178,7 @@ export default class WindowSandbox extends SandboxBase {
         if (nativeMethods.nodeBaseURIGetter) {
             overrideDescriptor(window.Node.prototype, 'baseURI', {
                 getter: function () {
-                    const baseURI   = nativeMethods.nodeBaseURIGetter.call(this);
-                    const parsedUrl = parseProxyUrl(baseURI);
-
-                    return parsedUrl ? parsedUrl.destUrl : baseURI;
+                    return getDestinationUrl(nativeMethods.nodeBaseURIGetter.call(this));
                 }
             });
         }

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -51,7 +51,7 @@ import constructorIsCalledWithoutNewKeyword from '../../utils/constructor-is-cal
 import INSTRUCTION from '../../../processing/script/instruction';
 import Promise from 'pinkie';
 import getMimeType from '../../utils/get-mime-type';
-import { overrideDescriptor, overrideStringRepresentation } from '../../utils/property-overriding';
+import { overrideDescriptor, overrideFunction, overrideStringRepresentation } from '../../utils/property-overriding';
 import { emptyActionAttrFallbacksToTheLocation } from '../../utils/feature-detection';
 import { HASH_RE, isValidUrl } from '../../../utils/url';
 import UploadSandbox from '../upload';
@@ -700,11 +700,8 @@ export default class WindowSandbox extends SandboxBase {
         if (window.EventTarget) {
             const overriddenMethods = this.listenersSandbox.createOverriddenMethods();
 
-            window.EventTarget.prototype.addEventListener    = overriddenMethods.addEventListener;
-            window.EventTarget.prototype.removeEventListener = overriddenMethods.removeEventListener;
-
-            overrideStringRepresentation(window.EventTarget.prototype.addEventListener, nativeMethods.addEventListener);
-            overrideStringRepresentation(window.EventTarget.prototype.removeEventListener, nativeMethods.removeEventListener);
+            overrideFunction(window.EventTarget.prototype, 'addEventListener', overriddenMethods.addEventListener);
+            overrideFunction(window.EventTarget.prototype, 'removeEventListener', overriddenMethods.removeEventListener);
         }
 
         window.Image           = function () {
@@ -735,9 +732,8 @@ export default class WindowSandbox extends SandboxBase {
             return nativeMethods.Function.apply(this, args);
         };
 
-        overrideStringRepresentation(FunctionWrapper, nativeMethods.Function);
+        overrideFunction(window, 'Function', FunctionWrapper);
 
-        window.Function                       = FunctionWrapper;
         window.Function.prototype             = nativeMethods.Function.prototype;
         window.Function.prototype.constructor = FunctionWrapper;
 

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -51,7 +51,7 @@ import constructorIsCalledWithoutNewKeyword from '../../utils/constructor-is-cal
 import INSTRUCTION from '../../../processing/script/instruction';
 import Promise from 'pinkie';
 import getMimeType from '../../utils/get-mime-type';
-import { overrideDescriptor, overrideFunction, overrideConstructor } from '../../utils/property-overriding';
+import { overrideDescriptor, overrideFunction, overrideConstructor } from '../../utils/overriding';
 import { emptyActionAttrFallbacksToTheLocation } from '../../utils/feature-detection';
 import { HASH_RE, isValidUrl } from '../../../utils/url';
 import UploadSandbox from '../upload';

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -718,8 +718,8 @@ export default class WindowSandbox extends SandboxBase {
         }, true);
 
         overrideFunction(window.Function.prototype, 'toString', function () {
-            if (nativeMethods.objectHasOwnProperty.call(this, INTERNAL_PROPS.nativeStringRepresentation))
-                return this[INTERNAL_PROPS.nativeStringRepresentation];
+            if (nativeMethods.objectHasOwnProperty.call(this, INTERNAL_PROPS.nativeStrRepresentation))
+                return this[INTERNAL_PROPS.nativeStrRepresentation];
 
             return nativeMethods.funcProtoToString.call(this);
         });

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -743,13 +743,11 @@ export default class WindowSandbox extends SandboxBase {
             return nativeMethods.Function.apply(this, args);
         };
 
-        const nativeFunctionPrototypeToString = nativeMethods.Function.prototype.toString;
-
         const funcToStringWrapper = function () {
             if (nativeMethods.objectHasOwnProperty.call(this, INTERNAL_PROPS.nativeStringRepresentation))
                 return this[INTERNAL_PROPS.nativeStringRepresentation];
 
-            return nativeFunctionPrototypeToString.call(this);
+            return nativeMethods.funcProtoToString.call(this);
         };
 
         overrideFunction(window.Function.prototype, 'toString', funcToStringWrapper);

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -721,7 +721,7 @@ export default class WindowSandbox extends SandboxBase {
             if (nativeMethods.objectHasOwnProperty.call(this, INTERNAL_PROPS.nativeStrRepresentation))
                 return this[INTERNAL_PROPS.nativeStrRepresentation];
 
-            return nativeMethods.funcProtoToString.call(this);
+            return nativeMethods.functionToString.call(this);
         });
 
         if (typeof window.history.pushState === 'function' && typeof window.history.replaceState === 'function') {

--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -265,7 +265,7 @@ export default class ShadowUI extends SandboxBase {
         const shadowUI = this;
         const docProto = window.Document.prototype;
 
-        const docProtoElementFromPointWrapper = function (...args) {
+        overrideFunction(docProto, 'elementFromPoint', function (...args) {
             // NOTE: T212974
             shadowUI.addClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
@@ -274,12 +274,10 @@ export default class ShadowUI extends SandboxBase {
             shadowUI.removeClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
             return res;
-        };
-
-        overrideFunction(docProto, 'elementFromPoint', docProtoElementFromPointWrapper);
+        });
 
         if (document.caretRangeFromPoint) {
-            const docProtoCaretRangeFromPointWrapper = function (...args) {
+            overrideFunction(docProto, 'caretRangeFromPoint', function (...args) {
                 shadowUI.addClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
                 let res = nativeMethods.caretRangeFromPoint.apply(this, args);
@@ -290,13 +288,11 @@ export default class ShadowUI extends SandboxBase {
                 shadowUI.removeClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
                 return res;
-            };
-
-            overrideFunction(docProto, 'caretRangeFromPoint', docProtoCaretRangeFromPointWrapper);
+            });
         }
 
         if (document.caretPositionFromPoint) {
-            const docProtoCaretPositionFromPointWrapper = function (...args) {
+            overrideFunction(docProto, 'caretPositionFromPoint', function (...args) {
                 shadowUI.addClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
                 let res = nativeMethods.caretPositionFromPoint.apply(this, args);
@@ -307,27 +303,21 @@ export default class ShadowUI extends SandboxBase {
                 shadowUI.removeClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
                 return res;
-            };
-
-            overrideFunction(docProto, 'caretPositionFromPoint', docProtoCaretPositionFromPointWrapper);
+            });
         }
 
-        const docProtoGetElementByIdWrapper = function (...args) {
+        overrideFunction(docProto, 'getElementById', function (...args) {
             return ShadowUI._filterElement(nativeMethods.getElementById.apply(this, args));
-        };
+        });
 
-        overrideFunction(docProto, 'getElementById', docProtoGetElementByIdWrapper);
-
-        const docProtoGetElementsByName = function (...args) {
+        overrideFunction(docProto, 'getElementsByName', function (...args) {
             const elements = nativeMethods.getElementsByName.apply(this, args);
             const length   = getElementsByNameReturnsHTMLCollection
                 ? nativeMethods.htmlCollectionLengthGetter.call(elements)
                 : nativeMethods.nodeListLengthGetter.call(elements);
 
             return shadowUI._filterNodeList(elements, length);
-        };
-
-        overrideFunction(docProto, 'getElementsByName', docProtoGetElementsByName);
+        });
 
         overrideFunction(docProto, 'getElementsByClassName', this.wrapperCreators.getElementsByClassName('getElementsByClassName'));
         overrideFunction(docProto, 'getElementsByTagName', this.wrapperCreators.getElementsByTagName('getElementsByTagName'));

--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -18,7 +18,7 @@ import MessageSandbox from './event/message';
 import IframeSandbox from './iframe';
 import IEDebugSandbox from './ie-debug';
 import removeElement from '../utils/remove-element';
-import { overrideFunction } from '../utils/property-overriding';
+import { overrideFunction } from '../utils/overriding';
 
 const IS_NON_STATIC_POSITION_RE = /fixed|relative|absolute/;
 const CLASSNAME_RE              = /\.((?:\\.|[-\w]|[^\x00-\xa0])+)/g;

--- a/src/client/sandbox/storages/index.ts
+++ b/src/client/sandbox/storages/index.ts
@@ -6,7 +6,7 @@ import { getTopSameDomainWindow } from '../../utils/dom';
 import getStorageKey from '../../../utils/get-storage-key';
 import INTERNAL_PROPS from '../../../processing/dom/internal-properties';
 import * as JSON from 'json-hammerhead';
-import { createOverriddenDescriptor } from '../../utils/property-overriding';
+import { createOverriddenDescriptor } from '../../utils/overriding';
 import hammerhead from '../../index';
 import Listeners from '../event/listeners';
 import UnloadSandbox from '../event/unload';

--- a/src/client/sandbox/style.ts
+++ b/src/client/sandbox/style.ts
@@ -178,9 +178,11 @@ export default class StyleSandbox extends SandboxBase {
 
             if (this.nativeMethods.objectHasOwnProperty.call(styleDeclarationProto, prop) &&
                 typeof nativeFn === 'function') {
-                styleDeclarationProto[prop] = function () {
+                const nativeFnWrapper = function () {
                     return nativeFn.apply(this[CSS_STYLE_PROXY_TARGET] || this, arguments);
                 };
+
+                overrideFunction(styleDeclarationProto, prop, nativeFnWrapper);
             }
         }
     }

--- a/src/client/sandbox/style.ts
+++ b/src/client/sandbox/style.ts
@@ -178,11 +178,11 @@ export default class StyleSandbox extends SandboxBase {
 
             if (this.nativeMethods.objectHasOwnProperty.call(styleDeclarationProto, prop) &&
                 typeof nativeFn === 'function') {
-                const nativeFnWrapper = function () {
+                styleDeclarationProto[prop] = function () {
                     return nativeFn.apply(this[CSS_STYLE_PROXY_TARGET] || this, arguments);
                 };
-
-                overrideFunction(styleDeclarationProto, prop, nativeFnWrapper);
+                
+                // overrideFunction(styleDeclarationProto, prop, nativeFnWrapper);
             }
         }
     }

--- a/src/client/sandbox/style.ts
+++ b/src/client/sandbox/style.ts
@@ -1,5 +1,5 @@
 import SandboxBase from './base';
-import { overrideDescriptor, overrideFunction } from './../utils/property-overriding';
+import { overrideDescriptor, overrideFunction, overrideStringRepresentation } from './../utils/property-overriding';
 import styleProcessor from './../../processing/style';
 import { getProxyUrl, parseProxyUrl } from './../utils/url';
 
@@ -181,6 +181,8 @@ export default class StyleSandbox extends SandboxBase {
                 styleDeclarationProto[prop] = function () {
                     return nativeFn.apply(this[CSS_STYLE_PROXY_TARGET] || this, arguments);
                 };
+
+                overrideStringRepresentation(styleDeclarationProto[prop], nativeFn);
                 
                 // overrideFunction(styleDeclarationProto, prop, nativeFnWrapper);
             }

--- a/src/client/sandbox/style.ts
+++ b/src/client/sandbox/style.ts
@@ -180,8 +180,7 @@ export default class StyleSandbox extends SandboxBase {
                     return nativeFn.apply(this[CSS_STYLE_PROXY_TARGET] || this, arguments);
                 };
 
-                // NOTE:
-                // we cannot use 'overrideFunction' here since the function may not exist
+                // NOTE: we cannot use 'overrideFunction' here since the function may not exist
                 overrideStringRepresentation(styleDeclarationProto[prop] as unknown as Function, nativeFn);
             }
         }

--- a/src/client/sandbox/style.ts
+++ b/src/client/sandbox/style.ts
@@ -1,5 +1,5 @@
 import SandboxBase from './base';
-import { overrideDescriptor, overrideFunction, overrideStringRepresentation } from './../utils/property-overriding';
+import { overrideDescriptor, overrideFunction, overrideStringRepresentation } from '../utils/overriding';
 import styleProcessor from './../../processing/style';
 import { getProxyUrl, parseProxyUrl } from './../utils/url';
 

--- a/src/client/sandbox/timers.ts
+++ b/src/client/sandbox/timers.ts
@@ -30,7 +30,6 @@ export default class TimersSandbox extends SandboxBase {
             const fnToRun       = isScriptFirstArg ? () => {
                 // NOTE: We are switching eval to the global context with this assignment.
                 // Unlike eval, the setTimeout/setInterval functions always work in the global context.
-                // @ts-ignore
                 const ev = this.window.eval;
 
                 return ev(script);

--- a/src/client/sandbox/timers.ts
+++ b/src/client/sandbox/timers.ts
@@ -75,17 +75,13 @@ export default class TimersSandbox extends SandboxBase {
 
         const timersSandbox = this;
 
-        const setTimeoutWrapper = function (...args) {
+        overrideFunction(window, 'setTimeout', function (...args) {
             return nativeMethods.setTimeout.apply(window, timersSandbox._wrapTimeoutFunctionsArguments(args));
-        };
+        });
 
-        overrideFunction(window, 'setTimeout', setTimeoutWrapper);
-
-        const setIntervalWrapper = function (...args) {
+        overrideFunction(window, 'setInterval', function (...args) {
             return nativeMethods.setInterval.apply(window, timersSandbox._wrapTimeoutFunctionsArguments(args));
-        };
-
-        overrideFunction(window, 'setInterval', setIntervalWrapper);
+        });
 
         // NOTE: We are saving the setTimeout wrapper for internal use in case the page-script replaces
         // it with an invalid value.

--- a/src/client/sandbox/timers.ts
+++ b/src/client/sandbox/timers.ts
@@ -2,7 +2,7 @@ import SandboxBase from './base';
 import nativeMethods from './native-methods';
 import { processScript } from '../../processing/script';
 import { isIE, version as browserVersion } from '../utils/browser';
-import { overrideFunction } from '../utils/property-overriding';
+import { overrideFunction } from '../utils/overriding';
 
 // NOTE: When you call the focus and blur function for some elements in IE, the event handlers  must be raised
 // asynchronously, but before executing functions that are called by using the window.setTimeout function. So,

--- a/src/client/sandbox/timers.ts
+++ b/src/client/sandbox/timers.ts
@@ -2,6 +2,7 @@ import SandboxBase from './base';
 import nativeMethods from './native-methods';
 import { processScript } from '../../processing/script';
 import { isIE, version as browserVersion } from '../utils/browser';
+import { overrideFunction } from '../utils/property-overriding';
 
 // NOTE: When you call the focus and blur function for some elements in IE, the event handlers  must be raised
 // asynchronously, but before executing functions that are called by using the window.setTimeout function. So,
@@ -75,13 +76,17 @@ export default class TimersSandbox extends SandboxBase {
 
         const timersSandbox = this;
 
-        window.setTimeout = function (...args) {
+        const setTimeoutWrapper = function (...args) {
             return nativeMethods.setTimeout.apply(window, timersSandbox._wrapTimeoutFunctionsArguments(args));
         };
 
-        window.setInterval = function (...args) {
+        overrideFunction(window, 'setTimeout', setTimeoutWrapper);
+
+        const setIntervalWrapper = function (...args) {
             return nativeMethods.setInterval.apply(window, timersSandbox._wrapTimeoutFunctionsArguments(args));
         };
+
+        overrideFunction(window, 'setInterval', setIntervalWrapper);
 
         // NOTE: We are saving the setTimeout wrapper for internal use in case the page-script replaces
         // it with an invalid value.

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -85,7 +85,11 @@ export default class XhrSandbox extends SandboxBase {
         }
 
         // NOTE: We cannot just assign constructor property in OS X 10.11 safari 9.0
-        overrideConstructor(window, 'XMLHttpRequest', xmlHttpRequestWrapper, true);
+        overrideConstructor(window, 'XMLHttpRequest', xmlHttpRequestWrapper);
+
+        nativeMethods.objectDefineProperty(xmlHttpRequestProto, 'constructor', {
+            value: xmlHttpRequestWrapper
+        });
 
         overrideFunction(xmlHttpRequestProto, 'abort', function () {
             nativeMethods.xhrAbort.apply(this, arguments);

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -84,7 +84,7 @@ export default class XhrSandbox extends SandboxBase {
             });
         }
 
-        // NOTE: We cannot just assign constructor property in OS X 10.11 safari 9.0
+        // NOTE: We cannot just assign constructor property of the prototype of XMLHttpRequest in OS X 10.11 safari 9.0
         overrideConstructor(window, 'XMLHttpRequest', xmlHttpRequestWrapper);
 
         nativeMethods.objectDefineProperty(xmlHttpRequestProto, 'constructor', {

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -84,12 +84,8 @@ export default class XhrSandbox extends SandboxBase {
             });
         }
 
-        overrideConstructor(window, 'XMLHttpRequest', xmlHttpRequestWrapper);
-
         // NOTE: We cannot just assign constructor property in OS X 10.11 safari 9.0
-        nativeMethods.objectDefineProperty(xmlHttpRequestProto, 'constructor', {
-            value: xmlHttpRequestWrapper
-        });
+        overrideConstructor(window, 'XMLHttpRequest', xmlHttpRequestWrapper, true);
 
         const xmlHttpRequestProtoAbortWrapper = function () {
             nativeMethods.xhrAbort.apply(this, arguments);

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -5,7 +5,7 @@ import BUILTIN_HEADERS from '../../request-pipeline/builtin-header-names';
 import INTERNAL_HEADERS from '../../request-pipeline/internal-header-names';
 import { transformHeaderNameToInternal } from '../utils/headers';
 import { getOriginHeader } from '../utils/destination-location';
-import { overrideConstructor, overrideDescriptor, overrideFunction } from '../utils/property-overriding';
+import { overrideConstructor, overrideDescriptor, overrideFunction } from '../utils/overriding';
 import SAME_ORIGIN_CHECK_FAILED_STATUS_CODE from '../../request-pipeline/xhr/same-origin-check-failed-status-code';
 import CookieSandbox from './cookie';
 

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -84,7 +84,7 @@ export default class XhrSandbox extends SandboxBase {
             });
         }
 
-        // NOTE: We cannot just assign constructor property of the prototype of XMLHttpRequest in OS X 10.11 safari 9.0
+        // NOTE: We cannot just assign constructor property of the prototype of XMLHttpRequest starts from safari 9.0
         overrideConstructor(window, 'XMLHttpRequest', xmlHttpRequestWrapper);
 
         nativeMethods.objectDefineProperty(xmlHttpRequestProto, 'constructor', {

--- a/src/client/utils/overriding.ts
+++ b/src/client/utils/overriding.ts
@@ -68,16 +68,12 @@ function overrideFunctionName (fn: Function, name: string): void {
 }
 
 function overrideToString (nativeFnWrapper: Function, nativeFn: Function): void {
-    // NOTE:
-    // `configurable`, `enumerable` and `writable` optional keys of the descriptor are set implicitly to false
-    // because we want to hide our internal property from the user code
     nativeMethods.objectDefineProperty(nativeFnWrapper, INTERNAL_PROPS.nativeStrRepresentation, {
         value: nativeMethods.Function.prototype.toString.call(nativeFn)
     });
 }
 
-// TODO:
-// this function should not be used outside this file
+// TODO: this function should not be used outside this file
 // for now it's used to flag cases in which we assign our wrapper to a native function when it is missing
 export function overrideStringRepresentation (nativeFnWrapper: Function, nativeFn: Function): void {
     overrideFunctionName(nativeFnWrapper, nativeFn.name);

--- a/src/client/utils/property-overriding.ts
+++ b/src/client/utils/property-overriding.ts
@@ -56,11 +56,28 @@ export function overrideDescriptor<O extends object, K extends keyof O> (obj: O,
     nativeMethods.objectDefineProperty(obj, prop, descriptor);
 }
 
-export function overrideStringRepresentation (nativeFunctionWrapper: Function, nativeFunction: Function): void {
-    const nativeStringRepresentation = nativeMethods.Function.prototype.toString.call(nativeFunction);
+export function overrideStringRepresentation (nativeFnWrapper: Function, nativeFn: Function): void {
+    const nativeStringRepresentation = nativeMethods.Function.prototype.toString.call(nativeFn);
 
-    nativeMethods.objectDefineProperty(nativeFunctionWrapper, INTERNAL_PROPS.nativeStringRepresentation, {
+    nativeMethods.objectDefineProperty(nativeFnWrapper, INTERNAL_PROPS.nativeStringRepresentation, {
         value: nativeStringRepresentation,
         configurable: true
     });
+}
+
+export function isNativeFunction (fn: Function): boolean {
+    return !nativeMethods.objectHasOwnProperty.call(fn, INTERNAL_PROPS.nativeStringRepresentation);
+}
+
+export function overrideFunction<O extends object, K extends keyof O> (obj: O, fnName: K, wrapper: Function): void {
+    const descriptor = nativeMethods.objectGetOwnPropertyDescriptor(obj, fnName);
+    const value      = descriptor.value; // eslint-disable-line no-restricted-properties
+
+    if (value && isNativeFunction(value)) {
+        overrideStringRepresentation(wrapper, value);
+        
+        nativeMethods.objectDefineProperty(obj, fnName, {
+            value: wrapper
+        });
+    }
 }

--- a/src/client/utils/property-overriding.ts
+++ b/src/client/utils/property-overriding.ts
@@ -1,4 +1,5 @@
 import nativeMethods from '../sandbox/native-methods';
+import INTERNAL_PROPS from '../../processing/dom/internal-properties';
 
 
 interface PropertySettings<T extends object, K extends keyof T> {
@@ -53,4 +54,13 @@ export function overrideDescriptor<O extends object, K extends keyof O> (obj: O,
     const descriptor = createOverriddenDescriptor(obj, prop, propertyAccessors);
 
     nativeMethods.objectDefineProperty(obj, prop, descriptor);
+}
+
+export function overrideStringRepresentation (nativeFunctionWrapper: Function, nativeFunction: Function): void {
+    const nativeStringRepresentation = nativeMethods.Function.prototype.toString.call(nativeFunction);
+
+    nativeMethods.objectDefineProperty(nativeFunctionWrapper, INTERNAL_PROPS.nativeStringRepresentation, {
+        value: nativeStringRepresentation,
+        configurable: true
+    });
 }

--- a/src/client/utils/property-overriding.ts
+++ b/src/client/utils/property-overriding.ts
@@ -65,8 +65,6 @@ function overrideFunctionName (fn: Function, name: string) {
 
         nativeMethods.objectDefineProperty(fn, 'name', wrapperNameDescriptor);
     }
-    else
-        nativeMethods.objectDefineProperty(fn, 'name', { value: name });
 }
 
 export function overrideStringRepresentation (nativeFnWrapper: Function, nativeFn: Function): void {

--- a/src/client/utils/property-overriding.ts
+++ b/src/client/utils/property-overriding.ts
@@ -58,6 +58,12 @@ export function overrideDescriptor<O extends object, K extends keyof O> (obj: O,
 
 // NOTE: saves the original string representation of a native function in its wrapper as an additional property
 export function overrideStringRepresentation (nativeFnWrapper: Function, nativeFn: Function): void {
+    // NOTE: we need to override the 'name' property of our wrapper 
+    // to be the same as the `name` property of a native function
+    nativeMethods.objectDefineProperty(nativeFnWrapper, 'name', {
+        value: nativeFn['name']
+    });
+    
     const nativeStringRepresentation = nativeMethods.Function.prototype.toString.call(nativeFn);
 
     nativeMethods.objectDefineProperty(nativeFnWrapper, INTERNAL_PROPS.nativeStringRepresentation, {
@@ -74,12 +80,6 @@ export function overrideFunction<O extends object, K extends keyof O> (obj: O, f
     const fn = obj[fnName] as unknown as Function;
 
     if (isNativeFunction(fn)) {
-        // NOTE: we need to override the 'name' property of our wrapper 
-        // to be the same as the `name` property of a native function
-        nativeMethods.objectDefineProperty(wrapper, 'name', {
-            value: obj[fnName]['name']
-        });
-
         overrideStringRepresentation(wrapper, fn);
         
         nativeMethods.objectDefineProperty(obj, fnName, {

--- a/src/client/utils/property-overriding.ts
+++ b/src/client/utils/property-overriding.ts
@@ -68,9 +68,14 @@ function overrideFunctionName (fn: Function, name: string) {
 }
 
 export function overrideStringRepresentation (nativeFnWrapper: Function, nativeFn: Function): void {
-    overrideFunctionName(nativeFnWrapper, nativeFn['name']);
+    overrideFunctionName(nativeFnWrapper, nativeFn.name);
 
-    nativeFnWrapper[INTERNAL_PROPS.nativeStrRepresentation] = nativeMethods.Function.prototype.toString.call(nativeFn);
+    // NOTE:
+    // `configurable`, `enumerable` and `writable` optional keys of the descriptor are set implicitly to false
+    // because we want to hide our internal property from the user code
+    nativeMethods.objectDefineProperty(nativeFnWrapper, INTERNAL_PROPS.nativeStrRepresentation, {
+        value: nativeMethods.Function.prototype.toString.call(nativeFn)
+    });
 }
 
 export function isNativeFunction (fn: Function): boolean {

--- a/src/processing/dom/internal-properties.ts
+++ b/src/processing/dom/internal-properties.ts
@@ -16,6 +16,5 @@ export default {
     skipNextLoadEventForImage: 'hammerhead|image|skip-next-load-event-flag',
     cachedImage:               'hammerhead|image|cached-image',
     sandboxIsReattached:       'hammerhead|sandbox-is-reattached',
-    
-    nativeStringRepresentation: 'hammerhead|nativeStringRepresentation'
+    nativeStrRepresentation:   'hammerhead|native-string-representation'
 };

--- a/src/processing/dom/internal-properties.ts
+++ b/src/processing/dom/internal-properties.ts
@@ -15,5 +15,7 @@ export default {
     forceProxySrcForImage:     'hammerhead|image|force-proxy-src-flag',
     skipNextLoadEventForImage: 'hammerhead|image|skip-next-load-event-flag',
     cachedImage:               'hammerhead|image|cached-image',
-    sandboxIsReattached:       'hammerhead|sandbox-is-reattached'
+    sandboxIsReattached:       'hammerhead|sandbox-is-reattached',
+    
+    nativeStringRepresentation: 'hammerhead|nativeStringRepresentation'
 };

--- a/test/client/before-test.js
+++ b/test/client/before-test.js
@@ -199,22 +199,12 @@
     window.noop = function () {
     };
 
-    window.checkStringRepresentation = function (wrappedFn, originalFn) {
-        strictEqual(
-            wrappedFn.toString(),
-            originalFn.toString(),
-            'the outputs of the "toString()" method should be the same'
-        );
-        strictEqual(
-            Function.prototype.toString.call(wrappedFn),
-            nativeMethods.functionToString.call(originalFn),
-            'the outputs of the "Function.prototype.toString" function should be the same'
-        );
-        strictEqual(
-            wrappedFn.name,
-            originalFn.name,
-            'the function names should be the same'
-        );
+    window.checkStringRepresentation = function (wrappedFn, originalFn, fnName) {
+        strictEqual(wrappedFn.toString(), originalFn.toString(),
+            fnName + ': the outputs of the "toString()" method should be the same');
+        strictEqual(Function.prototype.toString.call(wrappedFn), nativeMethods.functionToString.call(originalFn),
+            fnName + ': the outputs of the "Function.prototype.toString" function should be the same');
+        strictEqual(wrappedFn.name, originalFn.name, fnName + ': the function names should be the same');
     };
 
     QUnitGlobals.WAIT_FOR_IFRAME_TIMEOUT = 20000;

--- a/test/client/before-test.js
+++ b/test/client/before-test.js
@@ -207,7 +207,7 @@
         );
         strictEqual(
             Function.prototype.toString.call(wrappedFn),
-            nativeMethods.Function.prototype.toString.call(originalFn),
+            nativeMethods.funcProtoToString.call(originalFn),
             'the outputs of the "Function.prototype.toString" function should be the same'
         );
         strictEqual(

--- a/test/client/before-test.js
+++ b/test/client/before-test.js
@@ -207,7 +207,7 @@
         );
         strictEqual(
             Function.prototype.toString.call(wrappedFn),
-            nativeMethods.funcProtoToString.call(originalFn),
+            nativeMethods.functionToString.call(originalFn),
             'the outputs of the "Function.prototype.toString" function should be the same'
         );
         strictEqual(

--- a/test/client/before-test.js
+++ b/test/client/before-test.js
@@ -199,6 +199,24 @@
     window.noop = function () {
     };
 
+    window.checkStringRepresentation = function (wrappedFn, originalFn) {
+        strictEqual(
+            wrappedFn.toString(),
+            originalFn.toString(),
+            'the outputs of the "toString()" method should be the same'
+        );
+        strictEqual(
+            Function.prototype.toString.call(wrappedFn),
+            nativeMethods.Function.prototype.toString.call(originalFn),
+            'the outputs of the "Function.prototype.toString" function should be the same'
+        );
+        strictEqual(
+            wrappedFn.name,
+            originalFn.name,
+            'the function names should be the same'
+        );
+    };
+
     QUnitGlobals.WAIT_FOR_IFRAME_TIMEOUT = 20000;
     QUnit.config.testTimeout             = window.QUnitGlobals.WAIT_FOR_IFRAME_TIMEOUT * 2 + 5000;
 

--- a/test/client/data/node-sandbox/iframe-override-elems-after-write.html
+++ b/test/client/data/node-sandbox/iframe-override-elems-after-write.html
@@ -20,7 +20,7 @@
 <script>
     var iframeSandbox = window['%hammerhead%'].sandbox.iframe;
     var INTERNAL_PROPS = hammerhead.get('../processing/dom/internal-properties');
-    // var isNativeFunction = hammerhead.get('../client/utils/property-overriding');
+    var propertyOverridingUtils = hammerhead.get('../client/utils/property-overriding');
     var hhPostMessage = hammerhead.sandbox.event.message.postMessage;
 
     iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, window.top.initIframeTestHandler);
@@ -39,8 +39,7 @@
         },
 
         {
-            success:     document.querySelector('iframe').contentDocument.write.toString() !==
-                         hammerhead.nativeMethods.documentWrite.toString(),
+            success:     !propertyOverridingUtils.isNativeFunction(document.querySelector('iframe').contentDocument.write),
             description: 'document.write function of element "iframe" is overridden'
         }
     ], '*']);

--- a/test/client/data/node-sandbox/iframe-override-elems-after-write.html
+++ b/test/client/data/node-sandbox/iframe-override-elems-after-write.html
@@ -20,6 +20,7 @@
 <script>
     var iframeSandbox = window['%hammerhead%'].sandbox.iframe;
     var INTERNAL_PROPS = hammerhead.get('../processing/dom/internal-properties');
+    // var isNativeFunction = hammerhead.get('../client/utils/property-overriding');
     var hhPostMessage = hammerhead.sandbox.event.message.postMessage;
 
     iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, window.top.initIframeTestHandler);

--- a/test/client/data/node-sandbox/iframe-override-elems-after-write.html
+++ b/test/client/data/node-sandbox/iframe-override-elems-after-write.html
@@ -18,10 +18,10 @@
     hammerhead.shadowUI.getRoot();
 </script>
 <script>
-    var iframeSandbox = window['%hammerhead%'].sandbox.iframe;
-    var INTERNAL_PROPS = hammerhead.get('../processing/dom/internal-properties');
-    var propertyOverridingUtils = hammerhead.get('../client/utils/property-overriding');
-    var hhPostMessage = hammerhead.sandbox.event.message.postMessage;
+    var iframeSandbox   = window['%hammerhead%'].sandbox.iframe;
+    var INTERNAL_PROPS  = hammerhead.get('../processing/dom/internal-properties');
+    var overriding      = hammerhead.get('../client/utils/overriding');
+    var hhPostMessage   = hammerhead.sandbox.event.message.postMessage;
 
     iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, window.top.initIframeTestHandler);
 
@@ -39,7 +39,7 @@
         },
 
         {
-            success:     !propertyOverridingUtils.isNativeFunction(document.querySelector('iframe').contentDocument.write),
+            success:     !overriding.isNativeFunction(document.querySelector('iframe').contentDocument.write),
             description: 'document.write function of element "iframe" is overridden'
         }
     ], '*']);

--- a/test/client/fixtures/sandbox/console-test.js
+++ b/test/client/fixtures/sandbox/console-test.js
@@ -154,22 +154,11 @@ if (window.console && typeof window.console.log !== 'undefined') {
         });
     }
 
-    module('wrappers of native functions should return the correct string representations', function () {
-        test('console.log', function () {
-            window.checkStringRepresentation(window.console.log, nativeMethods.consoleMeths.log);
-        });
-
-        test('console.warn', function () {
-            window.checkStringRepresentation(window.console.warn, nativeMethods.consoleMeths.warn);
-        });
-
-        test('console.error', function () {
-            window.checkStringRepresentation(window.console.error, nativeMethods.consoleMeths.error);
-        });
-
-        test('console.info', function () {
-            window.checkStringRepresentation(window.console.info, nativeMethods.consoleMeths.info);
-        });
+    test('wrappers of native functions should return the correct string representations', function () {
+        window.checkStringRepresentation(window.console.log, nativeMethods.consoleMeths.log, 'console.log');
+        window.checkStringRepresentation(window.console.warn, nativeMethods.consoleMeths.warn, 'console.warn');
+        window.checkStringRepresentation(window.console.error, nativeMethods.consoleMeths.error, 'console.error');
+        window.checkStringRepresentation(window.console.info, nativeMethods.consoleMeths.info, 'console.info');
     });
 
     module('regression');

--- a/test/client/fixtures/sandbox/console-test.js
+++ b/test/client/fixtures/sandbox/console-test.js
@@ -154,6 +154,24 @@ if (window.console && typeof window.console.log !== 'undefined') {
         });
     }
 
+    module('wrappers of native functions should return the correct string representations', function () {
+        test('console.log', function () {
+            window.checkStringRepresentation(window.console.log, nativeMethods.consoleMeths.log);
+        });
+
+        test('console.warn', function () {
+            window.checkStringRepresentation(window.console.warn, nativeMethods.consoleMeths.warn);
+        });
+
+        test('console.error', function () {
+            window.checkStringRepresentation(window.console.error, nativeMethods.consoleMeths.error);
+        });
+
+        test('console.info', function () {
+            window.checkStringRepresentation(window.console.info, nativeMethods.consoleMeths.info);
+        });
+    });
+
     module('regression');
 
     test('console message with circular structure object from iframe (GH-1546)', function () {

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -68,66 +68,43 @@ test('remove event listener in the context of optional parameters ("options" obj
     checkEventListenerRemoving(divEl);
 });
 
-module('wrappers of native functions should return the correct string representations', function () {
-    test('window.HTMLInputElement.prototype.setSelectionRange', function () {
-        window.checkStringRepresentation(window.HTMLInputElement.prototype.setSelectionRange, nativeMethods.setSelectionRange);
-    });
-
-    test('window.HTMLTextAreaElement.prototype.setSelectionRange', function () {
-        window.checkStringRepresentation(window.HTMLTextAreaElement.prototype.setSelectionRange, nativeMethods.textAreaSetSelectionRange);
-    });
+test('wrappers of native functions should return the correct string representations', function () {
+    window.checkStringRepresentation(window.HTMLInputElement.prototype.setSelectionRange,
+        nativeMethods.setSelectionRange,
+        'HTMLInputElement.prototype.setSelectionRange');
+    window.checkStringRepresentation(window.HTMLTextAreaElement.prototype.setSelectionRange,
+        nativeMethods.textAreaSetSelectionRange,
+        'HTMLTextAreaElement.prototype.setSelectionRange');
 
     if (window.EventTarget) {
-        test('window.EventTarget.prototype.dispatchEvent', function () {
-            window.checkStringRepresentation(window.EventTarget.prototype.dispatchEvent, nativeMethods.dispatchEvent);
-        });
+        window.checkStringRepresentation(window.EventTarget.prototype.dispatchEvent, nativeMethods.dispatchEvent,
+            'EventTarget.prototype.dispatchEvent');
     }
     else {
-        test('window.Window.prototype.dispatchEvent', function () {
-            window.checkStringRepresentation(window.Window.prototype.dispatchEvent, nativeMethods.dispatchEvent);
-        });
-
-        test('window.Document.prototype.dispatchEvent', function () {
-            window.checkStringRepresentation(window.Document.prototype.dispatchEvent, nativeMethods.dispatchEvent);
-        });
-
-        test('window.HTMLElement.prototype.dispatchEvent', function () {
-            window.checkStringRepresentation(window.HTMLElement.prototype.dispatchEvent, nativeMethods.dispatchEvent);
-        });
-
-        test('window.SVGElement.prototype.dispatchEvent', function () {
-            window.checkStringRepresentation(window.SVGElement.prototype.dispatchEvent, nativeMethods.dispatchEvent);
-        });
+        window.checkStringRepresentation(window.Window.prototype.dispatchEvent, nativeMethods.dispatchEvent,
+            'Window.prototype.dispatchEvent');
+        window.checkStringRepresentation(window.Document.prototype.dispatchEvent, nativeMethods.dispatchEvent,
+            'Document.prototype.dispatchEvent');
+        window.checkStringRepresentation(window.HTMLElement.prototype.dispatchEvent, nativeMethods.dispatchEvent,
+            'HTMLElement.prototype.dispatchEvent');
+        window.checkStringRepresentation(window.SVGElement.prototype.dispatchEvent, nativeMethods.dispatchEvent,
+            'SVGElement.prototype.dispatchEvent');
     }
 
-    test('window.HTMLElement.prototype.focus', function () {
-        window.checkStringRepresentation(window.HTMLElement.prototype.focus, nativeMethods.focus);
-    });
-
-    test('window.HTMLElement.prototype.blur', function () {
-        window.checkStringRepresentation(window.HTMLElement.prototype.blur, nativeMethods.blur);
-    });
-
-    test('window.HTMLElement.prototype.click', function () {
-        window.checkStringRepresentation(window.HTMLElement.prototype.click, nativeMethods.click);
-    });
-
-    test('window.Window.focus', function () {
-        window.checkStringRepresentation(window.Window.focus, nativeMethods.focus);
-    });
-
-    test('window.Window.blur', function () {
-        window.checkStringRepresentation(window.Window.blur, nativeMethods.blur);
-    });
-
-    test('window.Event.prototype.preventDefault', function () {
-        window.checkStringRepresentation(window.Event.prototype.preventDefault, nativeMethods.preventDefault);
-    });
+    window.checkStringRepresentation(window.HTMLElement.prototype.focus, nativeMethods.focus,
+        'HTMLElement.prototype.focus');
+    window.checkStringRepresentation(window.HTMLElement.prototype.blur, nativeMethods.blur,
+        'HTMLElement.prototype.blur');
+    window.checkStringRepresentation(window.HTMLElement.prototype.click, nativeMethods.click,
+        'HTMLElement.prototype.click');
+    window.checkStringRepresentation(window.Window.focus, nativeMethods.focus, 'Window.focus');
+    window.checkStringRepresentation(window.Window.blur, nativeMethods.blur, 'Window.blur');
+    window.checkStringRepresentation(window.Event.prototype.preventDefault, nativeMethods.preventDefault,
+        'Event.prototype.preventDefault');
 
     if (window.TextRange && window.TextRange.prototype.select) {
-        test('window.TextRange.prototype.select', function () {
-            window.checkStringRepresentation(window.TextRange.prototype.select, nativeMethods.select);
-        });
+        window.checkStringRepresentation(window.TextRange.prototype.select, nativeMethods.select,
+            'TextRange.prototype.select');
     }
 });
 

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -68,6 +68,68 @@ test('remove event listener in the context of optional parameters ("options" obj
     checkEventListenerRemoving(divEl);
 });
 
+module('wrappers of native functions should return the correct string representations', function () {
+    test('window.HTMLInputElement.prototype.setSelectionRange', function () {
+        window.checkStringRepresentation(window.HTMLInputElement.prototype.setSelectionRange, nativeMethods.setSelectionRange);
+    });
+
+    test('window.HTMLTextAreaElement.prototype.setSelectionRange', function () {
+        window.checkStringRepresentation(window.HTMLTextAreaElement.prototype.setSelectionRange, nativeMethods.textAreaSetSelectionRange);
+    });
+
+    if (window.EventTarget) {
+        test('window.EventTarget.prototype.dispatchEvent', function () {
+            window.checkStringRepresentation(window.EventTarget.prototype.dispatchEvent, nativeMethods.dispatchEvent);
+        });
+    }
+    else {
+        test('window.Window.prototype.dispatchEvent', function () {
+            window.checkStringRepresentation(window.Window.prototype.dispatchEvent, nativeMethods.dispatchEvent);
+        });
+
+        test('window.Document.prototype.dispatchEvent', function () {
+            window.checkStringRepresentation(window.Document.prototype.dispatchEvent, nativeMethods.dispatchEvent);
+        });
+
+        test('window.HTMLElement.prototype.dispatchEvent', function () {
+            window.checkStringRepresentation(window.HTMLElement.prototype.dispatchEvent, nativeMethods.dispatchEvent);
+        });
+
+        test('window.SVGElement.prototype.dispatchEvent', function () {
+            window.checkStringRepresentation(window.SVGElement.prototype.dispatchEvent, nativeMethods.dispatchEvent);
+        });
+    }
+
+    test('window.HTMLElement.prototype.focus', function () {
+        window.checkStringRepresentation(window.HTMLElement.prototype.focus, nativeMethods.focus);
+    });
+
+    test('window.HTMLElement.prototype.blur', function () {
+        window.checkStringRepresentation(window.HTMLElement.prototype.blur, nativeMethods.blur);
+    });
+
+    test('window.HTMLElement.prototype.click', function () {
+        window.checkStringRepresentation(window.HTMLElement.prototype.click, nativeMethods.click);
+    });
+
+    test('window.Window.focus', function () {
+        window.checkStringRepresentation(window.Window.focus, nativeMethods.focus);
+    });
+
+    test('window.Window.blur', function () {
+        window.checkStringRepresentation(window.Window.blur, nativeMethods.blur);
+    });
+
+    test('window.Event.prototype.preventDefault', function () {
+        window.checkStringRepresentation(window.Event.prototype.preventDefault, nativeMethods.preventDefault);
+    });
+
+    if (window.TextRange && window.TextRange.prototype.select) {
+        test('window.TextRange.prototype.select', function () {
+            window.checkStringRepresentation(window.TextRange.prototype.select, nativeMethods.select);
+        });
+    }
+});
 
 module('regression');
 

--- a/test/client/fixtures/sandbox/fetch-test.js
+++ b/test/client/fixtures/sandbox/fetch-test.js
@@ -530,6 +530,40 @@ if (window.fetch) {
         });
     });
 
+    module('wrappers of native functions should return the correct string representations', function () {
+        test('window.Request', function () {
+            window.checkStringRepresentation(window.Request, nativeMethods.Request);
+        });
+
+        test('window.fetch', function () {
+            window.checkStringRepresentation(window.fetch, nativeMethods.fetch);
+        });
+
+        test('window.Headers.prototype.entries', function () {
+            window.checkStringRepresentation(window.Headers.prototype.entries, nativeMethods.headersEntries);
+        });
+
+        test('window.Headers.prototype.values', function () {
+            window.checkStringRepresentation(window.Headers.prototype.values, nativeMethods.headersValues);
+        });
+
+        test('window.Headers.prototype.forEach', function () {
+            window.checkStringRepresentation(window.Headers.prototype.forEach, nativeMethods.headersForEach);
+        });
+
+        test('window.Headers.prototype.get', function () {
+            window.checkStringRepresentation(window.Headers.prototype.get, nativeMethods.headersGet);
+        });
+
+        test('window.Headers.prototype.set', function () {
+            window.checkStringRepresentation(window.Headers.prototype.set, nativeMethods.headersSet);
+        });
+
+        test('window.Headers.prototype.has', function () {
+            window.checkStringRepresentation(window.Headers.prototype.has, nativeMethods.headersHas);
+        });
+    });
+
     module('regression', function () {
         test('should emulate native browser behavior for fetch requests that end with an error or non-success status code (GH-1397)', function () {
             var performRequest = function (fetchFn, url) {

--- a/test/client/fixtures/sandbox/fetch-test.js
+++ b/test/client/fixtures/sandbox/fetch-test.js
@@ -530,38 +530,21 @@ if (window.fetch) {
         });
     });
 
-    module('wrappers of native functions should return the correct string representations', function () {
-        test('window.Request', function () {
-            window.checkStringRepresentation(window.Request, nativeMethods.Request);
-        });
-
-        test('window.fetch', function () {
-            window.checkStringRepresentation(window.fetch, nativeMethods.fetch);
-        });
-
-        test('window.Headers.prototype.entries', function () {
-            window.checkStringRepresentation(window.Headers.prototype.entries, nativeMethods.headersEntries);
-        });
-
-        test('window.Headers.prototype.values', function () {
-            window.checkStringRepresentation(window.Headers.prototype.values, nativeMethods.headersValues);
-        });
-
-        test('window.Headers.prototype.forEach', function () {
-            window.checkStringRepresentation(window.Headers.prototype.forEach, nativeMethods.headersForEach);
-        });
-
-        test('window.Headers.prototype.get', function () {
-            window.checkStringRepresentation(window.Headers.prototype.get, nativeMethods.headersGet);
-        });
-
-        test('window.Headers.prototype.set', function () {
-            window.checkStringRepresentation(window.Headers.prototype.set, nativeMethods.headersSet);
-        });
-
-        test('window.Headers.prototype.has', function () {
-            window.checkStringRepresentation(window.Headers.prototype.has, nativeMethods.headersHas);
-        });
+    test('wrappers of native functions should return the correct string representations', function () {
+        window.checkStringRepresentation(window.Request, nativeMethods.Request, 'Request');
+        window.checkStringRepresentation(window.fetch, nativeMethods.fetch, 'fetch');
+        window.checkStringRepresentation(window.Headers.prototype.entries, nativeMethods.headersEntries,
+            'Headers.prototype.entries');
+        window.checkStringRepresentation(window.Headers.prototype.values, nativeMethods.headersValues,
+            'Headers.prototype.values');
+        window.checkStringRepresentation(window.Headers.prototype.forEach, nativeMethods.headersForEach,
+            'Headers.prototype.forEach');
+        window.checkStringRepresentation(window.Headers.prototype.get, nativeMethods.headersGet,
+            'Headers.prototype.get');
+        window.checkStringRepresentation(window.Headers.prototype.set, nativeMethods.headersSet,
+            'Headers.prototype.set');
+        window.checkStringRepresentation(window.Headers.prototype.has, nativeMethods.headersHas,
+            'Headers.prototype.has');
     });
 
     module('regression', function () {

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -1,4 +1,5 @@
 var settings = hammerhead.get('./settings');
+var propertyOverridingUtils = hammerhead.get('./utils/property-overriding');
 
 var iframeSandbox = hammerhead.sandbox.iframe;
 var cookieSandbox = hammerhead.sandbox.cookie;
@@ -143,13 +144,11 @@ test('native methods are properly initialized in an iframe without src (GH-279)'
             var iframeDocument         = iframe.contentDocument;
             var iframeWindow           = iframe.contentWindow;
             var iframeHammerhead       = iframeWindow['%hammerhead%'];
-            var nativeCreateElement    = iframeHammerhead.sandbox.nativeMethods.createElement.toString();
-            var nativeAppendChild      = iframeHammerhead.sandbox.nativeMethods.appendChild.toString();
-            var overridedCreateElement = iframeDocument.createElement.toString();
-            var overridedAppendChild   = iframeDocument.createElement('div').appendChild.toString();
+            var overridedCreateElement = iframeDocument.createElement;
+            var overridedAppendChild   = iframeDocument.createElement('div').appendChild;
 
-            ok(nativeCreateElement !== overridedCreateElement);
-            ok(nativeAppendChild !== overridedAppendChild);
+            ok(!propertyOverridingUtils.isNativeFunction(overridedCreateElement));
+            ok(!propertyOverridingUtils.isNativeFunction(overridedAppendChild));
 
             var nativeImage     = new iframeHammerhead.sandbox.nativeMethods.Image(10, 10);
             var overridedImage  = new iframeWindow.Image(10, 10);

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -1,5 +1,5 @@
-var settings = hammerhead.get('./settings');
-var propertyOverridingUtils = hammerhead.get('./utils/property-overriding');
+var settings   = hammerhead.get('./settings');
+var overriding = hammerhead.get('./utils/overriding');
 
 var iframeSandbox = hammerhead.sandbox.iframe;
 var cookieSandbox = hammerhead.sandbox.cookie;
@@ -141,14 +141,14 @@ test('the AMD module loader disturbs proxying an iframe without src (GH-127)', f
 test('native methods are properly initialized in an iframe without src (GH-279)', function () {
     return createTestIframe()
         .then(function (iframe) {
-            var iframeDocument         = iframe.contentDocument;
-            var iframeWindow           = iframe.contentWindow;
-            var iframeHammerhead       = iframeWindow['%hammerhead%'];
-            var overridedCreateElement = iframeDocument.createElement;
-            var overridedAppendChild   = iframeDocument.createElement('div').appendChild;
+            var iframeDocument          = iframe.contentDocument;
+            var iframeWindow            = iframe.contentWindow;
+            var iframeHammerhead        = iframeWindow['%hammerhead%'];
+            var overriddenCreateElement = iframeDocument.createElement;
+            var overriddenAppendChild   = iframeDocument.createElement('div').appendChild;
 
-            ok(!propertyOverridingUtils.isNativeFunction(overridedCreateElement));
-            ok(!propertyOverridingUtils.isNativeFunction(overridedAppendChild));
+            ok(!overriding.isNativeFunction(overriddenCreateElement));
+            ok(!overriding.isNativeFunction(overriddenAppendChild));
 
             var nativeImage     = new iframeHammerhead.sandbox.nativeMethods.Image(10, 10);
             var overridedImage  = new iframeWindow.Image(10, 10);

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -117,6 +117,32 @@ if (!browserUtils.isFirefox) {
     });
 }
 
+test('wrappers of native functions should return the correct string representations', function () {
+    window.checkStringRepresentation(window[nativeMethods.documentOpenPropOwnerName].prototype.open,
+        nativeMethods.documentOpen,
+        nativeMethods.documentOpenPropOwnerName + '.prototype.open');
+    window.checkStringRepresentation(window[nativeMethods.documentClosePropOwnerName].prototype.close,
+        nativeMethods.documentClose,
+        nativeMethods.documentClosePropOwnerName + '.prototype.close');
+    window.checkStringRepresentation(window[nativeMethods.documentWritePropOwnerName].prototype.write,
+        nativeMethods.documentWrite,
+        nativeMethods.documentWritePropOwnerName + '.prototype.write');
+    window.checkStringRepresentation(window[nativeMethods.documentWriteLnPropOwnerName].prototype.writeln,
+        nativeMethods.documentWriteLn,
+        nativeMethods.documentWriteLnPropOwnerName + '.prototype.writeln');
+    window.checkStringRepresentation(document.open, nativeMethods.documentOpen, 'document.open');
+    window.checkStringRepresentation(document.close, nativeMethods.documentClose, 'document.close');
+    window.checkStringRepresentation(document.write, nativeMethods.documentWrite, 'document.write');
+    window.checkStringRepresentation(document.writeln, nativeMethods.documentWriteLn, 'document.writeln');
+    window.checkStringRepresentation(window.Document.prototype.createElement, nativeMethods.createElement,
+        'Document.prototype.createElement');
+    window.checkStringRepresentation(window.Document.prototype.createElementNS, nativeMethods.createElementNS,
+        'Document.prototype.createElementNS');
+    window.checkStringRepresentation(window.Document.prototype.createDocumentFragment,
+        nativeMethods.createDocumentFragment,
+        'Document.prototype.createDocumentFragment');
+});
+
 module('querySelector, querySelectorAll (GH-340)');
 
 test('quote types in attribute selectors', function () {
@@ -673,52 +699,6 @@ test("SVG's <title> element (GH-2364)", function () {
     strictEqual(title.textContent, 'I am a circle');
 
     div.parentNode.removeChild(div);
-});
-
-module('wrappers of native functions should return the correct string representations', function () {
-    test('window.Document.prototype.open', function () {
-        window.checkStringRepresentation(window[nativeMethods.documentOpenPropOwnerName].prototype.open, nativeMethods.documentOpen);
-    });
-
-    test('window.Document.prototype.close', function () {
-        window.checkStringRepresentation(window[nativeMethods.documentClosePropOwnerName].prototype.close, nativeMethods.documentClose);
-    });
-
-    test('window.Document.prototype.write', function () {
-        window.checkStringRepresentation(window[nativeMethods.documentWritePropOwnerName].prototype.write, nativeMethods.documentWrite);
-    });
-
-    test('window.Document.prototype.writeln', function () {
-        window.checkStringRepresentation(window[nativeMethods.documentWriteLnPropOwnerName].prototype.writeln, nativeMethods.documentWriteLn);
-    });
-
-    test('open', function () {
-        window.checkStringRepresentation(document.open, nativeMethods.documentOpen);
-    });
-
-    test('close', function () {
-        window.checkStringRepresentation(document.close, nativeMethods.documentClose);
-    });
-
-    test('write', function () {
-        window.checkStringRepresentation(document.write, nativeMethods.documentWrite);
-    });
-
-    test('writeln', function () {
-        window.checkStringRepresentation(document.writeln, nativeMethods.documentWriteLn);
-    });
-
-    test('window.Document.prototype.createElement', function () {
-        window.checkStringRepresentation(window.Document.prototype.createElement, nativeMethods.createElement);
-    });
-
-    test('window.Document.prototype.createElementNS', function () {
-        window.checkStringRepresentation(window.Document.prototype.createElementNS, nativeMethods.createElementNS);
-    });
-
-    test('window.Document.prototype.createDocumentFragment', function () {
-        window.checkStringRepresentation(window.Document.prototype.createDocumentFragment, nativeMethods.createDocumentFragment);
-    });
 });
 
 module('regression');

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -3,7 +3,7 @@ var SHADOW_UI_CLASSNAME     = hammerhead.get('../shadow-ui/class-name');
 var INTERNAL_PROPS          = hammerhead.get('../processing/dom/internal-properties');
 var urlUtils                = hammerhead.get('./utils/url');
 var destLocation            = hammerhead.get('./utils/destination-location');
-var propertyOverridingUtils = hammerhead.get('./utils/property-overriding');
+var overriding              = hammerhead.get('./utils/overriding');
 var settings                = hammerhead.get('./settings');
 
 var browserUtils  = hammerhead.utils.browser;
@@ -19,7 +19,7 @@ test('document.write for iframe.src with javascript protocol', function () {
     var $iframe = $('<iframe id="test4" src="javascript:&quot;<html><body><a id=\'link\' href=\'http://google.com/\'></body></html>&quot;"></iframe>"');
 
     $div[0].appendChild($iframe[0]);
-    ok(!propertyOverridingUtils.isNativeFunction($iframe[0].contentDocument.write), 'iframe.contentDocument.write should be overridden');
+    ok(!overriding.isNativeFunction($iframe[0].contentDocument.write), 'iframe.contentDocument.write should be overridden');
 
     $iframe.remove();
 });
@@ -36,7 +36,7 @@ asyncTest('document.write for iframe with empty url', function () {
         var document = $iframe[0].contentDocument;
 
         if (document)
-            ok(!propertyOverridingUtils.isNativeFunction(document.write), 'document.write should be overridden');
+            ok(!overriding.isNativeFunction(document.write), 'document.write should be overridden');
     };
 
     check();
@@ -72,7 +72,7 @@ if (!browserUtils.isFirefox) {
             var result   = true;
 
             if (document) {
-                if (propertyOverridingUtils.isNativeFunction(document.write))
+                if (overriding.isNativeFunction(document.write))
                     result = false;
             }
 

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -1,9 +1,10 @@
-var processScript       = hammerhead.get('../processing/script').processScript;
-var SHADOW_UI_CLASSNAME = hammerhead.get('../shadow-ui/class-name');
-var INTERNAL_PROPS      = hammerhead.get('../processing/dom/internal-properties');
-var urlUtils            = hammerhead.get('./utils/url');
-var destLocation        = hammerhead.get('./utils/destination-location');
-var settings            = hammerhead.get('./settings');
+var processScript           = hammerhead.get('../processing/script').processScript;
+var SHADOW_UI_CLASSNAME     = hammerhead.get('../shadow-ui/class-name');
+var INTERNAL_PROPS          = hammerhead.get('../processing/dom/internal-properties');
+var urlUtils                = hammerhead.get('./utils/url');
+var destLocation            = hammerhead.get('./utils/destination-location');
+var propertyOverridingUtils = hammerhead.get('./utils/property-overriding');
+var settings                = hammerhead.get('./settings');
 
 var browserUtils  = hammerhead.utils.browser;
 var nativeMethods = hammerhead.nativeMethods;
@@ -18,7 +19,7 @@ test('document.write for iframe.src with javascript protocol', function () {
     var $iframe = $('<iframe id="test4" src="javascript:&quot;<html><body><a id=\'link\' href=\'http://google.com/\'></body></html>&quot;"></iframe>"');
 
     $div[0].appendChild($iframe[0]);
-    ok($iframe[0].contentDocument.write.toString() !== nativeMethods.documentWrite.toString());
+    ok(!propertyOverridingUtils.isNativeFunction($iframe[0].contentDocument.write), 'iframe.contentDocument.write should be overridden');
 
     $iframe.remove();
 });
@@ -35,7 +36,7 @@ asyncTest('document.write for iframe with empty url', function () {
         var document = $iframe[0].contentDocument;
 
         if (document)
-            ok(document.write.toString() !== nativeMethods.documentWrite.toString());
+            ok(!propertyOverridingUtils.isNativeFunction(document.write), 'document.write should be overridden');
     };
 
     check();
@@ -71,7 +72,7 @@ if (!browserUtils.isFirefox) {
             var result   = true;
 
             if (document) {
-                if (document.write.toString() === nativeMethods.documentWrite.toString())
+                if (propertyOverridingUtils.isNativeFunction(document.write))
                     result = false;
             }
 
@@ -672,6 +673,52 @@ test("SVG's <title> element (GH-2364)", function () {
     strictEqual(title.textContent, 'I am a circle');
 
     div.parentNode.removeChild(div);
+});
+
+module('wrappers of native functions should return the correct string representations', function () {
+    test('window.Document.prototype.open', function () {
+        window.checkStringRepresentation(window[nativeMethods.documentOpenPropOwnerName].prototype.open, nativeMethods.documentOpen);
+    });
+
+    test('window.Document.prototype.close', function () {
+        window.checkStringRepresentation(window[nativeMethods.documentClosePropOwnerName].prototype.close, nativeMethods.documentClose);
+    });
+
+    test('window.Document.prototype.write', function () {
+        window.checkStringRepresentation(window[nativeMethods.documentWritePropOwnerName].prototype.write, nativeMethods.documentWrite);
+    });
+
+    test('window.Document.prototype.writeln', function () {
+        window.checkStringRepresentation(window[nativeMethods.documentWriteLnPropOwnerName].prototype.writeln, nativeMethods.documentWriteLn);
+    });
+
+    test('open', function () {
+        window.checkStringRepresentation(document.open, nativeMethods.documentOpen);
+    });
+
+    test('close', function () {
+        window.checkStringRepresentation(document.close, nativeMethods.documentClose);
+    });
+
+    test('write', function () {
+        window.checkStringRepresentation(document.write, nativeMethods.documentWrite);
+    });
+
+    test('writeln', function () {
+        window.checkStringRepresentation(document.writeln, nativeMethods.documentWriteLn);
+    });
+
+    test('window.Document.prototype.createElement', function () {
+        window.checkStringRepresentation(window.Document.prototype.createElement, nativeMethods.createElement);
+    });
+
+    test('window.Document.prototype.createElementNS', function () {
+        window.checkStringRepresentation(window.Document.prototype.createElementNS, nativeMethods.createElementNS);
+    });
+
+    test('window.Document.prototype.createDocumentFragment', function () {
+        window.checkStringRepresentation(window.Document.prototype.createDocumentFragment, nativeMethods.createDocumentFragment);
+    });
 });
 
 module('regression');

--- a/test/client/fixtures/sandbox/node/element-test.js
+++ b/test/client/fixtures/sandbox/node/element-test.js
@@ -70,135 +70,81 @@ test('prevent form submit', function () {
     strictEqual(submitPrevented, true);
 });
 
-module('wrappers of native functions should return the correct string representations', function () {
-    test('Element.prototype.setAttribute', function () {
-        window.checkStringRepresentation(window.Element.prototype.setAttribute, nativeMethods.setAttribute);
-    });
-
-    test('Element.prototype.setAttributeNS', function () {
-        window.checkStringRepresentation(window.Element.prototype.setAttributeNS, nativeMethods.setAttributeNS);
-    });
-
-    test('Element.prototype.getAttribute', function () {
-        window.checkStringRepresentation(window.Element.prototype.getAttribute, nativeMethods.getAttribute);
-    });
-
-    test('Element.prototype.getAttributeNS', function () {
-        window.checkStringRepresentation(window.Element.prototype.getAttributeNS, nativeMethods.getAttributeNS);
-    });
-
-    test('Element.prototype.removeAttribute', function () {
-        window.checkStringRepresentation(window.Element.prototype.removeAttribute, nativeMethods.removeAttribute);
-    });
-
-    test('Element.prototype.removeAttributeNS', function () {
-        window.checkStringRepresentation(window.Element.prototype.removeAttributeNS, nativeMethods.removeAttributeNS);
-    });
-
-    test('Element.prototype.cloneNode', function () {
-        window.checkStringRepresentation(window.Element.prototype.cloneNode, nativeMethods.cloneNode);
-    });
-
-    test('Element.prototype.querySelector', function () {
-        window.checkStringRepresentation(window.Element.prototype.querySelector, nativeMethods.elementQuerySelector);
-    });
-
-    test('Element.prototype.querySelectorAll', function () {
-        window.checkStringRepresentation(window.Element.prototype.querySelectorAll, nativeMethods.elementQuerySelectorAll);
-    });
-
-    test('Element.prototype.hasAttribute', function () {
-        window.checkStringRepresentation(window.Element.prototype.hasAttribute, nativeMethods.hasAttribute);
-    });
-
-    test('Element.prototype.hasAttributeNS', function () {
-        window.checkStringRepresentation(window.Element.prototype.hasAttributeNS, nativeMethods.hasAttributeNS);
-    });
-
-    test('Element.prototype.hasAttributes', function () {
-        window.checkStringRepresentation(window.Element.prototype.hasAttributes, nativeMethods.hasAttributes);
-    });
-
-    test('Node.prototype.cloneNode', function () {
-        window.checkStringRepresentation(window.Node.prototype.cloneNode, nativeMethods.cloneNode);
-    });
-
-    test('Node.prototype.appendChild', function () {
-        window.checkStringRepresentation(window.Node.prototype.appendChild, nativeMethods.appendChild);
-    });
-
-    test('Node.prototype.removeChild', function () {
-        window.checkStringRepresentation(window.Node.prototype.removeChild, nativeMethods.removeChild);
-    });
-
-    test('Node.prototype.insertBefore', function () {
-        window.checkStringRepresentation(window.Node.prototype.insertBefore, nativeMethods.insertBefore);
-    });
-
-    test('Node.prototype.replaceChild', function () {
-        window.checkStringRepresentation(window.Node.prototype.replaceChild, nativeMethods.replaceChild);
-    });
-
-    test('DocumentFragment.prototype.querySelector', function () {
-        window.checkStringRepresentation(window.DocumentFragment.prototype.querySelector, nativeMethods.documentFragmentQuerySelector);
-    });
-
-    test('DocumentFragment.prototype.querySelectorAll', function () {
-        window.checkStringRepresentation(window.DocumentFragment.prototype.querySelectorAll, nativeMethods.documentFragmentQuerySelectorAll);
-    });
-
-    test('HTMLTableElement.prototype.insertRow', function () {
-        window.checkStringRepresentation(window.HTMLTableElement.prototype.insertRow, nativeMethods.insertTableRow);
-    });
-
-    test('HTMLTableSectionElement.prototype.insertRow', function () {
-        window.checkStringRepresentation(window.HTMLTableSectionElement.prototype.insertRow, nativeMethods.insertTableRow);
-    });
-
-    test('HTMLTableRowElement.prototype.insertCell', function () {
-        window.checkStringRepresentation(window.HTMLTableRowElement.prototype.insertCell, nativeMethods.insertCell);
-    });
-
-    test('HTMLFormElement.prototype.submit', function () {
-        window.checkStringRepresentation(window.HTMLFormElement.prototype.submit, nativeMethods.formSubmit);
-    });
-
-    test('HTMLAnchorElement.prototype.toString', function () {
-        window.checkStringRepresentation(window.HTMLAnchorElement.prototype.toString, nativeMethods.anchorToString);
-    });
-
-    test('CharacterData.prototype.appendData', function () {
-        window.checkStringRepresentation(window.CharacterData.prototype.appendData, nativeMethods.appendData);
-    });
+test('wrappers of native functions should return the correct string representations', function () {
+    window.checkStringRepresentation(window.Element.prototype.setAttribute, nativeMethods.setAttribute,
+        'Element.prototype.setAttribute');
+    window.checkStringRepresentation(window.Element.prototype.setAttributeNS, nativeMethods.setAttributeNS,
+        'Element.prototype.setAttributeNS');
+    window.checkStringRepresentation(window.Element.prototype.getAttribute, nativeMethods.getAttribute,
+        'Element.prototype.getAttribute');
+    window.checkStringRepresentation(window.Element.prototype.getAttributeNS, nativeMethods.getAttributeNS,
+        'Element.prototype.getAttributeNS');
+    window.checkStringRepresentation(window.Element.prototype.removeAttribute, nativeMethods.removeAttribute,
+        'Element.prototype.removeAttribute');
+    window.checkStringRepresentation(window.Element.prototype.removeAttributeNS, nativeMethods.removeAttributeNS,
+        'Element.prototype.removeAttributeNS');
+    window.checkStringRepresentation(window.Element.prototype.cloneNode, nativeMethods.cloneNode,
+        'Element.prototype.cloneNode');
+    window.checkStringRepresentation(window.Element.prototype.querySelector, nativeMethods.elementQuerySelector,
+        'Element.prototype.querySelector');
+    window.checkStringRepresentation(window.Element.prototype.querySelectorAll, nativeMethods.elementQuerySelectorAll,
+        'Element.prototype.querySelectorAll');
+    window.checkStringRepresentation(window.Element.prototype.hasAttribute, nativeMethods.hasAttribute,
+        'Element.prototype.hasAttribute');
+    window.checkStringRepresentation(window.Element.prototype.hasAttributeNS, nativeMethods.hasAttributeNS,
+        'Element.prototype.hasAttributeNS');
+    window.checkStringRepresentation(window.Element.prototype.hasAttributes, nativeMethods.hasAttributes,
+        'Element.prototype.hasAttributes');
+    window.checkStringRepresentation(window.Node.prototype.cloneNode, nativeMethods.cloneNode,
+        'Node.prototype.cloneNode');
+    window.checkStringRepresentation(window.Node.prototype.appendChild, nativeMethods.appendChild,
+        'Node.prototype.appendChild');
+    window.checkStringRepresentation(window.Node.prototype.removeChild, nativeMethods.removeChild,
+        'Node.prototype.removeChild');
+    window.checkStringRepresentation(window.Node.prototype.insertBefore, nativeMethods.insertBefore,
+        'Node.prototype.insertBefore');
+    window.checkStringRepresentation(window.Node.prototype.replaceChild, nativeMethods.replaceChild,
+        'Node.prototype.replaceChild');
+    window.checkStringRepresentation(window.DocumentFragment.prototype.querySelector,
+        nativeMethods.documentFragmentQuerySelector,
+        'DocumentFragment.prototype.querySelector');
+    window.checkStringRepresentation(window.DocumentFragment.prototype.querySelectorAll,
+        nativeMethods.documentFragmentQuerySelectorAll,
+        'DocumentFragment.prototype.querySelectorAll');
+    window.checkStringRepresentation(window.HTMLTableElement.prototype.insertRow, nativeMethods.insertTableRow,
+        'HTMLTableElement.prototype.insertRow');
+    window.checkStringRepresentation(window.HTMLTableSectionElement.prototype.insertRow, nativeMethods.insertTableRow,
+        'HTMLTableSectionElement.prototype.insertRow');
+    window.checkStringRepresentation(window.HTMLTableRowElement.prototype.insertCell, nativeMethods.insertCell,
+        'HTMLTableRowElement.prototype.insertCell');
+    window.checkStringRepresentation(window.HTMLFormElement.prototype.submit, nativeMethods.formSubmit,
+        'HTMLFormElement.prototype.submit');
+    window.checkStringRepresentation(window.HTMLAnchorElement.prototype.toString, nativeMethods.anchorToString,
+        'HTMLAnchorElement.prototype.toString');
+    window.checkStringRepresentation(window.CharacterData.prototype.appendData, nativeMethods.appendData,
+        'CharacterData.prototype.appendData');
 
     if (window.Document.prototype.registerElement) {
-        test('Document.prototype.registerElement', function () {
-            window.checkStringRepresentation(window.Document.prototype.registerElement, nativeMethods.registerElement);
-        });
+        window.checkStringRepresentation(window.Document.prototype.registerElement, nativeMethods.registerElement,
+            'Document.prototype.registerElement');
     }
 
     if (window.Element.prototype.insertAdjacentHTML) {
-        test('Element.prototype.insertAdjacentHTML', function () {
-            window.checkStringRepresentation(window.Element.prototype.insertAdjacentHTML, nativeMethods.insertAdjacentHTML);
-        });
+        window.checkStringRepresentation(window.Element.prototype.insertAdjacentHTML, nativeMethods.insertAdjacentHTML,
+            'Element.prototype.insertAdjacentHTML');
     }
     else if (HTMLElement.prototype.insertAdjacentHTML) {
-        test('HTMLElement.prototype.insertAdjacentHTML', function () {
-            window.checkStringRepresentation(window.HTMLElement.prototype.insertAdjacentHTML, nativeMethods.insertAdjacentHTML);
-        });
+        window.checkStringRepresentation(window.HTMLElement.prototype.insertAdjacentHTML,
+            nativeMethods.insertAdjacentHTML,
+            'HTMLElement.prototype.insertAdjacentHTML');
     }
 
-    test('element.addEventListener', function () {
-        const someElement = document.createElement('div');
+    const someElement = document.createElement('div');
 
-        window.checkStringRepresentation(someElement.addEventListener, nativeMethods.addEventListener);
-    });
-
-    test('element.removeEventListener', function () {
-        const someElement = document.createElement('div');
-
-        window.checkStringRepresentation(someElement.removeEventListener, nativeMethods.removeEventListener);
-    });
+    window.checkStringRepresentation(someElement.addEventListener, nativeMethods.addEventListener,
+        'element.addEventListener');
+    window.checkStringRepresentation(someElement.removeEventListener, nativeMethods.removeEventListener,
+        'element.removeEventListener');
 });
 
 module('regression');

--- a/test/client/fixtures/sandbox/node/element-test.js
+++ b/test/client/fixtures/sandbox/node/element-test.js
@@ -70,6 +70,125 @@ test('prevent form submit', function () {
     strictEqual(submitPrevented, true);
 });
 
+module('wrappers of native functions should return the correct string representations', function () {
+    test('Element.prototype.setAttribute', function () {
+        window.checkStringRepresentation(window.Element.prototype.setAttribute, nativeMethods.setAttribute);
+    });
+
+    test('Element.prototype.setAttributeNS', function () {
+        window.checkStringRepresentation(window.Element.prototype.setAttributeNS, nativeMethods.setAttributeNS);
+    });
+
+    test('Element.prototype.getAttribute', function () {
+        window.checkStringRepresentation(window.Element.prototype.getAttribute, nativeMethods.getAttribute);
+    });
+
+    test('Element.prototype.getAttributeNS', function () {
+        window.checkStringRepresentation(window.Element.prototype.getAttributeNS, nativeMethods.getAttributeNS);
+    });
+
+    test('Element.prototype.removeAttribute', function () {
+        window.checkStringRepresentation(window.Element.prototype.removeAttribute, nativeMethods.removeAttribute);
+    });
+
+    test('Element.prototype.removeAttributeNS', function () {
+        window.checkStringRepresentation(window.Element.prototype.removeAttributeNS, nativeMethods.removeAttributeNS);
+    });
+
+    test('Element.prototype.cloneNode', function () {
+        window.checkStringRepresentation(window.Element.prototype.cloneNode, nativeMethods.cloneNode);
+    });
+
+    test('Element.prototype.querySelector', function () {
+        window.checkStringRepresentation(window.Element.prototype.querySelector, nativeMethods.elementQuerySelector);
+    });
+
+    test('Element.prototype.querySelectorAll', function () {
+        window.checkStringRepresentation(window.Element.prototype.querySelectorAll, nativeMethods.elementQuerySelectorAll);
+    });
+
+    test('Element.prototype.hasAttribute', function () {
+        window.checkStringRepresentation(window.Element.prototype.hasAttribute, nativeMethods.hasAttribute);
+    });
+
+    test('Element.prototype.hasAttributeNS', function () {
+        window.checkStringRepresentation(window.Element.prototype.hasAttributeNS, nativeMethods.hasAttributeNS);
+    });
+
+    test('Element.prototype.hasAttributes', function () {
+        window.checkStringRepresentation(window.Element.prototype.hasAttributes, nativeMethods.hasAttributes);
+    });
+
+    test('Node.prototype.cloneNode', function () {
+        window.checkStringRepresentation(window.Node.prototype.cloneNode, nativeMethods.cloneNode);
+    });
+
+    test('Node.prototype.appendChild', function () {
+        window.checkStringRepresentation(window.Node.prototype.appendChild, nativeMethods.appendChild);
+    });
+
+    test('Node.prototype.removeChild', function () {
+        window.checkStringRepresentation(window.Node.prototype.removeChild, nativeMethods.removeChild);
+    });
+
+    test('Node.prototype.insertBefore', function () {
+        window.checkStringRepresentation(window.Node.prototype.insertBefore, nativeMethods.insertBefore);
+    });
+
+    test('Node.prototype.replaceChild', function () {
+        window.checkStringRepresentation(window.Node.prototype.replaceChild, nativeMethods.replaceChild);
+    });
+
+    test('DocumentFragment.prototype.querySelector', function () {
+        window.checkStringRepresentation(window.DocumentFragment.prototype.querySelector, nativeMethods.documentFragmentQuerySelector);
+    });
+
+    test('DocumentFragment.prototype.querySelectorAll', function () {
+        window.checkStringRepresentation(window.DocumentFragment.prototype.querySelectorAll, nativeMethods.documentFragmentQuerySelectorAll);
+    });
+
+    test('HTMLTableElement.prototype.insertRow', function () {
+        window.checkStringRepresentation(window.HTMLTableElement.prototype.insertRow, nativeMethods.insertTableRow);
+    });
+
+    test('HTMLTableSectionElement.prototype.insertRow', function () {
+        window.checkStringRepresentation(window.HTMLTableSectionElement.prototype.insertRow, nativeMethods.insertTableRow);
+    });
+
+    test('HTMLTableRowElement.prototype.insertCell', function () {
+        window.checkStringRepresentation(window.HTMLTableRowElement.prototype.insertCell, nativeMethods.insertCell);
+    });
+
+    test('HTMLFormElement.prototype.submit', function () {
+        window.checkStringRepresentation(window.HTMLFormElement.prototype.submit, nativeMethods.formSubmit);
+    });
+
+    test('HTMLAnchorElement.prototype.toString', function () {
+        window.checkStringRepresentation(window.HTMLAnchorElement.prototype.toString, nativeMethods.anchorToString);
+    });
+
+    test('CharacterData.prototype.appendData', function () {
+        window.checkStringRepresentation(window.CharacterData.prototype.appendData, nativeMethods.appendData);
+    });
+
+    if (window.Document.prototype.registerElement) {
+        test('Document.prototype.registerElement', function () {
+            window.checkStringRepresentation(window.Document.prototype.registerElement, nativeMethods.registerElement);
+        });
+    }
+
+    if (window.Element.prototype.insertAdjacentHTML) {
+        test('Element.prototype.insertAdjacentHTML', function () {
+            window.checkStringRepresentation(window.Element.prototype.insertAdjacentHTML, nativeMethods.insertAdjacentHTML);
+        });
+    }
+    else if (HTMLElement.prototype.insertAdjacentHTML) {
+        test('HTMLElement.prototype.insertAdjacentHTML', function () {
+            window.checkStringRepresentation(window.HTMLElement.prototype.insertAdjacentHTML, nativeMethods.insertAdjacentHTML);
+        });
+    }
+});
+
 module('regression');
 
 test('a document fragment should correctly process when it is appending to iframe (GH-912)', function () {

--- a/test/client/fixtures/sandbox/node/element-test.js
+++ b/test/client/fixtures/sandbox/node/element-test.js
@@ -187,6 +187,18 @@ module('wrappers of native functions should return the correct string representa
             window.checkStringRepresentation(window.HTMLElement.prototype.insertAdjacentHTML, nativeMethods.insertAdjacentHTML);
         });
     }
+
+    test('element.addEventListener', function () {
+        const someElement = document.createElement('div');
+
+        window.checkStringRepresentation(someElement.addEventListener, nativeMethods.addEventListener);
+    });
+
+    test('element.removeEventListener', function () {
+        const someElement = document.createElement('div');
+
+        window.checkStringRepresentation(someElement.removeEventListener, nativeMethods.removeEventListener);
+    });
 });
 
 module('regression');

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -480,6 +480,18 @@ if (nativeMethods.windowOriginGetter) {
     });
 }
 
+module('wrappers of native functions should have correct string representations');
+
+test('addEventListener string representation should be correct', function () {
+    strictEqual(window.addEventListener.toString(), nativeMethods.addEventListener.toString());
+    strictEqual(Function.prototype.toString.call(window.addEventListener), nativeMethods.addEventListener.toString());
+});
+
+test('removeEventListener string representation should be correct', function () {
+    strictEqual(window.removeEventListener.toString(), nativeMethods.removeEventListener.toString());
+    strictEqual(Function.prototype.toString.call(window.removeEventListener), nativeMethods.removeEventListener.toString());
+});
+
 module('regression');
 
 if (window.navigator.sendBeacon) {

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -573,11 +573,13 @@ module('wrappers of native functions should return the correct string representa
         });
     }
     else {
-        test('addEventListener', function () {
+        // // NOTE: it's temporarily
+        QUnit.skip('addEventListener', function () {
             window.checkStringRepresentation(window.addEventListener, nativeMethods.windowAddEventListener);
         });
 
-        test('removeEventListener', function () {
+        // NOTE: it's temporarily
+        QUnit.skip('removeEventListener', function () {
             window.checkStringRepresentation(window.removeEventListener, nativeMethods.windowRemoveEventListener);
         });
     }

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -480,16 +480,191 @@ if (nativeMethods.windowOriginGetter) {
     });
 }
 
-module('wrappers of native functions should have correct string representations');
+module('wrappers of native functions should have correct string representations', function () {
+    function checkStringRepresentation (wrappedFn, originalFn) {
+        strictEqual(wrappedFn.toString(), originalFn.toString());
+        strictEqual(Function.prototype.toString.call(wrappedFn), originalFn.toString());
+    }
 
-test('addEventListener string representation should be correct', function () {
-    strictEqual(window.addEventListener.toString(), nativeMethods.addEventListener.toString());
-    strictEqual(Function.prototype.toString.call(window.addEventListener), nativeMethods.addEventListener.toString());
-});
+    test('CanvasRenderingContext2D.prototype.drawImage', function () {
+        checkStringRepresentation(window.CanvasRenderingContext2D.prototype.drawImage, nativeMethods.canvasContextDrawImage);
+    });
 
-test('removeEventListener string representation should be correct', function () {
-    strictEqual(window.removeEventListener.toString(), nativeMethods.removeEventListener.toString());
-    strictEqual(Function.prototype.toString.call(window.removeEventListener), nativeMethods.removeEventListener.toString());
+    if (window.Object.assign) {
+        test('Object.assign', function () {
+            checkStringRepresentation(window.Object.assign, nativeMethods.objectAssign);
+        });
+    }
+
+    test('open', function () {
+        checkStringRepresentation(window.open, nativeMethods.windowOpen);
+    });
+
+    if (window.FontFace) {
+        test('FontFace', function () {
+            checkStringRepresentation(window.FontFace, nativeMethods.FontFace);
+        });
+    }
+
+    if (window.Worker) {
+        test('Worker', function () {
+            checkStringRepresentation(window.Worker, nativeMethods.Worker);
+        });
+    }
+
+    if (window.Blob) {
+        test('Blob', function () {
+            checkStringRepresentation(window.Blob, nativeMethods.Blob);
+        });
+    }
+
+    // NOTE: File in IE11 is not constructable.
+    if (window.File && typeof window.File === 'function') {
+        test('File', function () {
+            checkStringRepresentation(window.File, nativeMethods.File);
+        });
+    }
+
+    if (window.EventSource) {
+        test('EventSource', function () {
+            checkStringRepresentation(window.EventSource, nativeMethods.EventSource);
+        });
+    }
+
+    if (window.MutationObserver) {
+        test('MutationObserver', function () {
+            checkStringRepresentation(window.MutationObserver, nativeMethods.MutationObserver);
+        });
+    }
+
+    if (window.WebKitMutationObserver) {
+        test('WebKitMutationObserver', function () {
+            checkStringRepresentation(window.WebKitMutationObserver, nativeMethods.MutationObserver);
+        });
+    }
+
+    if (window.Proxy) {
+        test('Proxy', function () {
+            checkStringRepresentation(window.Proxy, nativeMethods.Proxy);
+        });
+    }
+
+    if (window.registerServiceWorker) {
+        test('registerServiceWorker', function () {
+            checkStringRepresentation(window.registerServiceWorker, nativeMethods.registerServiceWorker);
+        });
+    }
+
+    if (window.getRegistrationServiceWorker) {
+        test('getRegistrationServiceWorker', function () {
+            checkStringRepresentation(window.getRegistrationServiceWorker, nativeMethods.getRegistrationServiceWorker);
+        });
+    }
+
+    if (window.Range.prototype.createContextualFragment) {
+        test('Range.prototype.createContextualFragment', function () {
+            checkStringRepresentation(window.Range.prototype.createContextualFragment, nativeMethods.createContextualFragment);
+        });
+    }
+
+    if (window.EventTarget) {
+        test('addEventListener', function () {
+            checkStringRepresentation(window.EventTarget.prototype.addEventListener, nativeMethods.windowAddEventListener);
+        });
+
+        test('removeEventListener', function () {
+            checkStringRepresentation(window.EventTarget.prototype.removeEventListener, nativeMethods.windowRemoveEventListener);
+        });
+    }
+    else {
+        test('addEventListener', function () {
+            checkStringRepresentation(window.addEventListener, nativeMethods.windowAddEventListener);
+        });
+
+        test('removeEventListener', function () {
+            checkStringRepresentation(window.removeEventListener, nativeMethods.windowRemoveEventListener);
+        });
+    }
+
+    if (window.Image) {
+        test('Image', function () {
+            checkStringRepresentation(window.Image, nativeMethods.Image);
+        });
+    }
+
+    test('Function', function () {
+        checkStringRepresentation(window.Function, nativeMethods.Function);
+    });
+
+    if (typeof window.history.pushState === 'function' && typeof window.history.replaceState === 'function') {
+        test('history.pushState', function () {
+            checkStringRepresentation(window.history.pushState, nativeMethods.historyPushState);
+        });
+
+        test('history.replaceState', function () {
+            checkStringRepresentation(window.history.replaceState, nativeMethods.historyReplaceState);
+        });
+    }
+
+    if (window.navigator.sendBeacon) {
+        test('navigator.sendBeacon', function () {
+            checkStringRepresentation(window.navigator.sendBeacon, nativeMethods.sendBeacon);
+        });
+    }
+
+    if (window.navigator.registerProtocolHandler) {
+        test('navigator.registerProtocolHandler', function () {
+            checkStringRepresentation(window.navigator.registerProtocolHandler, nativeMethods.registerProtocolHandler);
+        });
+    }
+
+    if (window.FormData) {
+        test('FormData.prototype.append', function () {
+            checkStringRepresentation(window.FormData.prototype.append, nativeMethods.formDataAppend);
+        });
+    }
+
+    if (window.WebSocket) {
+        test('WebSocket', function () {
+            checkStringRepresentation(window.WebSocket, nativeMethods.WebSocket);
+        });
+    }
+
+    if (window.DOMParser) {
+        test('DOMParser.prototype.parseFromString', function () {
+            checkStringRepresentation(window.DOMParser.prototype.parseFromString, nativeMethods.DOMParserParseFromString);
+        });
+    }
+
+    if (window.DOMTokenList) {
+        test('DOMTokenList.prototype.add', function () {
+            checkStringRepresentation(window.DOMTokenList.prototype.add, nativeMethods.tokenListAdd);
+        });
+
+        test('DOMTokenList.prototype.remove', function () {
+            checkStringRepresentation(window.DOMTokenList.prototype.remove, nativeMethods.tokenListRemove);
+        });
+
+        test('DOMTokenList.prototype.toggle', function () {
+            checkStringRepresentation(window.DOMTokenList.prototype.toggle, nativeMethods.tokenListToggle);
+        });
+
+        if (window.DOMTokenList.prototype.replace) {
+            test('DOMTokenList.prototype.replace', function () {
+                checkStringRepresentation(window.DOMTokenList.prototype.replace, nativeMethods.tokenListReplace);
+            });
+        }
+
+        if (window.DOMTokenList.prototype.supports) {
+            test('DOMTokenList.prototype.supports', function () {
+                checkStringRepresentation(window.DOMTokenList.prototype.supports, nativeMethods.tokenListSupports);
+            });
+        }
+    }
+
+    test('DOMImplementation.prototype.createHTMLDocument', function () {
+        checkStringRepresentation(window.DOMImplementation.prototype.createHTMLDocument, nativeMethods.createHTMLDocument);
+    });
 });
 
 module('regression');

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -27,6 +27,139 @@ test('window.onerror setter/getter', function () {
     window.onerror = storedOnErrorHandler;
 });
 
+test('wrappers of native functions should return the correct string representations', function () {
+    window.checkStringRepresentation(window.CanvasRenderingContext2D.prototype.drawImage,
+        nativeMethods.canvasContextDrawImage,
+        'CanvasRenderingContext2D.prototype.drawImage');
+
+    if (window.Object.assign)
+        window.checkStringRepresentation(window.Object.assign, nativeMethods.objectAssign, 'Object.assign');
+
+    window.checkStringRepresentation(window.open, nativeMethods.windowOpen, 'open');
+
+    if (window.FontFace)
+        window.checkStringRepresentation(window.FontFace, nativeMethods.FontFace, 'FontFace');
+
+    if (window.Worker) {
+        window.checkStringRepresentation(window.Worker, nativeMethods.Worker, 'Worker');
+        window.checkStringRepresentation(window.Worker.prototype.constructor, nativeMethods.Worker,
+            'Worker.prototype.constructor');
+    }
+
+    if (window.Blob)
+        window.checkStringRepresentation(window.Blob, nativeMethods.Blob, 'Blob');
+
+    // NOTE: File in IE11 is not constructable.
+    if (window.File && typeof window.File === 'function')
+        window.checkStringRepresentation(window.File, nativeMethods.File, 'File');
+
+    if (window.EventSource)
+        window.checkStringRepresentation(window.EventSource, nativeMethods.EventSource, 'EventSource');
+
+    if (window.MutationObserver)
+        window.checkStringRepresentation(window.MutationObserver, nativeMethods.MutationObserver, 'MutationObserver');
+
+    if (window.WebKitMutationObserver) {
+        window.checkStringRepresentation(window.WebKitMutationObserver, nativeMethods.MutationObserver,
+            'WebKitMutationObserver');
+    }
+
+    if (window.Proxy)
+        window.checkStringRepresentation(window.Proxy, nativeMethods.Proxy, 'Proxy');
+
+    if (window.registerServiceWorker) {
+        window.checkStringRepresentation(window.registerServiceWorker, nativeMethods.registerServiceWorker,
+            'registerServiceWorker');
+    }
+
+    if (window.getRegistrationServiceWorker) {
+        window.checkStringRepresentation(window.getRegistrationServiceWorker,
+            nativeMethods.getRegistrationServiceWorker,
+            'getRegistrationServiceWorker');
+    }
+
+    if (window.Range.prototype.createContextualFragment) {
+        window.checkStringRepresentation(window.Range.prototype.createContextualFragment,
+            nativeMethods.createContextualFragment,
+            'Range.prototype.createContextualFragment');
+    }
+
+    if (window.EventTarget) {
+        window.checkStringRepresentation(window.EventTarget.prototype.addEventListener,
+            nativeMethods.windowAddEventListener,
+            'EventTarget.prototype.addEventListener');
+        window.checkStringRepresentation(window.EventTarget.prototype.removeEventListener,
+            nativeMethods.windowRemoveEventListener,
+            'EventTarget.prototype.removeEventListener');
+    }
+    else {
+        window.checkStringRepresentation(window.addEventListener, nativeMethods.windowAddEventListener,
+            'addEventListener');
+        window.checkStringRepresentation(window.removeEventListener, nativeMethods.windowRemoveEventListener,
+            'removeEventListener');
+    }
+
+    if (window.Image)
+        window.checkStringRepresentation(window.Image, nativeMethods.Image, 'Image');
+
+    window.checkStringRepresentation(window.Function, nativeMethods.Function, 'Function');
+    window.checkStringRepresentation(window.Function.prototype.constructor, nativeMethods.Function,
+        'Function.prototype.constructor');
+
+    if (typeof window.history.pushState === 'function' && typeof window.history.replaceState === 'function') {
+        window.checkStringRepresentation(window.history.pushState, nativeMethods.historyPushState,
+            'history.pushState');
+        window.checkStringRepresentation(window.history.replaceState, nativeMethods.historyReplaceState,
+            'history.replaceState');
+    }
+
+    if (window.navigator.sendBeacon)
+        window.checkStringRepresentation(window.navigator.sendBeacon, nativeMethods.sendBeacon);
+
+    if (window.navigator.registerProtocolHandler) {
+        window.checkStringRepresentation(window.navigator.registerProtocolHandler,
+            nativeMethods.registerProtocolHandler,
+            'navigator.registerProtocolHandler');
+    }
+
+    if (window.FormData) {
+        window.checkStringRepresentation(window.FormData.prototype.append, nativeMethods.formDataAppend,
+            'FormData.prototype.append');
+    }
+
+    if (window.WebSocket)
+        window.checkStringRepresentation(window.WebSocket, nativeMethods.WebSocket, 'WebSocket');
+
+    if (window.DOMParser) {
+        window.checkStringRepresentation(window.DOMParser.prototype.parseFromString,
+            nativeMethods.DOMParserParseFromString,
+            'DOMParser.prototype.parseFromString');
+    }
+
+    if (window.DOMTokenList) {
+        window.checkStringRepresentation(window.DOMTokenList.prototype.add, nativeMethods.tokenListAdd,
+            'DOMTokenList.prototype.add');
+        window.checkStringRepresentation(window.DOMTokenList.prototype.remove, nativeMethods.tokenListRemove,
+            'DOMTokenList.prototype.remove');
+        window.checkStringRepresentation(window.DOMTokenList.prototype.toggle, nativeMethods.tokenListToggle,
+            'DOMTokenList.prototype.toggle');
+
+        if (window.DOMTokenList.prototype.replace) {
+            window.checkStringRepresentation(window.DOMTokenList.prototype.replace, nativeMethods.tokenListReplace,
+                'DOMTokenList.prototype.replace');
+        }
+
+        if (window.DOMTokenList.prototype.supports) {
+            window.checkStringRepresentation(window.DOMTokenList.prototype.supports, nativeMethods.tokenListSupports,
+                'DOMTokenList.prototype.supports');
+        }
+    }
+
+    window.checkStringRepresentation(window.DOMImplementation.prototype.createHTMLDocument,
+        nativeMethods.createHTMLDocument,
+        'DOMImplementation.prototype.createHTMLDocument');
+});
+
 if (nativeMethods.winOnUnhandledRejectionSetter) {
     module('unhandledrejection event (GH-1247)', function () {
         asyncTest('window.onunhandledrejection should be instrumented', function () {
@@ -479,190 +612,6 @@ if (nativeMethods.windowOriginGetter) {
         strictEqual(window.origin, 2);
     });
 }
-
-module('wrappers of native functions should return the correct string representations', function () {
-    test('CanvasRenderingContext2D.prototype.drawImage', function () {
-        window.checkStringRepresentation(window.CanvasRenderingContext2D.prototype.drawImage, nativeMethods.canvasContextDrawImage);
-    });
-
-    if (window.Object.assign) {
-        test('Object.assign', function () {
-            window.checkStringRepresentation(window.Object.assign, nativeMethods.objectAssign);
-        });
-    }
-
-    test('open', function () {
-        window.checkStringRepresentation(window.open, nativeMethods.windowOpen);
-    });
-
-    if (window.FontFace) {
-        test('FontFace', function () {
-            window.checkStringRepresentation(window.FontFace, nativeMethods.FontFace);
-        });
-    }
-
-    if (window.Worker) {
-        test('Worker', function () {
-            window.checkStringRepresentation(window.Worker, nativeMethods.Worker);
-            window.checkStringRepresentation(window.Worker.prototype.constructor, nativeMethods.Worker);
-        });
-    }
-
-    if (window.Blob) {
-        test('Blob', function () {
-            window.checkStringRepresentation(window.Blob, nativeMethods.Blob);
-        });
-    }
-
-    // NOTE: File in IE11 is not constructable.
-    if (window.File && typeof window.File === 'function') {
-        test('File', function () {
-            window.checkStringRepresentation(window.File, nativeMethods.File);
-        });
-    }
-
-    if (window.EventSource) {
-        test('EventSource', function () {
-            window.checkStringRepresentation(window.EventSource, nativeMethods.EventSource);
-        });
-    }
-
-    if (window.MutationObserver) {
-        test('MutationObserver', function () {
-            window.checkStringRepresentation(window.MutationObserver, nativeMethods.MutationObserver);
-        });
-    }
-
-    if (window.WebKitMutationObserver) {
-        test('WebKitMutationObserver', function () {
-            window.checkStringRepresentation(window.WebKitMutationObserver, nativeMethods.MutationObserver);
-        });
-    }
-
-    if (window.Proxy) {
-        test('Proxy', function () {
-            window.checkStringRepresentation(window.Proxy, nativeMethods.Proxy);
-        });
-    }
-
-    if (window.registerServiceWorker) {
-        test('registerServiceWorker', function () {
-            window.checkStringRepresentation(window.registerServiceWorker, nativeMethods.registerServiceWorker);
-        });
-    }
-
-    if (window.getRegistrationServiceWorker) {
-        test('getRegistrationServiceWorker', function () {
-            window.checkStringRepresentation(window.getRegistrationServiceWorker, nativeMethods.getRegistrationServiceWorker);
-        });
-    }
-
-    if (window.Range.prototype.createContextualFragment) {
-        test('Range.prototype.createContextualFragment', function () {
-            window.checkStringRepresentation(window.Range.prototype.createContextualFragment, nativeMethods.createContextualFragment);
-        });
-    }
-
-    if (window.EventTarget) {
-        test('addEventListener', function () {
-            window.checkStringRepresentation(window.EventTarget.prototype.addEventListener, nativeMethods.windowAddEventListener);
-        });
-
-        test('removeEventListener', function () {
-            window.checkStringRepresentation(window.EventTarget.prototype.removeEventListener, nativeMethods.windowRemoveEventListener);
-        });
-    }
-    else {
-        test('addEventListener', function () {
-            window.checkStringRepresentation(window.addEventListener, nativeMethods.windowAddEventListener);
-        });
-
-        test('removeEventListener', function () {
-            window.checkStringRepresentation(window.removeEventListener, nativeMethods.windowRemoveEventListener);
-        });
-    }
-
-    if (window.Image) {
-        test('Image', function () {
-            window.checkStringRepresentation(window.Image, nativeMethods.Image);
-        });
-    }
-
-    test('Function', function () {
-        window.checkStringRepresentation(window.Function, nativeMethods.Function);
-        window.checkStringRepresentation(window.Function.prototype.constructor, nativeMethods.Function);
-    });
-
-    if (typeof window.history.pushState === 'function' && typeof window.history.replaceState === 'function') {
-        test('history.pushState', function () {
-            window.checkStringRepresentation(window.history.pushState, nativeMethods.historyPushState);
-        });
-
-        test('history.replaceState', function () {
-            window.checkStringRepresentation(window.history.replaceState, nativeMethods.historyReplaceState);
-        });
-    }
-
-    if (window.navigator.sendBeacon) {
-        test('navigator.sendBeacon', function () {
-            window.checkStringRepresentation(window.navigator.sendBeacon, nativeMethods.sendBeacon);
-        });
-    }
-
-    if (window.navigator.registerProtocolHandler) {
-        test('navigator.registerProtocolHandler', function () {
-            window.checkStringRepresentation(window.navigator.registerProtocolHandler, nativeMethods.registerProtocolHandler);
-        });
-    }
-
-    if (window.FormData) {
-        test('FormData.prototype.append', function () {
-            window.checkStringRepresentation(window.FormData.prototype.append, nativeMethods.formDataAppend);
-        });
-    }
-
-    if (window.WebSocket) {
-        test('WebSocket', function () {
-            window.checkStringRepresentation(window.WebSocket, nativeMethods.WebSocket);
-        });
-    }
-
-    if (window.DOMParser) {
-        test('DOMParser.prototype.parseFromString', function () {
-            window.checkStringRepresentation(window.DOMParser.prototype.parseFromString, nativeMethods.DOMParserParseFromString);
-        });
-    }
-
-    if (window.DOMTokenList) {
-        test('DOMTokenList.prototype.add', function () {
-            window.checkStringRepresentation(window.DOMTokenList.prototype.add, nativeMethods.tokenListAdd);
-        });
-
-        test('DOMTokenList.prototype.remove', function () {
-            window.checkStringRepresentation(window.DOMTokenList.prototype.remove, nativeMethods.tokenListRemove);
-        });
-
-        test('DOMTokenList.prototype.toggle', function () {
-            window.checkStringRepresentation(window.DOMTokenList.prototype.toggle, nativeMethods.tokenListToggle);
-        });
-
-        if (window.DOMTokenList.prototype.replace) {
-            test('DOMTokenList.prototype.replace', function () {
-                window.checkStringRepresentation(window.DOMTokenList.prototype.replace, nativeMethods.tokenListReplace);
-            });
-        }
-
-        if (window.DOMTokenList.prototype.supports) {
-            test('DOMTokenList.prototype.supports', function () {
-                window.checkStringRepresentation(window.DOMTokenList.prototype.supports, nativeMethods.tokenListSupports);
-            });
-        }
-    }
-
-    test('DOMImplementation.prototype.createHTMLDocument', function () {
-        window.checkStringRepresentation(window.DOMImplementation.prototype.createHTMLDocument, nativeMethods.createHTMLDocument);
-    });
-});
 
 module('regression');
 

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -573,13 +573,11 @@ module('wrappers of native functions should return the correct string representa
         });
     }
     else {
-        // // NOTE: it's temporarily
-        QUnit.skip('addEventListener', function () {
+        test('addEventListener', function () {
             window.checkStringRepresentation(window.addEventListener, nativeMethods.windowAddEventListener);
         });
 
-        // NOTE: it's temporarily
-        QUnit.skip('removeEventListener', function () {
+        test('removeEventListener', function () {
             window.checkStringRepresentation(window.removeEventListener, nativeMethods.windowRemoveEventListener);
         });
     }

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -86,10 +86,10 @@ test('wrappers of native functions should return the correct string representati
 
     if (window.EventTarget) {
         window.checkStringRepresentation(window.EventTarget.prototype.addEventListener,
-            nativeMethods.windowAddEventListener,
+            nativeMethods.addEventListener,
             'EventTarget.prototype.addEventListener');
         window.checkStringRepresentation(window.EventTarget.prototype.removeEventListener,
-            nativeMethods.windowRemoveEventListener,
+            nativeMethods.removeEventListener,
             'EventTarget.prototype.removeEventListener');
     }
     else {

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -504,7 +504,7 @@ module('wrappers of native functions should return the correct string representa
     if (window.Worker) {
         test('Worker', function () {
             window.checkStringRepresentation(window.Worker, nativeMethods.Worker);
-            window.checkStringRepresentation(window.Worker.prototype.constructor, nativeMethods.Worker.prototype.constructor);
+            window.checkStringRepresentation(window.Worker.prototype.constructor, nativeMethods.workerProtoCtor);
         });
     }
 
@@ -590,7 +590,7 @@ module('wrappers of native functions should return the correct string representa
 
     test('Function', function () {
         window.checkStringRepresentation(window.Function, nativeMethods.Function);
-        window.checkStringRepresentation(window.Function.prototype.constructor, nativeMethods.Function.prototype.constructor);
+        window.checkStringRepresentation(window.Function.prototype.constructor, nativeMethods.functionProtoCtor);
     });
 
     if (typeof window.history.pushState === 'function' && typeof window.history.replaceState === 'function') {

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -522,6 +522,7 @@ module('wrappers of native functions should return the correct string representa
     if (window.Worker) {
         test('Worker', function () {
             checkStringRepresentation(window.Worker, nativeMethods.Worker);
+            checkStringRepresentation(window.Worker.prototype.constructor, nativeMethods.Worker.prototype.constructor);
         });
     }
 
@@ -607,6 +608,7 @@ module('wrappers of native functions should return the correct string representa
 
     test('Function', function () {
         checkStringRepresentation(window.Function, nativeMethods.Function);
+        checkStringRepresentation(window.Function.prototype.constructor, nativeMethods.Function.prototype.constructor);
     });
 
     if (typeof window.history.pushState === 'function' && typeof window.history.replaceState === 'function') {

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -504,7 +504,7 @@ module('wrappers of native functions should return the correct string representa
     if (window.Worker) {
         test('Worker', function () {
             window.checkStringRepresentation(window.Worker, nativeMethods.Worker);
-            window.checkStringRepresentation(window.Worker.prototype.constructor, nativeMethods.workerProtoCtor);
+            window.checkStringRepresentation(window.Worker.prototype.constructor, nativeMethods.Worker);
         });
     }
 
@@ -590,7 +590,7 @@ module('wrappers of native functions should return the correct string representa
 
     test('Function', function () {
         window.checkStringRepresentation(window.Function, nativeMethods.Function);
-        window.checkStringRepresentation(window.Function.prototype.constructor, nativeMethods.functionProtoCtor);
+        window.checkStringRepresentation(window.Function.prototype.constructor, nativeMethods.Function);
     });
 
     if (typeof window.history.pushState === 'function' && typeof window.history.replaceState === 'function') {

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -480,10 +480,23 @@ if (nativeMethods.windowOriginGetter) {
     });
 }
 
-module('wrappers of native functions should have correct string representations', function () {
+module('wrappers of native functions should return the correct string representations', function () {
     function checkStringRepresentation (wrappedFn, originalFn) {
-        strictEqual(wrappedFn.toString(), originalFn.toString());
-        strictEqual(Function.prototype.toString.call(wrappedFn), originalFn.toString());
+        strictEqual(
+            wrappedFn.toString(),
+            originalFn.toString(),
+            "the outputs of the 'toString()' method should be the same"
+        );
+        strictEqual(
+            Function.prototype.toString.call(wrappedFn),
+            nativeMethods.Function.prototype.toString.call(originalFn),
+            "the outputs of the 'Function.prototype.toString' function should be the same"
+        );
+        strictEqual(
+            wrappedFn.name,
+            originalFn.name,
+            'the function names should be the same'
+        );
     }
 
     test('CanvasRenderingContext2D.prototype.drawImage', function () {

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -481,204 +481,186 @@ if (nativeMethods.windowOriginGetter) {
 }
 
 module('wrappers of native functions should return the correct string representations', function () {
-    function checkStringRepresentation (wrappedFn, originalFn) {
-        strictEqual(
-            wrappedFn.toString(),
-            originalFn.toString(),
-            "the outputs of the 'toString()' method should be the same"
-        );
-        strictEqual(
-            Function.prototype.toString.call(wrappedFn),
-            nativeMethods.Function.prototype.toString.call(originalFn),
-            "the outputs of the 'Function.prototype.toString' function should be the same"
-        );
-        strictEqual(
-            wrappedFn.name,
-            originalFn.name,
-            'the function names should be the same'
-        );
-    }
-
     test('CanvasRenderingContext2D.prototype.drawImage', function () {
-        checkStringRepresentation(window.CanvasRenderingContext2D.prototype.drawImage, nativeMethods.canvasContextDrawImage);
+        window.checkStringRepresentation(window.CanvasRenderingContext2D.prototype.drawImage, nativeMethods.canvasContextDrawImage);
     });
 
     if (window.Object.assign) {
         test('Object.assign', function () {
-            checkStringRepresentation(window.Object.assign, nativeMethods.objectAssign);
+            window.checkStringRepresentation(window.Object.assign, nativeMethods.objectAssign);
         });
     }
 
     test('open', function () {
-        checkStringRepresentation(window.open, nativeMethods.windowOpen);
+        window.checkStringRepresentation(window.open, nativeMethods.windowOpen);
     });
 
     if (window.FontFace) {
         test('FontFace', function () {
-            checkStringRepresentation(window.FontFace, nativeMethods.FontFace);
+            window.checkStringRepresentation(window.FontFace, nativeMethods.FontFace);
         });
     }
 
     if (window.Worker) {
         test('Worker', function () {
-            checkStringRepresentation(window.Worker, nativeMethods.Worker);
-            checkStringRepresentation(window.Worker.prototype.constructor, nativeMethods.Worker.prototype.constructor);
+            window.checkStringRepresentation(window.Worker, nativeMethods.Worker);
+            window.checkStringRepresentation(window.Worker.prototype.constructor, nativeMethods.Worker.prototype.constructor);
         });
     }
 
     if (window.Blob) {
         test('Blob', function () {
-            checkStringRepresentation(window.Blob, nativeMethods.Blob);
+            window.checkStringRepresentation(window.Blob, nativeMethods.Blob);
         });
     }
 
     // NOTE: File in IE11 is not constructable.
     if (window.File && typeof window.File === 'function') {
         test('File', function () {
-            checkStringRepresentation(window.File, nativeMethods.File);
+            window.checkStringRepresentation(window.File, nativeMethods.File);
         });
     }
 
     if (window.EventSource) {
         test('EventSource', function () {
-            checkStringRepresentation(window.EventSource, nativeMethods.EventSource);
+            window.checkStringRepresentation(window.EventSource, nativeMethods.EventSource);
         });
     }
 
     if (window.MutationObserver) {
         test('MutationObserver', function () {
-            checkStringRepresentation(window.MutationObserver, nativeMethods.MutationObserver);
+            window.checkStringRepresentation(window.MutationObserver, nativeMethods.MutationObserver);
         });
     }
 
     if (window.WebKitMutationObserver) {
         test('WebKitMutationObserver', function () {
-            checkStringRepresentation(window.WebKitMutationObserver, nativeMethods.MutationObserver);
+            window.checkStringRepresentation(window.WebKitMutationObserver, nativeMethods.MutationObserver);
         });
     }
 
     if (window.Proxy) {
         test('Proxy', function () {
-            checkStringRepresentation(window.Proxy, nativeMethods.Proxy);
+            window.checkStringRepresentation(window.Proxy, nativeMethods.Proxy);
         });
     }
 
     if (window.registerServiceWorker) {
         test('registerServiceWorker', function () {
-            checkStringRepresentation(window.registerServiceWorker, nativeMethods.registerServiceWorker);
+            window.checkStringRepresentation(window.registerServiceWorker, nativeMethods.registerServiceWorker);
         });
     }
 
     if (window.getRegistrationServiceWorker) {
         test('getRegistrationServiceWorker', function () {
-            checkStringRepresentation(window.getRegistrationServiceWorker, nativeMethods.getRegistrationServiceWorker);
+            window.checkStringRepresentation(window.getRegistrationServiceWorker, nativeMethods.getRegistrationServiceWorker);
         });
     }
 
     if (window.Range.prototype.createContextualFragment) {
         test('Range.prototype.createContextualFragment', function () {
-            checkStringRepresentation(window.Range.prototype.createContextualFragment, nativeMethods.createContextualFragment);
+            window.checkStringRepresentation(window.Range.prototype.createContextualFragment, nativeMethods.createContextualFragment);
         });
     }
 
     if (window.EventTarget) {
         test('addEventListener', function () {
-            checkStringRepresentation(window.EventTarget.prototype.addEventListener, nativeMethods.windowAddEventListener);
+            window.checkStringRepresentation(window.EventTarget.prototype.addEventListener, nativeMethods.windowAddEventListener);
         });
 
         test('removeEventListener', function () {
-            checkStringRepresentation(window.EventTarget.prototype.removeEventListener, nativeMethods.windowRemoveEventListener);
+            window.checkStringRepresentation(window.EventTarget.prototype.removeEventListener, nativeMethods.windowRemoveEventListener);
         });
     }
     else {
         test('addEventListener', function () {
-            checkStringRepresentation(window.addEventListener, nativeMethods.windowAddEventListener);
+            window.checkStringRepresentation(window.addEventListener, nativeMethods.windowAddEventListener);
         });
 
         test('removeEventListener', function () {
-            checkStringRepresentation(window.removeEventListener, nativeMethods.windowRemoveEventListener);
+            window.checkStringRepresentation(window.removeEventListener, nativeMethods.windowRemoveEventListener);
         });
     }
 
     if (window.Image) {
         test('Image', function () {
-            checkStringRepresentation(window.Image, nativeMethods.Image);
+            window.checkStringRepresentation(window.Image, nativeMethods.Image);
         });
     }
 
     test('Function', function () {
-        checkStringRepresentation(window.Function, nativeMethods.Function);
-        checkStringRepresentation(window.Function.prototype.constructor, nativeMethods.Function.prototype.constructor);
+        window.checkStringRepresentation(window.Function, nativeMethods.Function);
+        window.checkStringRepresentation(window.Function.prototype.constructor, nativeMethods.Function.prototype.constructor);
     });
 
     if (typeof window.history.pushState === 'function' && typeof window.history.replaceState === 'function') {
         test('history.pushState', function () {
-            checkStringRepresentation(window.history.pushState, nativeMethods.historyPushState);
+            window.checkStringRepresentation(window.history.pushState, nativeMethods.historyPushState);
         });
 
         test('history.replaceState', function () {
-            checkStringRepresentation(window.history.replaceState, nativeMethods.historyReplaceState);
+            window.checkStringRepresentation(window.history.replaceState, nativeMethods.historyReplaceState);
         });
     }
 
     if (window.navigator.sendBeacon) {
         test('navigator.sendBeacon', function () {
-            checkStringRepresentation(window.navigator.sendBeacon, nativeMethods.sendBeacon);
+            window.checkStringRepresentation(window.navigator.sendBeacon, nativeMethods.sendBeacon);
         });
     }
 
     if (window.navigator.registerProtocolHandler) {
         test('navigator.registerProtocolHandler', function () {
-            checkStringRepresentation(window.navigator.registerProtocolHandler, nativeMethods.registerProtocolHandler);
+            window.checkStringRepresentation(window.navigator.registerProtocolHandler, nativeMethods.registerProtocolHandler);
         });
     }
 
     if (window.FormData) {
         test('FormData.prototype.append', function () {
-            checkStringRepresentation(window.FormData.prototype.append, nativeMethods.formDataAppend);
+            window.checkStringRepresentation(window.FormData.prototype.append, nativeMethods.formDataAppend);
         });
     }
 
     if (window.WebSocket) {
         test('WebSocket', function () {
-            checkStringRepresentation(window.WebSocket, nativeMethods.WebSocket);
+            window.checkStringRepresentation(window.WebSocket, nativeMethods.WebSocket);
         });
     }
 
     if (window.DOMParser) {
         test('DOMParser.prototype.parseFromString', function () {
-            checkStringRepresentation(window.DOMParser.prototype.parseFromString, nativeMethods.DOMParserParseFromString);
+            window.checkStringRepresentation(window.DOMParser.prototype.parseFromString, nativeMethods.DOMParserParseFromString);
         });
     }
 
     if (window.DOMTokenList) {
         test('DOMTokenList.prototype.add', function () {
-            checkStringRepresentation(window.DOMTokenList.prototype.add, nativeMethods.tokenListAdd);
+            window.checkStringRepresentation(window.DOMTokenList.prototype.add, nativeMethods.tokenListAdd);
         });
 
         test('DOMTokenList.prototype.remove', function () {
-            checkStringRepresentation(window.DOMTokenList.prototype.remove, nativeMethods.tokenListRemove);
+            window.checkStringRepresentation(window.DOMTokenList.prototype.remove, nativeMethods.tokenListRemove);
         });
 
         test('DOMTokenList.prototype.toggle', function () {
-            checkStringRepresentation(window.DOMTokenList.prototype.toggle, nativeMethods.tokenListToggle);
+            window.checkStringRepresentation(window.DOMTokenList.prototype.toggle, nativeMethods.tokenListToggle);
         });
 
         if (window.DOMTokenList.prototype.replace) {
             test('DOMTokenList.prototype.replace', function () {
-                checkStringRepresentation(window.DOMTokenList.prototype.replace, nativeMethods.tokenListReplace);
+                window.checkStringRepresentation(window.DOMTokenList.prototype.replace, nativeMethods.tokenListReplace);
             });
         }
 
         if (window.DOMTokenList.prototype.supports) {
             test('DOMTokenList.prototype.supports', function () {
-                checkStringRepresentation(window.DOMTokenList.prototype.supports, nativeMethods.tokenListSupports);
+                window.checkStringRepresentation(window.DOMTokenList.prototype.supports, nativeMethods.tokenListSupports);
             });
         }
     }
 
     test('DOMImplementation.prototype.createHTMLDocument', function () {
-        checkStringRepresentation(window.DOMImplementation.prototype.createHTMLDocument, nativeMethods.createHTMLDocument);
+        window.checkStringRepresentation(window.DOMImplementation.prototype.createHTMLDocument, nativeMethods.createHTMLDocument);
     });
 });
 

--- a/test/client/fixtures/sandbox/shadow-ui-test.js
+++ b/test/client/fixtures/sandbox/shadow-ui-test.js
@@ -130,6 +130,53 @@ test('set innerHTML for root', function () {
     ok(domUtils.isShadowUIElement(root.childNodes[0]));
 });
 
+test('wrappers of native functions should return the correct string representations', function () {
+    window.checkStringRepresentation(window.Document.prototype.elementFromPoint, nativeMethods.elementFromPoint,
+        'Document.prototype.elementFromPoint');
+    if (document.caretRangeFromPoint) {
+        window.checkStringRepresentation(window.Document.prototype.caretRangeFromPoint,
+            nativeMethods.caretRangeFromPoint,
+            'Document.prototype.caretRangeFromPoint');
+    }
+    if (document.caretPositionFromPoint) {
+        window.checkStringRepresentation(window.Document.prototype.caretPositionFromPoint,
+            nativeMethods.caretPositionFromPoint,
+            'Document.prototype.caretPositionFromPoint');
+    }
+    window.checkStringRepresentation(window.Document.prototype.getElementById, nativeMethods.getElementById,
+        'Document.prototype.getElementById');
+    window.checkStringRepresentation(window.Document.prototype.getElementsByName, nativeMethods.getElementsByName,
+        'Document.prototype.getElementsByName');
+    window.checkStringRepresentation(window.Document.prototype.getElementsByClassName,
+        nativeMethods.getElementsByClassName,
+        'Document.prototype.getElementsByClassName');
+    window.checkStringRepresentation(window.Document.prototype.getElementsByTagName, nativeMethods.getElementsByTagName,
+        'Document.prototype.getElementsByTagName');
+    window.checkStringRepresentation(window.Document.prototype.querySelector, nativeMethods.querySelector,
+        'Document.prototype.querySelector');
+    window.checkStringRepresentation(window.Document.prototype.querySelectorAll, nativeMethods.querySelectorAll,
+        'Document.prototype.querySelectorAll');
+    window.checkStringRepresentation(window.Element.prototype.getElementsByTagName,
+        nativeMethods.elementGetElementsByTagName,
+        'Element.prototype.getElementsByTagName');
+    window.checkStringRepresentation(window.HTMLBodyElement.prototype.getElementsByClassName,
+        nativeMethods.elementGetElementsByClassName,
+        'HTMLBodyElement.prototype.getElementsByClassName');
+    window.checkStringRepresentation(window.HTMLBodyElement.prototype.querySelector, nativeMethods.elementQuerySelector,
+        'HTMLBodyElement.prototype.querySelector');
+    window.checkStringRepresentation(window.HTMLBodyElement.prototype.querySelectorAll,
+        nativeMethods.elementQuerySelectorAll,
+        'HTMLBodyElement.prototype.querySelectorAll');
+    window.checkStringRepresentation(window.HTMLHeadElement.prototype.getElementsByClassName,
+        nativeMethods.elementGetElementsByClassName,
+        'HTMLHeadElement.prototype.getElementsByClassName');
+    window.checkStringRepresentation(window.HTMLHeadElement.prototype.querySelector, nativeMethods.elementQuerySelector,
+        'HTMLHeadElement.prototype.querySelector');
+    window.checkStringRepresentation(window.HTMLHeadElement.prototype.querySelectorAll,
+        nativeMethods.elementQuerySelectorAll,
+        'HTMLHeadElement.prototype.querySelectorAll');
+});
+
 if (window.MutationObserver) {
     module('MutationObserver', function () {
         module('child list');
@@ -1183,76 +1230,6 @@ test("do nothing if ShadowUIStylesheet doesn't exist", function () {
 
             qUnitCssLink.className = SHADOW_UI_CLASSNAME.uiStylesheet;
         });
-});
-
-module('wrappers of native functions should return the correct string representations', function () {
-    test('window.Document.prototype.elementFromPoint', function () {
-        window.checkStringRepresentation(window.Document.prototype.elementFromPoint, nativeMethods.elementFromPoint);
-    });
-
-    if (document.caretRangeFromPoint) {
-        test('window.Document.prototype.caretRangeFromPoint', function () {
-            window.checkStringRepresentation(window.Document.prototype.caretRangeFromPoint, nativeMethods.caretRangeFromPoint);
-        });
-    }
-
-    if (document.caretPositionFromPoint) {
-        test('window.setInterval', function () {
-            window.checkStringRepresentation(window.Document.prototype.caretPositionFromPoint, nativeMethods.caretPositionFromPoint);
-        });
-    }
-
-    test('window.Document.prototype.getElementById', function () {
-        window.checkStringRepresentation(window.Document.prototype.getElementById, nativeMethods.getElementById);
-    });
-
-    test('window.Document.prototype.getElementsByName', function () {
-        window.checkStringRepresentation(window.Document.prototype.getElementsByName, nativeMethods.getElementsByName);
-    });
-
-    test('window.Document.prototype.getElementsByClassName', function () {
-        window.checkStringRepresentation(window.Document.prototype.getElementsByClassName, nativeMethods.getElementsByClassName);
-    });
-
-    test('window.Document.prototype.getElementsByTagName', function () {
-        window.checkStringRepresentation(window.Document.prototype.getElementsByTagName, nativeMethods.getElementsByTagName);
-    });
-
-    test('window.Document.prototype.querySelector', function () {
-        window.checkStringRepresentation(window.Document.prototype.querySelector, nativeMethods.querySelector);
-    });
-
-    test('window.Document.prototype.querySelectorAll', function () {
-        window.checkStringRepresentation(window.Document.prototype.querySelectorAll, nativeMethods.querySelectorAll);
-    });
-
-    test('window.Element.prototype.getElementsByTagName', function () {
-        window.checkStringRepresentation(window.Element.prototype.getElementsByTagName, nativeMethods.elementGetElementsByTagName);
-    });
-
-    test('window.HTMLBodyElement.prototype.getElementsByClassName', function () {
-        window.checkStringRepresentation(window.HTMLBodyElement.prototype.getElementsByClassName, nativeMethods.elementGetElementsByClassName);
-    });
-
-    test('window.HTMLBodyElement.prototype.querySelector', function () {
-        window.checkStringRepresentation(window.HTMLBodyElement.prototype.querySelector, nativeMethods.elementQuerySelector);
-    });
-
-    test('window.HTMLBodyElement.prototype.querySelectorAll', function () {
-        window.checkStringRepresentation(window.HTMLBodyElement.prototype.querySelectorAll, nativeMethods.elementQuerySelectorAll);
-    });
-
-    test('window.HTMLHeadElement.prototype.getElementsByClassName', function () {
-        window.checkStringRepresentation(window.HTMLHeadElement.prototype.getElementsByClassName, nativeMethods.elementGetElementsByClassName);
-    });
-
-    test('window.HTMLHeadElement.prototype.querySelector', function () {
-        window.checkStringRepresentation(window.HTMLHeadElement.prototype.querySelector, nativeMethods.elementQuerySelector);
-    });
-
-    test('window.HTMLHeadElement.prototype.querySelectorAll', function () {
-        window.checkStringRepresentation(window.HTMLHeadElement.prototype.querySelectorAll, nativeMethods.elementQuerySelectorAll);
-    });
 });
 
 module('regression');

--- a/test/client/fixtures/sandbox/shadow-ui-test.js
+++ b/test/client/fixtures/sandbox/shadow-ui-test.js
@@ -1185,6 +1185,76 @@ test("do nothing if ShadowUIStylesheet doesn't exist", function () {
         });
 });
 
+module('wrappers of native functions should return the correct string representations', function () {
+    test('window.Document.prototype.elementFromPoint', function () {
+        window.checkStringRepresentation(window.Document.prototype.elementFromPoint, nativeMethods.elementFromPoint);
+    });
+
+    if (document.caretRangeFromPoint) {
+        test('window.Document.prototype.caretRangeFromPoint', function () {
+            window.checkStringRepresentation(window.Document.prototype.caretRangeFromPoint, nativeMethods.caretRangeFromPoint);
+        });
+    }
+
+    if (document.caretPositionFromPoint) {
+        test('window.setInterval', function () {
+            window.checkStringRepresentation(window.Document.prototype.caretPositionFromPoint, nativeMethods.caretPositionFromPoint);
+        });
+    }
+
+    test('window.Document.prototype.getElementById', function () {
+        window.checkStringRepresentation(window.Document.prototype.getElementById, nativeMethods.getElementById);
+    });
+
+    test('window.Document.prototype.getElementsByName', function () {
+        window.checkStringRepresentation(window.Document.prototype.getElementsByName, nativeMethods.getElementsByName);
+    });
+
+    test('window.Document.prototype.getElementsByClassName', function () {
+        window.checkStringRepresentation(window.Document.prototype.getElementsByClassName, nativeMethods.getElementsByClassName);
+    });
+
+    test('window.Document.prototype.getElementsByTagName', function () {
+        window.checkStringRepresentation(window.Document.prototype.getElementsByTagName, nativeMethods.getElementsByTagName);
+    });
+
+    test('window.Document.prototype.querySelector', function () {
+        window.checkStringRepresentation(window.Document.prototype.querySelector, nativeMethods.querySelector);
+    });
+
+    test('window.Document.prototype.querySelectorAll', function () {
+        window.checkStringRepresentation(window.Document.prototype.querySelectorAll, nativeMethods.querySelectorAll);
+    });
+
+    test('window.Element.prototype.getElementsByTagName', function () {
+        window.checkStringRepresentation(window.Element.prototype.getElementsByTagName, nativeMethods.elementGetElementsByTagName);
+    });
+
+    test('window.HTMLBodyElement.prototype.getElementsByClassName', function () {
+        window.checkStringRepresentation(window.HTMLBodyElement.prototype.getElementsByClassName, nativeMethods.elementGetElementsByClassName);
+    });
+
+    test('window.HTMLBodyElement.prototype.querySelector', function () {
+        window.checkStringRepresentation(window.HTMLBodyElement.prototype.querySelector, nativeMethods.elementQuerySelector);
+    });
+
+    test('window.HTMLBodyElement.prototype.querySelectorAll', function () {
+        window.checkStringRepresentation(window.HTMLBodyElement.prototype.querySelectorAll, nativeMethods.elementQuerySelectorAll);
+    });
+
+    test('window.HTMLHeadElement.prototype.getElementsByClassName', function () {
+        window.checkStringRepresentation(window.HTMLHeadElement.prototype.getElementsByClassName, nativeMethods.elementGetElementsByClassName);
+    });
+
+    test('window.HTMLHeadElement.prototype.querySelector', function () {
+        window.checkStringRepresentation(window.HTMLHeadElement.prototype.querySelector, nativeMethods.elementQuerySelector);
+    });
+
+    test('window.HTMLHeadElement.prototype.querySelectorAll', function () {
+        window.checkStringRepresentation(window.HTMLHeadElement.prototype.querySelectorAll, nativeMethods.elementQuerySelectorAll);
+    });
+});
+
 module('regression');
 
 test('SVG elements\' className is of the SVGAnimatedString type instead of string (GH-354)', function () {

--- a/test/client/fixtures/sandbox/style-test.js
+++ b/test/client/fixtures/sandbox/style-test.js
@@ -134,22 +134,17 @@ test('getPropertyValue, setProperty, getPropertyValue (GH-1212)', function () {
     ok(!div.style.removeProperty('background'));
 });
 
-module('wrappers of native functions should return the correct string representations', function () {
-    test('window.CSSStyleSheet.prototype.insertRule', function () {
-        window.checkStringRepresentation(window.CSSStyleSheet.prototype.insertRule, nativeMethods.styleInsertRule);
-    });
-
-    test('window.CSSStyleDeclaration.prototype.getPropertyValue', function () {
-        window.checkStringRepresentation(window.CSSStyleDeclaration.prototype.getPropertyValue, nativeMethods.styleGetPropertyValue);
-    });
-
-    test('window.CSSStyleDeclaration.prototype.setProperty', function () {
-        window.checkStringRepresentation(window.CSSStyleDeclaration.prototype.setProperty, nativeMethods.styleSetProperty);
-    });
-
-    test('window.CSSStyleDeclaration.prototype.removeProperty', function () {
-        window.checkStringRepresentation(window.CSSStyleDeclaration.prototype.removeProperty, nativeMethods.styleRemoveProperty);
-    });
+test('wrappers of native functions should return the correct string representations', function () {
+    window.checkStringRepresentation(window.CSSStyleSheet.prototype.insertRule, nativeMethods.styleInsertRule,
+        'CSSStyleSheet.prototype.insertRule');
+    window.checkStringRepresentation(window.CSSStyleDeclaration.prototype.getPropertyValue,
+        nativeMethods.styleGetPropertyValue,
+        'CSSStyleDeclaration.prototype.getPropertyValue');
+    window.checkStringRepresentation(window.CSSStyleDeclaration.prototype.setProperty, nativeMethods.styleSetProperty,
+        'CSSStyleDeclaration.prototype.setProperty');
+    window.checkStringRepresentation(window.CSSStyleDeclaration.prototype.removeProperty,
+        nativeMethods.styleRemoveProperty,
+        'CSSStyleDeclaration.prototype.removeProperty');
 });
 
 module('regression');

--- a/test/client/fixtures/sandbox/style-test.js
+++ b/test/client/fixtures/sandbox/style-test.js
@@ -134,6 +134,24 @@ test('getPropertyValue, setProperty, getPropertyValue (GH-1212)', function () {
     ok(!div.style.removeProperty('background'));
 });
 
+module('wrappers of native functions should return the correct string representations', function () {
+    test('window.CSSStyleSheet.prototype.insertRule', function () {
+        window.checkStringRepresentation(window.CSSStyleSheet.prototype.insertRule, nativeMethods.styleInsertRule);
+    });
+
+    test('window.CSSStyleDeclaration.prototype.getPropertyValue', function () {
+        window.checkStringRepresentation(window.CSSStyleDeclaration.prototype.getPropertyValue, nativeMethods.styleGetPropertyValue);
+    });
+
+    test('window.CSSStyleDeclaration.prototype.setProperty', function () {
+        window.checkStringRepresentation(window.CSSStyleDeclaration.prototype.setProperty, nativeMethods.styleSetProperty);
+    });
+
+    test('window.CSSStyleDeclaration.prototype.removeProperty', function () {
+        window.checkStringRepresentation(window.CSSStyleDeclaration.prototype.removeProperty, nativeMethods.styleRemoveProperty);
+    });
+});
+
 module('regression');
 
 test('the getAttribute function should return cleaned style (GH-1922)', function () {

--- a/test/client/fixtures/sandbox/timers-test.js
+++ b/test/client/fixtures/sandbox/timers-test.js
@@ -80,3 +80,13 @@ asyncTest('setTimeout method invocation by using ".apply"', function () {
     notEqual(nativeMethods.anchorHrefGetter.call(window.testAnchor), url);
     window.setTimeout.apply(window, ['strictEqual(window.testAnchor.href, "' + url + '"); start();', 0]);
 });
+
+module('wrappers of native functions should return the correct string representations', function () {
+    test('window.setTimeout', function () {
+        window.checkStringRepresentation(window.setTimeout, nativeMethods.setTimeout);
+    });
+
+    test('window.setInterval', function () {
+        window.checkStringRepresentation(window.setInterval, nativeMethods.setInterval);
+    });
+});

--- a/test/client/fixtures/sandbox/timers-test.js
+++ b/test/client/fixtures/sandbox/timers-test.js
@@ -81,12 +81,7 @@ asyncTest('setTimeout method invocation by using ".apply"', function () {
     window.setTimeout.apply(window, ['strictEqual(window.testAnchor.href, "' + url + '"); start();', 0]);
 });
 
-module('wrappers of native functions should return the correct string representations', function () {
-    test('window.setTimeout', function () {
-        window.checkStringRepresentation(window.setTimeout, nativeMethods.setTimeout);
-    });
-
-    test('window.setInterval', function () {
-        window.checkStringRepresentation(window.setInterval, nativeMethods.setInterval);
-    });
+test('wrappers of native functions should return the correct string representations', function () {
+    window.checkStringRepresentation(window.setTimeout, nativeMethods.setTimeout, 'setTimeout');
+    window.checkStringRepresentation(window.setInterval, nativeMethods.setInterval, 'setInterval');
 });

--- a/test/client/fixtures/sandbox/xhr-test.js
+++ b/test/client/fixtures/sandbox/xhr-test.js
@@ -136,6 +136,39 @@ test('throwing an error on invalid calling "open" method (GH-1613)', function ()
     }
 });
 
+module('wrappers of native functions should return the correct string representations', function () {
+    if (window.XMLHttpRequest) {
+        test('window.XMLHttpRequest', function () {
+            window.checkStringRepresentation(window.XMLHttpRequest, nativeMethods.XMLHttpRequest);
+            window.checkStringRepresentation(window.XMLHttpRequest.prototype.constructor, nativeMethods.XMLHttpRequest.prototype.constructor);
+        });
+
+        test('window.XMLHttpRequest.prototype.abort', function () {
+            window.checkStringRepresentation(window.XMLHttpRequest.prototype.abort, nativeMethods.xhrAbort);
+        });
+
+        test('window.XMLHttpRequest.prototype.open', function () {
+            window.checkStringRepresentation(window.XMLHttpRequest.prototype.open, nativeMethods.xhrOpen);
+        });
+
+        test('window.XMLHttpRequest.prototype.send', function () {
+            window.checkStringRepresentation(window.XMLHttpRequest.prototype.send, nativeMethods.xhrSend);
+        });
+
+        test('window.XMLHttpRequest.prototype.setRequestHeader', function () {
+            window.checkStringRepresentation(window.XMLHttpRequest.prototype.setRequestHeader, nativeMethods.xhrSetRequestHeader);
+        });
+
+        test('window.XMLHttpRequest.prototype.getResponseHeader', function () {
+            window.checkStringRepresentation(window.XMLHttpRequest.prototype.getResponseHeader, nativeMethods.xhrGetResponseHeader);
+        });
+
+        test('window.XMLHttpRequest.prototype.getAllResponseHeaders', function () {
+            window.checkStringRepresentation(window.XMLHttpRequest.prototype.getAllResponseHeaders, nativeMethods.xhrGetAllResponseHeaders);
+        });
+    }
+});
+
 module('regression');
 
 asyncTest('unexpected text modifying during typing text in the search input on the http://www.google.co.uk (B238528)', function () {

--- a/test/client/fixtures/sandbox/xhr-test.js
+++ b/test/client/fixtures/sandbox/xhr-test.js
@@ -136,38 +136,28 @@ test('throwing an error on invalid calling "open" method (GH-1613)', function ()
     }
 });
 
-module('wrappers of native functions should return the correct string representations', function () {
-    if (window.XMLHttpRequest) {
-        test('window.XMLHttpRequest', function () {
-            window.checkStringRepresentation(window.XMLHttpRequest, nativeMethods.XMLHttpRequest);
-            window.checkStringRepresentation(window.XMLHttpRequest.prototype.constructor, nativeMethods.XMLHttpRequest);
-        });
-
-        test('window.XMLHttpRequest.prototype.abort', function () {
-            window.checkStringRepresentation(window.XMLHttpRequest.prototype.abort, nativeMethods.xhrAbort);
-        });
-
-        test('window.XMLHttpRequest.prototype.open', function () {
-            window.checkStringRepresentation(window.XMLHttpRequest.prototype.open, nativeMethods.xhrOpen);
-        });
-
-        test('window.XMLHttpRequest.prototype.send', function () {
-            window.checkStringRepresentation(window.XMLHttpRequest.prototype.send, nativeMethods.xhrSend);
-        });
-
-        test('window.XMLHttpRequest.prototype.setRequestHeader', function () {
-            window.checkStringRepresentation(window.XMLHttpRequest.prototype.setRequestHeader, nativeMethods.xhrSetRequestHeader);
-        });
-
-        test('window.XMLHttpRequest.prototype.getResponseHeader', function () {
-            window.checkStringRepresentation(window.XMLHttpRequest.prototype.getResponseHeader, nativeMethods.xhrGetResponseHeader);
-        });
-
-        test('window.XMLHttpRequest.prototype.getAllResponseHeaders', function () {
-            window.checkStringRepresentation(window.XMLHttpRequest.prototype.getAllResponseHeaders, nativeMethods.xhrGetAllResponseHeaders);
-        });
-    }
-});
+if (window.XMLHttpRequest) {
+    test('wrappers of native functions should return the correct string representations', function () {
+        window.checkStringRepresentation(window.XMLHttpRequest, nativeMethods.XMLHttpRequest, 'XMLHttpRequest');
+        window.checkStringRepresentation(window.XMLHttpRequest.prototype.constructor, nativeMethods.XMLHttpRequest,
+            'XMLHttpRequest.prototype.constructor');
+        window.checkStringRepresentation(window.XMLHttpRequest.prototype.abort, nativeMethods.xhrAbort,
+            'XMLHttpRequest.prototype.abort');
+        window.checkStringRepresentation(window.XMLHttpRequest.prototype.open, nativeMethods.xhrOpen,
+            'XMLHttpRequest.prototype.open');
+        window.checkStringRepresentation(window.XMLHttpRequest.prototype.send, nativeMethods.xhrSend,
+            'XMLHttpRequest.prototype.send');
+        window.checkStringRepresentation(window.XMLHttpRequest.prototype.setRequestHeader,
+            nativeMethods.xhrSetRequestHeader,
+            'XMLHttpRequest.prototype.setRequestHeader');
+        window.checkStringRepresentation(window.XMLHttpRequest.prototype.getResponseHeader,
+            nativeMethods.xhrGetResponseHeader,
+            'XMLHttpRequest.prototype.getResponseHeader');
+        window.checkStringRepresentation(window.XMLHttpRequest.prototype.getAllResponseHeaders,
+            nativeMethods.xhrGetAllResponseHeaders,
+            'XMLHttpRequest.prototype.getAllResponseHeaders');
+    });
+}
 
 module('regression');
 

--- a/test/client/fixtures/sandbox/xhr-test.js
+++ b/test/client/fixtures/sandbox/xhr-test.js
@@ -140,7 +140,7 @@ module('wrappers of native functions should return the correct string representa
     if (window.XMLHttpRequest) {
         test('window.XMLHttpRequest', function () {
             window.checkStringRepresentation(window.XMLHttpRequest, nativeMethods.XMLHttpRequest);
-            window.checkStringRepresentation(window.XMLHttpRequest.prototype.constructor, nativeMethods.XMLHttpRequest.prototype.constructor);
+            window.checkStringRepresentation(window.XMLHttpRequest.prototype.constructor, nativeMethods.xmlHttpRequestProtoCtor);
         });
 
         test('window.XMLHttpRequest.prototype.abort', function () {

--- a/test/client/fixtures/sandbox/xhr-test.js
+++ b/test/client/fixtures/sandbox/xhr-test.js
@@ -140,7 +140,7 @@ module('wrappers of native functions should return the correct string representa
     if (window.XMLHttpRequest) {
         test('window.XMLHttpRequest', function () {
             window.checkStringRepresentation(window.XMLHttpRequest, nativeMethods.XMLHttpRequest);
-            window.checkStringRepresentation(window.XMLHttpRequest.prototype.constructor, nativeMethods.xmlHttpRequestProtoCtor);
+            window.checkStringRepresentation(window.XMLHttpRequest.prototype.constructor, nativeMethods.XMLHttpRequest);
         });
 
         test('window.XMLHttpRequest.prototype.abort', function () {


### PR DESCRIPTION
## Purpose 
        
Customer who submitted the [original](https://supportcenter.devexpress.com/internal/ticket/details/T915177/) ticket to our Support Center is using `Power BI` library, which causes an issue when the customer tries to run tests on their site. First, the library creates a fake copy of `window` object ([issue](https://github.com/microsoft/PowerBI-visuals/issues/165)). Then it detects native functions by running a regexp search with pattern `/\{\s*\[native code\]\s*\}/` against the result of `Function.prototype.toString()` call. When a native function is found, the library binds it to a newly created `window` instance. But in our case, Power BI library can't detect any native functions because we're wrapping them, so their string representations are just the code of these wrappers. To resolve this, we need to override string representations of our native functions' wrappers so that `Function.prototype.toString()` method returns the expected value.

## Approach

The approach we decided on is to save the original string representation of a native function right in its wrapper as an additional property. Then override `Function.prototype.toString()` method so it returns this data if the function passed to it has our property, otherwise dispatch to default native method call.

It should be noted that instead of saving the initial string representation as a property, we could save a reference to the original native function in its wrapper and dispatch to that when needed (which is the same way `zone.js` library does it).

## References
Closes #2394 
Fixed missed typo that was introduced in #2203: should be `EventTarget` instead of `EventLisener`

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
