### PR TITLE
Fix the issues that appeared after merging #2448

### DIFF
--- a/src/client/sandbox/code-instrumentation/location/ancestor-origins-wrapper.ts
+++ b/src/client/sandbox/code-instrumentation/location/ancestor-origins-wrapper.ts
@@ -17,7 +17,7 @@ export default function DOMStringListWrapper (window: Window, getCrossDomainOrig
         const isCrossDomainParent   = parentLocationWrapper === parentWindow.location;
 
         // @ts-ignore
-        updateOrigin(nativeOrigins, this, i.toString(), isCrossDomainParent ? '' : parentWindow.origin); // eslint-disable-line no-restricted-properties
+        updateOrigin(nativeOrigins, this, i.toString(), isCrossDomainParent ? '' : parentLocationWrapper.origin); // eslint-disable-line no-restricted-properties
 
         if (isCrossDomainParent && getCrossDomainOrigin)
             //@ts-ignore

--- a/src/client/sandbox/code-instrumentation/location/ancestor-origins-wrapper.ts
+++ b/src/client/sandbox/code-instrumentation/location/ancestor-origins-wrapper.ts
@@ -17,7 +17,7 @@ export default function DOMStringListWrapper (window: Window, getCrossDomainOrig
         const isCrossDomainParent   = parentLocationWrapper === parentWindow.location;
 
         // @ts-ignore
-        updateOrigin(nativeOrigins, this, i.toString(), isCrossDomainParent ? '' : parentLocationWrapper.origin); // eslint-disable-line no-restricted-properties
+        updateOrigin(nativeOrigins, this, i.toString(), isCrossDomainParent ? '' : parentWindow.origin); // eslint-disable-line no-restricted-properties
 
         if (isCrossDomainParent && getCrossDomainOrigin)
             //@ts-ignore

--- a/src/client/sandbox/code-instrumentation/location/wrapper.ts
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.ts
@@ -185,12 +185,11 @@ export default class LocationWrapper {
         const createLocationPropertyDesc = (property, nativePropSetter) => {
             locationProps[property] = createOverriddenDescriptor(locationPropsOwner, property, {
                 getter: () => {
-                    const frameElement = domUtils.getFrameElement(window);
+                    const frameElement       = domUtils.getFrameElement(window);
+                    const inIframeWithoutSrc = frameElement && domUtils.isIframeWithoutSrc(frameElement);
+                    const parsedDestLocation = inIframeWithoutSrc ? window.location : getParsedDestLocation();
 
-                    if (frameElement && domUtils.isIframeWithoutSrc(frameElement))
-                        return nativeMethods.contentDocumentGetter.call(frameElement).location[property]; // eslint-disable-line no-restricted-properties
-
-                    return getParsedDestLocation()[property];
+                    return parsedDestLocation[property];
                 },
                 setter: value => {
                     const newLocation = changeDestUrlPart(window.location.toString(), nativePropSetter, value, resourceType);

--- a/src/client/sandbox/code-instrumentation/location/wrapper.ts
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.ts
@@ -135,16 +135,7 @@ export default class LocationWrapper {
 
         // eslint-disable-next-line no-restricted-properties
         locationProps.origin = createOverriddenDescriptor(locationPropsOwner, 'origin', {
-            getter: () => {
-                const frameElement = domUtils.getFrameElement(window);
-
-                if (frameElement && domUtils.isIframeWithoutSrc(frameElement))
-                    return nativeMethods.contentDocumentGetter.call(frameElement).location.origin; // eslint-disable-line no-restricted-properties
-
-                const parsedDestLocation = getParsedDestLocation();
-
-                return getDomain(parsedDestLocation);
-            },
+            getter: () => getDomain(getParsedDestLocation()),
             setter: origin => origin
         });
 

--- a/src/client/sandbox/code-instrumentation/location/wrapper.ts
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.ts
@@ -1,7 +1,6 @@
 import {
     get as getDestLocation,
-    getParsed as getParsedDestLocation,
-    inIframeWithourSrc
+    getParsed as getParsedDestLocation
 } from '../../../utils/destination-location';
 import {
     getProxyUrl,
@@ -17,9 +16,9 @@ import {
     sameOriginCheck,
     ensureTrailingSlash,
     prepareUrl,
-    SPECIAL_BLANK_PAGE,
-    ORIGIN_IN_IFRAME_WITHOUT_SRC_IN_IE
+    SPECIAL_BLANK_PAGE
 } from '../../../../utils/url';
+import * as domUtils from '../../../utils/dom';
 import nativeMethods from '../../native-methods';
 import urlResolver from '../../../utils/url-resolver';
 import DomProcessor from '../../../../processing/dom';
@@ -27,7 +26,6 @@ import DOMStringListWrapper from './ancestor-origins-wrapper';
 import IntegerIdGenerator from '../../../utils/integer-id-generator';
 import { createOverriddenDescriptor } from '../../../utils/overriding';
 import MessageSandbox from '../../event/message';
-import { isIE } from '../../../utils/browser';
 
 const GET_ORIGIN_CMD      = 'hammerhead|command|get-origin';
 const ORIGIN_RECEIVED_CMD = 'hammerhead|command|origin-received';
@@ -138,13 +136,12 @@ export default class LocationWrapper {
         // eslint-disable-next-line no-restricted-properties
         locationProps.origin = createOverriddenDescriptor(locationPropsOwner, 'origin', {
             getter: () => {
-                if (inIframeWithourSrc() && isIE)
-                    return ORIGIN_IN_IFRAME_WITHOUT_SRC_IN_IE;
+                const frameElement = domUtils.getFrameElement(window);
+
+                if (frameElement && domUtils.isIframeWithoutSrc(frameElement))
+                    return nativeMethods.contentDocumentGetter.call(frameElement).location.origin; // eslint-disable-line no-restricted-properties
 
                 const parsedDestLocation = getParsedDestLocation();
-
-                if (parsedDestLocation.origin) // eslint-disable-line no-restricted-properties
-                    return parsedDestLocation.origin; // eslint-disable-line no-restricted-properties
 
                 return getDomain(parsedDestLocation);
             },
@@ -196,7 +193,14 @@ export default class LocationWrapper {
 
         const createLocationPropertyDesc = (property, nativePropSetter) => {
             locationProps[property] = createOverriddenDescriptor(locationPropsOwner, property, {
-                getter: () => getParsedDestLocation()[property],
+                getter: () => {
+                    const frameElement = domUtils.getFrameElement(window);
+
+                    if (frameElement && domUtils.isIframeWithoutSrc(frameElement))
+                        return nativeMethods.contentDocumentGetter.call(frameElement).location[property]; // eslint-disable-line no-restricted-properties
+
+                    return getParsedDestLocation()[property];
+                },
                 setter: value => {
                     const newLocation = changeDestUrlPart(window.location.toString(), nativePropSetter, value, resourceType);
 

--- a/src/client/utils/destination-location.ts
+++ b/src/client/utils/destination-location.ts
@@ -13,7 +13,7 @@ export function getLocation (): string {
     if (forcedLocation)
         return forcedLocation;
 
-    const globalCtx = getGlobalContextInfo().global;
+    const globalCtx    = getGlobalContextInfo().global;
     const frameElement = domUtils.getFrameElement(globalCtx);
 
     // NOTE: Fallback to the owner page's URL if we are in an iframe without src.

--- a/src/client/utils/overriding.ts
+++ b/src/client/utils/overriding.ts
@@ -69,7 +69,8 @@ function overrideFunctionName (fn: Function, name: string): void {
 
 function overrideToString (nativeFnWrapper: Function, nativeFn: Function): void {
     nativeMethods.objectDefineProperty(nativeFnWrapper, INTERNAL_PROPS.nativeStrRepresentation, {
-        value: nativeMethods.Function.prototype.toString.call(nativeFn)
+        value: nativeMethods.Function.prototype.toString.call(nativeFn),
+        configurable: true
     });
 }
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -24,8 +24,6 @@ export const TRAILING_SLASH_RE                                = /\/$/;
 export const SPECIAL_BLANK_PAGE                               = 'about:blank';
 export const SPECIAL_ERROR_PAGE                               = 'about:error';
 export const SPECIAL_PAGES                                    = [SPECIAL_BLANK_PAGE, SPECIAL_ERROR_PAGE];
-export const PATHNAME_IN_IFRAME_WITHOUT_SRC_IN_FIREFOX        = 'blank';
-export const ORIGIN_IN_IFRAME_WITHOUT_SRC_IN_IE               = 'about://';
 
 export const HTTP_DEFAULT_PORT  = '80';
 export const HTTPS_DEFAULT_PORT = '443';

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -187,11 +187,6 @@ test('location object of iframe with empty src should have properties with corre
                     nativeIframe.contentDocument.location.search,
                     'search property in iframe with "' + iframeSrcAttribute + '" src attribute'
                 );
-                strictEqual(
-                    eval(processScript('iframe.contentDocument.location.origin')),
-                    nativeIframe.contentDocument.location.origin,
-                    'origin property in iframe with "' + iframeSrcAttribute + '" src attribute'
-                );
             });
     }
 


### PR DESCRIPTION
## Purpose
Fix the issues introduced in #2448 and #2433 

## Approach
* Revert changes in the `destination-location.ts` file (because functions from this file are used in many places in the code). 
* Separate handling of the location object properties of the "about:blank" document in `LocationWrapper`
* <s>Instead of calling the location "origin" getter, call the active document's origin when processing "ancestorOrigins". According to the [specification](https://www.w3.org/TR/2017/WD-html52-20170228/browsers.html#ancestor-origins-array):
> 5. Append the Unicode serialization of current’s active document’s origin to output as a new value.</s>
* remove handling of the `origin` property because it's causes different problems
* set `configurable: true` to the native str representation property in order to avoid "TypeError: Attempting to change value of a readonly property" in iOS (discovered in testcafe client mobile tests)
## References
#2448 
#2433

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
