### PR TITLE
Fix the 'document.body' shadow UI state in TestCafe

### DIFF
--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -11,7 +11,7 @@ import { stopPropagation } from '../utils/event';
 import { getNativeQuerySelectorAll } from '../utils/query-selector';
 import HTMLCollectionWrapper from './node/live-node-list/html-collection-wrapper';
 import { getElementsByNameReturnsHTMLCollection } from '../utils/feature-detection';
-import { isIE } from '../utils/browser';
+import { isIE, isChrome } from '../utils/browser';
 import { DocumentCleanedEvent } from '../../typings/client';
 import NodeMutation from './node/mutation';
 import MessageSandbox from './event/message';
@@ -391,6 +391,10 @@ export default class ShadowUI extends SandboxBase {
     }
 
     getRoot () {
+        // GH-2418
+        if (isChrome && !ShadowUI.isShadowContainer(this.document.body))
+            this._markShadowUIContainerAndCollections(this.document.body);
+
         if (!this.root || /* NOTE: T225944 */ !this.document.body.contains(this.root)) {
             if (!this.root) {
                 // NOTE: B254893
@@ -415,10 +419,6 @@ export default class ShadowUI extends SandboxBase {
             else
                 nativeMethods.appendChild.call(this.document.body, this.root);
         }
-
-        // GH-2418
-        if (!ShadowUI.isShadowContainer(this.document.body))
-            this._markShadowUIContainerAndCollections(this.document.body);
 
         return this.root;
     }

--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -416,6 +416,10 @@ export default class ShadowUI extends SandboxBase {
                 nativeMethods.appendChild.call(this.document.body, this.root);
         }
 
+        // GH-2418
+        if (!ShadowUI.isShadowContainer(this.document.body))
+            this._markShadowUIContainerAndCollections(this.document.body);
+
         return this.root;
     }
 


### PR DESCRIPTION
Fix https://github.com/DevExpress/testcafe-hammerhead/issues/2418

Test: https://github.com/DevExpress/testcafe/pull/5630

### (`body === null`) native Chrome example (use `http-server`)
**./index.html**:
```html
<!DOCTYPE html>
<html>
<head>
    <title>Title</title>

    <script language="javascript" type="text/javascript">
        function init()
        {
            setTimeout(load, 50);
        }

        function load()
        {
            var httpRequest = new XMLHttpRequest();
            var url         = "mainform.html";

            httpRequest.open("GET", encodeURI(url), false);
            httpRequest.setRequestHeader("Content-Type", "text/html; charset=utf-8");
            httpRequest.setRequestHeader("Accept", "text/html");
            httpRequest.send("");

            var html = httpRequest.responseText;

            var doc = document;
            doc.open("text/html", "replace");
            doc.write(html);
            doc.close();
            console.log('document.body:', document.body);
            debugger; // body is null
        }
    </script>
</head>
<body onload="init();">
</body>
</html>

```

**./mainform.html**:
```html
<!DOCTYPE html>
<html>
<head>
    <title>Title</title>
    <!--Comment one of the below elements to avoid "body === null" after document.close()-->
    <link href="some-style.css" rel="stylesheet" type="text/css" />
    <script language="JavaScript"  type="text/javascript">
    </script>
</head>
<body class="main-form" tabindex="1">
</body>
</html>

```

