### PR TITLE
Fix 'document.title' getting for iframe without src in Firefox, bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "17.1.22",
+  "version": "17.1.23",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/client/sandbox/iframe.ts
+++ b/src/client/sandbox/iframe.ts
@@ -31,7 +31,7 @@ export default class IframeSandbox extends SandboxBase {
         this.iframeNativeMethodsBackup = null;
     }
 
-    private _shouldSaveIframeNativeMethods (iframe: HTMLIFrameElement | HTMLFrameElement) {
+    private _shouldSaveIframeNativeMethods (iframe: HTMLIFrameElement | HTMLFrameElement): boolean {
         if (!isWebKit)
             return false;
 

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -28,12 +28,12 @@ export default class DocumentSandbox extends SandboxBase {
         this.documentWriter = null;
     }
 
-    static forceProxySrcForImageIfNecessary (element) {
+    static forceProxySrcForImageIfNecessary (element: HTMLElement): void {
         if (isImgElement(element) && settings.get().forceProxySrcForImage)
             element[INTERNAL_PROPS.forceProxySrcForImage] = true;
     }
 
-    private static _isDocumentInDesignMode (doc) {
+    private static _isDocumentInDesignMode (doc: HTMLDocument): boolean {
         return doc.designMode === 'on';
     }
 
@@ -115,7 +115,7 @@ export default class DocumentSandbox extends SandboxBase {
         return result;
     }
 
-    attach (window, document) {
+    attach (window, document, partialInitializationForNotLoadedIframe = false) {
         if (this._needToUpdateDocumentWriter(window, document)) {
             this.documentWriter = new DocumentWriter(window, document);
 
@@ -315,7 +315,7 @@ export default class DocumentSandbox extends SandboxBase {
             }
         });
 
-        if (this._documentTitleStorageInitializer) {
+        if (this._documentTitleStorageInitializer && !partialInitializationForNotLoadedIframe) {
             overrideDescriptor(docPrototype, 'title', {
                 getter: function () {
                     return documentSandbox._documentTitleStorageInitializer.storage.getTitle();

--- a/src/client/sandbox/node/index.ts
+++ b/src/client/sandbox/node/index.ts
@@ -148,7 +148,7 @@ export default class NodeSandbox extends SandboxBase {
             contentWindow[INTERNAL_PROPS.iframeNativeMethods] = iframeNativeMethods;
 
             // NOTE: Override only the document (in fact, we only need the 'write' and 'writeln' methods).
-            this.doc.attach(contentWindow, contentDocument);
+            this.doc.attach(contentWindow, contentDocument, true);
         });
 
         // NOTE: In Google Chrome, iframes whose src contains html code raise the 'load' event twice.


### PR DESCRIPTION
Changes:
* add the `partialInitializationForNotLoadedIframe` parameter for `DocumentSandbox`.
* few more strict typings