### PR TITLE
Fix location wrapping in iframes without the src attribute

### DIFF
--- a/src/client/sandbox/code-instrumentation/location/wrapper.ts
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.ts
@@ -13,7 +13,8 @@ import {
     sameOriginCheck,
     ensureTrailingSlash,
     prepareUrl,
-    SPECIAL_BLANK_PAGE
+    SPECIAL_BLANK_PAGE,
+    ORIGIN_IN_IFRAME_WITHOUT_SRC
 } from '../../../../utils/url';
 import nativeMethods from '../../native-methods';
 import urlResolver from '../../../utils/url-resolver';
@@ -131,7 +132,14 @@ export default class LocationWrapper {
 
         // eslint-disable-next-line no-restricted-properties
         locationProps.origin = createOverriddenDescriptor(locationPropsOwner, 'origin', {
-            getter: () => getDomain(getParsedDestLocation()),
+            getter: () => {
+                const origin = getDomain(getParsedDestLocation());
+
+                if (origin)
+                    return origin;
+                else
+                    return ORIGIN_IN_IFRAME_WITHOUT_SRC;
+            },
             setter: origin => origin
         });
 

--- a/src/client/sandbox/code-instrumentation/location/wrapper.ts
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.ts
@@ -1,4 +1,8 @@
-import { get as getDestLocation, getParsed as getParsedDestLocation } from '../../../utils/destination-location';
+import {
+    get as getDestLocation,
+    getParsed as getParsedDestLocation,
+    inIframeWithourSrc
+} from '../../../utils/destination-location';
 import {
     getProxyUrl,
     changeDestUrlPart,
@@ -14,7 +18,6 @@ import {
     ensureTrailingSlash,
     prepareUrl,
     SPECIAL_BLANK_PAGE,
-    ORIGIN_IN_IFRAME_WITHOUT_SRC,
     ORIGIN_IN_IFRAME_WITHOUT_SRC_IN_IE
 } from '../../../../utils/url';
 import nativeMethods from '../../native-methods';
@@ -135,12 +138,15 @@ export default class LocationWrapper {
         // eslint-disable-next-line no-restricted-properties
         locationProps.origin = createOverriddenDescriptor(locationPropsOwner, 'origin', {
             getter: () => {
-                const origin = getDomain(getParsedDestLocation());
+                if (inIframeWithourSrc() && isIE)
+                    return ORIGIN_IN_IFRAME_WITHOUT_SRC_IN_IE;
 
-                if (origin)
-                    return origin;
-                else
-                    return isIE ? ORIGIN_IN_IFRAME_WITHOUT_SRC_IN_IE : ORIGIN_IN_IFRAME_WITHOUT_SRC;
+                const parsedDestLocation = getParsedDestLocation();
+
+                if (parsedDestLocation.origin) // eslint-disable-line no-restricted-properties
+                    return parsedDestLocation.origin; // eslint-disable-line no-restricted-properties
+
+                return getDomain(parsedDestLocation);
             },
             setter: origin => origin
         });

--- a/src/client/sandbox/code-instrumentation/location/wrapper.ts
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.ts
@@ -14,7 +14,8 @@ import {
     ensureTrailingSlash,
     prepareUrl,
     SPECIAL_BLANK_PAGE,
-    ORIGIN_IN_IFRAME_WITHOUT_SRC
+    ORIGIN_IN_IFRAME_WITHOUT_SRC,
+    ORIGIN_IN_IFRAME_WITHOUT_SRC_IN_IE
 } from '../../../../utils/url';
 import nativeMethods from '../../native-methods';
 import urlResolver from '../../../utils/url-resolver';
@@ -23,6 +24,7 @@ import DOMStringListWrapper from './ancestor-origins-wrapper';
 import IntegerIdGenerator from '../../../utils/integer-id-generator';
 import { createOverriddenDescriptor } from '../../../utils/property-overriding';
 import MessageSandbox from '../../event/message';
+import { isIE } from '../../../utils/browser';
 
 const GET_ORIGIN_CMD      = 'hammerhead|command|get-origin';
 const ORIGIN_RECEIVED_CMD = 'hammerhead|command|origin-received';
@@ -138,7 +140,7 @@ export default class LocationWrapper {
                 if (origin)
                     return origin;
                 else
-                    return ORIGIN_IN_IFRAME_WITHOUT_SRC;
+                    return isIE ? ORIGIN_IN_IFRAME_WITHOUT_SRC_IN_IE : ORIGIN_IN_IFRAME_WITHOUT_SRC;
             },
             setter: origin => origin
         });

--- a/src/client/utils/destination-location.ts
+++ b/src/client/utils/destination-location.ts
@@ -1,9 +1,10 @@
 import * as sharedUrlUtils from '../../utils/url';
 import * as domUtils from './dom';
 import * as urlResolver from './url-resolver';
-import { SPECIAL_BLANK_PAGE } from '../../utils/url';
+import { PATHNAME_IN_IFRAME_WITHOUT_SRC_IN_FIREFOX, SPECIAL_BLANK_PAGE } from '../../utils/url';
 import nativeMethods from '../sandbox/native-methods';
 import getGlobalContextInfo from './global-context-info';
+import { isFirefox } from './browser';
 
 let forcedLocation = null;
 
@@ -88,6 +89,9 @@ function parseLocationThroughAnchor (url: string) {
     // NOTE: IE ignores the first '/' symbol in the pathname.
     if (hrefValue !== SPECIAL_BLANK_PAGE && pathname.charAt(0) !== '/')
         pathname = '/' + pathname;
+
+    if (hrefValue === SPECIAL_BLANK_PAGE && isFirefox)
+        pathname = PATHNAME_IN_IFRAME_WITHOUT_SRC_IN_FIREFOX;
 
     // TODO: Describe default ports logic.
     return {

--- a/src/client/utils/destination-location.ts
+++ b/src/client/utils/destination-location.ts
@@ -1,7 +1,7 @@
 import * as sharedUrlUtils from '../../utils/url';
 import * as domUtils from './dom';
 import * as urlResolver from './url-resolver';
-import settings from '../settings';
+import { SPECIAL_BLANK_PAGE } from '../../utils/url';
 import nativeMethods from '../sandbox/native-methods';
 import getGlobalContextInfo from './global-context-info';
 
@@ -18,7 +18,7 @@ export function getLocation (): string {
 
     // NOTE: Fallback to the owner page's URL if we are in an iframe without src.
     if (frameElement && domUtils.isIframeWithoutSrc(frameElement))
-        return settings.get().referer;
+        return SPECIAL_BLANK_PAGE;
 
     return globalCtx.location.toString();
 }
@@ -77,14 +77,16 @@ function parseLocationThroughAnchor (url: string) {
     // eslint-disable-next-line no-restricted-properties
     const destPort = sharedUrlUtils.parseUrl(url).port;
 
+    const hrefValue = get();
+
     // NOTE: IE browser adds the default port for the https protocol while resolving.
-    nativeMethods.anchorHrefSetter.call(resolver, get());
+    nativeMethods.anchorHrefSetter.call(resolver, hrefValue);
 
     const hostname = nativeMethods.anchorHostnameGetter.call(resolver);
     let pathname   = nativeMethods.anchorPathnameGetter.call(resolver);
 
     // NOTE: IE ignores the first '/' symbol in the pathname.
-    if (pathname.charAt(0) !== '/')
+    if (hrefValue !== SPECIAL_BLANK_PAGE && pathname.charAt(0) !== '/')
         pathname = '/' + pathname;
 
     // TODO: Describe default ports logic.

--- a/src/client/utils/destination-location.ts
+++ b/src/client/utils/destination-location.ts
@@ -8,17 +8,22 @@ import { isFirefox } from './browser';
 
 let forcedLocation = null;
 
+export function inIframeWithourSrc (): boolean {
+    const globalCtx    = getGlobalContextInfo().global;
+    const frameElement = domUtils.getFrameElement(globalCtx);
+
+    return frameElement && domUtils.isIframeWithoutSrc(frameElement);
+}
+
 // NOTE: exposed only for tests
 export function getLocation (): string {
     // NOTE: Used for testing. Unfortunately, we cannot override the 'getLocation' method in a test.
     if (forcedLocation)
         return forcedLocation;
 
-    const globalCtx    = getGlobalContextInfo().global;
-    const frameElement = domUtils.getFrameElement(globalCtx);
+    const globalCtx = getGlobalContextInfo().global;
 
-    // NOTE: Fallback to the owner page's URL if we are in an iframe without src.
-    if (frameElement && domUtils.isIframeWithoutSrc(frameElement))
+    if (inIframeWithourSrc())
         return SPECIAL_BLANK_PAGE;
 
     return globalCtx.location.toString();
@@ -103,7 +108,8 @@ function parseLocationThroughAnchor (url: string) {
         host:     destPort ? nativeMethods.anchorHostGetter.call(resolver) : hostname,
         pathname: pathname,
         hash:     resolver.hash,
-        search:   nativeMethods.anchorSearchGetter.call(resolver)
+        search:   nativeMethods.anchorSearchGetter.call(resolver),
+        origin:   nativeMethods.anchorOriginGetter ? nativeMethods.anchorOriginGetter.call(resolver) : null
     };
 }
 
@@ -118,7 +124,8 @@ function parseLocationThroughURL (url: string) {
         host:     parsedUrl.host,
         pathname: parsedUrl.pathname,
         hash:     parsedUrl.hash,
-        search:   parsedUrl.search
+        search:   parsedUrl.search,
+        origin:   parsedUrl.origin
     };
     /* eslint-enable no-restricted-properties */
 }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -24,6 +24,8 @@ export const TRAILING_SLASH_RE                                = /\/$/;
 export const SPECIAL_BLANK_PAGE                               = 'about:blank';
 export const SPECIAL_ERROR_PAGE                               = 'about:error';
 export const SPECIAL_PAGES                                    = [SPECIAL_BLANK_PAGE, SPECIAL_ERROR_PAGE];
+export const PATHNAME_IN_IFRAME_WITHOUT_SRC_IN_FIREFOX        = 'blank';
+export const ORIGIN_IN_IFRAME_WITHOUT_SRC                     = 'null';
 
 export const HTTP_DEFAULT_PORT  = '80';
 export const HTTPS_DEFAULT_PORT = '443';

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -26,6 +26,7 @@ export const SPECIAL_ERROR_PAGE                               = 'about:error';
 export const SPECIAL_PAGES                                    = [SPECIAL_BLANK_PAGE, SPECIAL_ERROR_PAGE];
 export const PATHNAME_IN_IFRAME_WITHOUT_SRC_IN_FIREFOX        = 'blank';
 export const ORIGIN_IN_IFRAME_WITHOUT_SRC                     = 'null';
+export const ORIGIN_IN_IFRAME_WITHOUT_SRC_IN_IE               = 'about://';
 
 export const HTTP_DEFAULT_PORT  = '80';
 export const HTTPS_DEFAULT_PORT = '443';

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -25,7 +25,6 @@ export const SPECIAL_BLANK_PAGE                               = 'about:blank';
 export const SPECIAL_ERROR_PAGE                               = 'about:error';
 export const SPECIAL_PAGES                                    = [SPECIAL_BLANK_PAGE, SPECIAL_ERROR_PAGE];
 export const PATHNAME_IN_IFRAME_WITHOUT_SRC_IN_FIREFOX        = 'blank';
-export const ORIGIN_IN_IFRAME_WITHOUT_SRC                     = 'null';
 export const ORIGIN_IN_IFRAME_WITHOUT_SRC_IN_IE               = 'about://';
 
 export const HTTP_DEFAULT_PORT  = '80';

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -146,48 +146,51 @@ test('location object of iframe with empty src should have properties with corre
         nativeMethods.setAttribute.call(nativeIframe, 'src', iframeSrcAttribute);
         nativeMethods.appendChild.call(iframe.contentDocument.body, nativeIframe);
 
-        iframe.contentWindow.eval('window["%hammerhead%"].get("./utils/destination-location").forceLocation(null);');
+        return window.QUnitGlobals.waitForIframe(nativeIframe)
+            .then(function () {
+                iframe.contentWindow.eval('window["%hammerhead%"].get("./utils/destination-location").forceLocation(null);');
 
-        strictEqual(
-            eval(processScript('iframe.contentDocument.location.protocol')),
-            nativeIframe.contentDocument.location.protocol,
-            'protocol property in iframe with "' + iframeSrcAttribute + '" src attribute'
-        );
-        strictEqual(
-            eval(processScript('iframe.contentDocument.location.port')),
-            nativeIframe.contentDocument.location.port,
-            'port property in iframe with "' + iframeSrcAttribute + '" src attribute'
-        );
-        strictEqual(
-            eval(processScript('iframe.contentDocument.location.host')),
-            nativeIframe.contentDocument.location.host,
-            'host property in iframe with "' + iframeSrcAttribute + '" src attribute'
-        );
-        strictEqual(
-            eval(processScript('iframe.contentDocument.location.hostname')),
-            nativeIframe.contentDocument.location.hostname,
-            'hostname property in iframe with "' + iframeSrcAttribute + '" src attribute'
-        );
-        strictEqual(
-            eval(processScript('iframe.contentDocument.location.pathname')),
-            nativeIframe.contentDocument.location.pathname,
-            'pathname property in iframe with "' + iframeSrcAttribute + '" src attribute'
-        );
-        strictEqual(
-            eval(processScript('iframe.contentDocument.location.hash')),
-            nativeIframe.contentDocument.location.hash,
-            'hash property in iframe with "' + iframeSrcAttribute + '" src attribute'
-        );
-        strictEqual(
-            eval(processScript('iframe.contentDocument.location.search')),
-            nativeIframe.contentDocument.location.search,
-            'search property in iframe with "' + iframeSrcAttribute + '" src attribute'
-        );
-        strictEqual(
-            eval(processScript('iframe.contentDocument.location.origin')),
-            nativeIframe.contentDocument.location.origin,
-            'origin property in iframe with "' + iframeSrcAttribute + '" src attribute'
-        );
+                strictEqual(
+                    eval(processScript('iframe.contentDocument.location.protocol')),
+                    nativeIframe.contentDocument.location.protocol,
+                    'protocol property in iframe with "' + iframeSrcAttribute + '" src attribute'
+                );
+                strictEqual(
+                    eval(processScript('iframe.contentDocument.location.port')),
+                    nativeIframe.contentDocument.location.port,
+                    'port property in iframe with "' + iframeSrcAttribute + '" src attribute'
+                );
+                strictEqual(
+                    eval(processScript('iframe.contentDocument.location.host')),
+                    nativeIframe.contentDocument.location.host,
+                    'host property in iframe with "' + iframeSrcAttribute + '" src attribute'
+                );
+                strictEqual(
+                    eval(processScript('iframe.contentDocument.location.hostname')),
+                    nativeIframe.contentDocument.location.hostname,
+                    'hostname property in iframe with "' + iframeSrcAttribute + '" src attribute'
+                );
+                strictEqual(
+                    eval(processScript('iframe.contentDocument.location.pathname')),
+                    nativeIframe.contentDocument.location.pathname,
+                    'pathname property in iframe with "' + iframeSrcAttribute + '" src attribute'
+                );
+                strictEqual(
+                    eval(processScript('iframe.contentDocument.location.hash')),
+                    nativeIframe.contentDocument.location.hash,
+                    'hash property in iframe with "' + iframeSrcAttribute + '" src attribute'
+                );
+                strictEqual(
+                    eval(processScript('iframe.contentDocument.location.search')),
+                    nativeIframe.contentDocument.location.search,
+                    'search property in iframe with "' + iframeSrcAttribute + '" src attribute'
+                );
+                strictEqual(
+                    eval(processScript('iframe.contentDocument.location.origin')),
+                    nativeIframe.contentDocument.location.origin,
+                    'origin property in iframe with "' + iframeSrcAttribute + '" src attribute'
+                );
+        });
     }
 
     return createTestIframe()

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -143,12 +143,14 @@ test('location object of iframe with empty src should have properties with corre
 
         const nativeIframe = nativeMethods.createElement.call(iframe.contentDocument, 'iframe');
 
-        nativeMethods.setAttribute.call(nativeIframe, 'src', iframeSrcAttribute);
+        if (iframeSrcAttribute)
+            nativeMethods.setAttribute.call(nativeIframe, 'src', iframeSrcAttribute);
+
         nativeMethods.appendChild.call(iframe.contentDocument.body, nativeIframe);
 
         return window.QUnitGlobals.waitForIframe(nativeIframe)
             .then(function () {
-                iframe.contentWindow.eval('window["%hammerhead%"].get("./utils/destination-location").forceLocation(null);');
+                iframe.contentWindow['%hammerhead%'].get('./utils/destination-location').forceLocation(null);
 
                 strictEqual(
                     eval(processScript('iframe.contentDocument.location.protocol')),

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -190,7 +190,7 @@ test('location object of iframe with empty src should have properties with corre
                     nativeIframe.contentDocument.location.origin,
                     'origin property in iframe with "' + iframeSrcAttribute + '" src attribute'
                 );
-        });
+            });
     }
 
     return createTestIframe()

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -183,14 +183,11 @@ test('location object of iframe with empty src should have properties with corre
             nativeIframe.contentDocument.location.search,
             'search property in iframe with "' + iframeSrcAttribute + '" src attribute'
         );
-        /*
-        NOTE: it's temporary disabled
         strictEqual(
             eval(processScript('iframe.contentDocument.location.origin')),
             nativeIframe.contentDocument.location.origin,
             'origin property in iframe with "' + iframeSrcAttribute + '" src attribute'
         );
-        */
     }
 
     return createTestIframe()

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -137,6 +137,74 @@ test('iframe with empty src', function () {
         .then(assert);
 });
 
+test('location object of iframe with empty src should have properties with correct values', function () {
+    function assert (iframe) {
+        const iframeSrcAttribute = iframe.getAttribute('src');
+
+        const nativeIframe = nativeMethods.createElement.call(iframe.contentDocument, 'iframe');
+
+        nativeMethods.setAttribute.call(nativeIframe, 'src', iframeSrcAttribute);
+        nativeMethods.appendChild.call(iframe.contentDocument.body, nativeIframe);
+
+        iframe.contentWindow.eval('window["%hammerhead%"].get("./utils/destination-location").forceLocation(null);');
+
+        strictEqual(
+            eval(processScript('iframe.contentDocument.location.protocol')),
+            nativeIframe.contentDocument.location.protocol,
+            'protocol property in iframe with "' + iframeSrcAttribute + '" src attribute'
+        );
+        strictEqual(
+            eval(processScript('iframe.contentDocument.location.port')),
+            nativeIframe.contentDocument.location.port,
+            'port property in iframe with "' + iframeSrcAttribute + '" src attribute'
+        );
+        strictEqual(
+            eval(processScript('iframe.contentDocument.location.host')),
+            nativeIframe.contentDocument.location.host,
+            'host property in iframe with "' + iframeSrcAttribute + '" src attribute'
+        );
+        strictEqual(
+            eval(processScript('iframe.contentDocument.location.hostname')),
+            nativeIframe.contentDocument.location.hostname,
+            'hostname property in iframe with "' + iframeSrcAttribute + '" src attribute'
+        );
+        strictEqual(
+            eval(processScript('iframe.contentDocument.location.pathname')),
+            nativeIframe.contentDocument.location.pathname,
+            'pathname property in iframe with "' + iframeSrcAttribute + '" src attribute'
+        );
+        strictEqual(
+            eval(processScript('iframe.contentDocument.location.hash')),
+            nativeIframe.contentDocument.location.hash,
+            'hash property in iframe with "' + iframeSrcAttribute + '" src attribute'
+        );
+        strictEqual(
+            eval(processScript('iframe.contentDocument.location.search')),
+            nativeIframe.contentDocument.location.search,
+            'search property in iframe with "' + iframeSrcAttribute + '" src attribute'
+        );
+        /*
+        NOTE: it's temporary disabled
+        strictEqual(
+            eval(processScript('iframe.contentDocument.location.origin')),
+            nativeIframe.contentDocument.location.origin,
+            'origin property in iframe with "' + iframeSrcAttribute + '" src attribute'
+        );
+        */
+    }
+
+    return createTestIframe()
+        .then(assert)
+        .then(function () {
+            return createTestIframe({ src: '' });
+        })
+        .then(assert)
+        .then(function () {
+            return createTestIframe({ src: 'about:blank' });
+        })
+        .then(assert);
+});
+
 // NOTE: Only Chrome raises the 'load' event for iframes with 'javascript:' src and creates a window instance.
 if (browserUtils.isWebKit) {
     test('iframe with "javascript:" src', function () {


### PR DESCRIPTION
## Purpose
As described by @AndreyBelym in #2383:
> Hammerhead creates an incorrect location wrapper when accessing an iframe without src

It is also reproducible in iframes with either empty or `about:blank` src attribute's value.

## Approach
WIP

## References
Closes #2383

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
