### PR TITLE
Fix document.title processing for iframes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "17.1.19",
+  "version": "17.1.20",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/processing/resources/page.ts
+++ b/src/processing/resources/page.ts
@@ -111,12 +111,15 @@ class PageProcessor extends ResourceProcessorBase {
     }
 
     private static _getTaskScriptNodeIndex (head: ASTNode, ctx: RequestPipelineContext): number {
-        const taskScriptUrl = ctx.resolveInjectableUrl(SERVICE_ROUTES.task);
+        const taskScriptUrls = [
+            ctx.resolveInjectableUrl(SERVICE_ROUTES.task),
+            ctx.resolveInjectableUrl(SERVICE_ROUTES.iframeTask)
+        ];
 
         return parse5Utils.findNodeIndex(head, node => {
             return node.tagName === 'script' &&
                 !!node.attrs.find(attr => attr.name === 'class' && attr.value === SHADOW_UI_CLASSNAME.script) &&
-                !!node.attrs.find(attr => attr.name === 'src' && attr.value === taskScriptUrl);
+                !!node.attrs.find(attr => attr.name === 'src' && taskScriptUrls.includes(attr.value));
         });
     }
 


### PR DESCRIPTION
Changes:
* fix insertion order for the `addPageOriginFirstTitleParsedScript` self removing script in iframes
* proxy `document.title` only for top window.
* tests [here](https://github.com/DevExpress/testcafe/pull/5578)