### PR TITLE
Configure request timeouts

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,23 +1,25 @@
-const babel          = require('@babel/core');
-const gulpBabel      = require('gulp-babel');
-const gulpTypeScript = require('gulp-typescript');
-const del            = require('del');
-const eslint         = require('gulp-eslint');
-const fs             = require('fs');
-const gulp           = require('gulp');
-const gulpStep       = require('gulp-step');
-const qunitHarness   = require('gulp-qunit-harness');
-const mocha          = require('gulp-mocha-simple');
-const mustache       = require('gulp-mustache');
-const rename         = require('gulp-rename');
-const webmake        = require('@belym.a.2105/gulp-webmake');
-const uglify         = require('gulp-uglify');
-const util           = require('gulp-util');
-const ll             = require('gulp-ll-next');
-const gulpRunCommand = require('gulp-run-command').default;
-const clone          = require('gulp-clone');
-const mergeStreams   = require('merge-stream');
-const path           = require('path');
+const babel                 = require('@babel/core');
+const gulpBabel             = require('gulp-babel');
+const gulpTypeScript        = require('gulp-typescript');
+const del                   = require('del');
+const eslint                = require('gulp-eslint');
+const fs                    = require('fs');
+const gulp                  = require('gulp');
+const gulpStep              = require('gulp-step');
+const qunitHarness          = require('gulp-qunit-harness');
+const mocha                 = require('gulp-mocha-simple');
+const mustache              = require('gulp-mustache');
+const rename                = require('gulp-rename');
+const webmake               = require('@belym.a.2105/gulp-webmake');
+const uglify                = require('gulp-uglify');
+const ll                    = require('gulp-ll-next');
+const gulpRunCommand        = require('gulp-run-command').default;
+const clone                 = require('gulp-clone');
+const mergeStreams          = require('merge-stream');
+const path                  = require('path');
+const getClientTestSettings = require('./gulp/utils/get-client-test-settings');
+const hang                  = require('./gulp/utils/hang');
+const SAUCELABS_SETTINGS    = require('./gulp/saucelabs-settings');
 
 gulpStep.install();
 
@@ -29,87 +31,7 @@ ll
         'client-scripts-bundle'
     ]);
 
-const getClientTestSettings = () => {
-    return {
-        basePath:        './test/client/fixtures',
-        port:            2000,
-        crossDomainPort: 2001,
-        scripts:         [
-            { src: '/hammerhead.js', path: util.env.dev ? './lib/client/hammerhead.js' : './lib/client/hammerhead.min.js' },
-            { src: '/before-test.js', path: './test/client/before-test.js' }
-        ],
-
-        configApp: require('./test/client/config-qunit-server-app')
-    };
-};
-
 const USE_STRICT_RE = /^(['"])use strict\1;?/;
-
-const CLIENT_TESTS_BROWSERS = [
-    {
-        platform:    'Windows 10',
-        browserName: 'MicrosoftEdge'
-    },
-    {
-        platform:    'Windows 10',
-        browserName: 'chrome'
-    },
-    {
-        platform:    'Windows 10',
-        browserName: 'firefox'
-    },
-    {
-        platform:    'Windows 10',
-        browserName: 'internet explorer',
-        version:     '11.0'
-    },
-    {
-        browserName: 'safari',
-        platform:    'macOS 10.14',
-        version:     '12.0'
-    },
-    {
-        browserName: 'safari',
-        platform:    'macOS 10.15',
-        version:     'latest'
-    },
-    {
-        browserName:     'Safari',
-        deviceName:      'iPhone 7 Plus Simulator',
-        platformVersion: '11.3',
-        platformName:    'iOS'
-    },
-    {
-        deviceName:      'Android GoogleAPI Emulator',
-        browserName:     'Chrome',
-        platformVersion: '7.1',
-        platformName:    'Android'
-    },
-    {
-        browserName: 'chrome',
-        platform:    'OS X 10.11'
-    },
-    {
-        browserName: 'firefox',
-        platform:    'OS X 10.11'
-    }
-];
-
-const SAUCELABS_SETTINGS = {
-    username:  process.env.SAUCE_USERNAME,
-    accessKey: process.env.SAUCE_ACCESS_KEY,
-    build:     process.env.TRAVIS_JOB_ID || '',
-    tags:      [process.env.TRAVIS_BRANCH || 'master'],
-    browsers:  CLIENT_TESTS_BROWSERS,
-    name:      'testcafe-hammerhead client tests',
-    timeout:   360
-};
-
-function hang () {
-    return new Promise(() => {
-        // NOTE: Hang forever.
-    });
-}
 
 // Build
 gulp.task('clean-lib', () => {
@@ -219,6 +141,7 @@ gulp.step('lint-js', () => {
         .src([
             './test/server/**/*.js',
             './test/client/fixtures/**/*.js',
+            './gulp/**/*.js',
             'Gulpfile.js',
             '!./test/server/data/**/*.js'
         ])

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -12,6 +12,7 @@ const mustache              = require('gulp-mustache');
 const rename                = require('gulp-rename');
 const webmake               = require('@belym.a.2105/gulp-webmake');
 const uglify                = require('gulp-uglify');
+const util                  = require('gulp-util');
 const ll                    = require('gulp-ll-next');
 const gulpRunCommand        = require('gulp-run-command').default;
 const clone                 = require('gulp-clone');

--- a/gulp/saucelabs-settings.js
+++ b/gulp/saucelabs-settings.js
@@ -1,0 +1,61 @@
+const CLIENT_TESTS_BROWSERS = [
+    {
+        platform:    'Windows 10',
+        browserName: 'MicrosoftEdge'
+    },
+    {
+        platform:    'Windows 10',
+        browserName: 'chrome'
+    },
+    {
+        platform:    'Windows 10',
+        browserName: 'firefox'
+    },
+    {
+        platform:    'Windows 10',
+        browserName: 'internet explorer',
+        version:     '11.0'
+    },
+    {
+        browserName: 'safari',
+        platform:    'macOS 10.14',
+        version:     '12.0'
+    },
+    {
+        browserName: 'safari',
+        platform:    'macOS 10.15',
+        version:     'latest'
+    },
+    {
+        browserName:     'Safari',
+        deviceName:      'iPhone 7 Plus Simulator',
+        platformVersion: '11.3',
+        platformName:    'iOS'
+    },
+    {
+        deviceName:      'Android GoogleAPI Emulator',
+        browserName:     'Chrome',
+        platformVersion: '7.1',
+        platformName:    'Android'
+    },
+    {
+        browserName: 'chrome',
+        platform:    'OS X 10.11'
+    },
+    {
+        browserName: 'firefox',
+        platform:    'OS X 10.11'
+    }
+];
+
+const SAUCELABS_SETTINGS = {
+    username:  process.env.SAUCE_USERNAME,
+    accessKey: process.env.SAUCE_ACCESS_KEY,
+    build:     process.env.TRAVIS_JOB_ID || '',
+    tags:      [process.env.TRAVIS_BRANCH || 'master'],
+    browsers:  CLIENT_TESTS_BROWSERS,
+    name:      'testcafe-hammerhead client tests',
+    timeout:   360
+};
+
+module.exports = SAUCELABS_SETTINGS;

--- a/gulp/utils/get-client-test-settings.js
+++ b/gulp/utils/get-client-test-settings.js
@@ -10,6 +10,6 @@ module.exports = function getClientTestSettings () {
             { src: '/before-test.js', path: './test/client/before-test.js' }
         ],
 
-        configApp: require('./test/client/config-qunit-server-app')
+        configApp: require('../../test/client/config-qunit-server-app')
     };
 };

--- a/gulp/utils/get-client-test-settings.js
+++ b/gulp/utils/get-client-test-settings.js
@@ -1,0 +1,15 @@
+const util = require('gulp-util');
+
+module.exports = function getClientTestSettings () {
+    return {
+        basePath:        './test/client/fixtures',
+        port:            2000,
+        crossDomainPort: 2001,
+        scripts:         [
+            { src: '/hammerhead.js', path: util.env.dev ? './lib/client/hammerhead.js' : './lib/client/hammerhead.min.js' },
+            { src: '/before-test.js', path: './test/client/before-test.js' }
+        ],
+
+        configApp: require('./test/client/config-qunit-server-app')
+    };
+};

--- a/gulp/utils/hang.js
+++ b/gulp/utils/hang.js
@@ -1,0 +1,5 @@
+module.exports = function hang () {
+    return new Promise(() => {
+        // NOTE: Hang forever.
+    });
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "17.1.26",
+  "version": "18.0.0",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/processing/resources/page.ts
+++ b/src/processing/resources/page.ts
@@ -202,7 +202,7 @@ class PageProcessor extends ResourceProcessorBase {
             urlReplacer(resourceUrl, resourceType, charsetAttrValue, baseUrl, isCrossDomain);
 
         domProcessor.forceProxySrcForImage = ctx.session.hasRequestEventListeners();
-        domProcessor.allowMultipleWindows  = ctx.session.allowMultipleWindows;
+        domProcessor.allowMultipleWindows  = ctx.session.options.allowMultipleWindows;
 
         parse5Utils.walkElements(root, el => domProcessor.processElement(el, replacer));
 

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -2,7 +2,13 @@ import net from 'net';
 import Session from '../session';
 import { ExternalProxySettingsRaw } from '../typings/session';
 import Router from './router';
-import { StaticContent, ServiceMessage, ServerInfo } from '../typings/proxy';
+import {
+    StaticContent,
+    ServiceMessage,
+    ServerInfo,
+    ProxyOptions
+} from '../typings/proxy';
+
 import http from 'http';
 import https from 'https';
 import * as urlUtils from '../utils/url';
@@ -51,7 +57,7 @@ export default class Proxy extends Router {
     // https://github.com/nodejs/node/commit/186035243fad247e3955fa0c202987cae99e82db#diff-1d0d420098503156cddb601e523b82e7R59
     public static MAX_REQUEST_HEADER_SIZE = 80 * 1024;
 
-    constructor (hostname: string, port1: number, port2: number, options: any = {}) {
+    constructor (hostname: string, port1: number, port2: number, options: ProxyOptions = {}) {
         super(options);
 
         const { ssl, developmentMode } = options;
@@ -226,7 +232,7 @@ export default class Proxy extends Router {
             proxyPort:     this.server1Info.port.toString(),
             proxyProtocol: this.server1Info.protocol,
             sessionId:     session.id,
-            windowId:      session.windowId
+            windowId:      session.options.windowId
         });
     }
 

--- a/src/proxy/router.ts
+++ b/src/proxy/router.ts
@@ -1,7 +1,7 @@
 import net from 'net';
 import http from 'http';
 import { respondStatic } from '../utils/http';
-import { StaticContent, ServerInfo } from '../typings/proxy';
+import { StaticContent, ServerInfo, RouterOptions } from '../typings/proxy';
 import md5 from 'crypto-md5';
 import { getPathname } from '../utils/url';
 import { isEqual } from 'lodash';
@@ -31,7 +31,7 @@ export default abstract class Router {
     private readonly routes: Map<string, Route> = new Map();
     private readonly routesWithParams: RouteWithParams[] = [];
 
-    protected constructor (options = {}) {
+    protected constructor (options: RouterOptions = {}) {
         this.options = options;
     }
 

--- a/src/request-pipeline/context.ts
+++ b/src/request-pipeline/context.ts
@@ -388,7 +388,7 @@ export default class RequestPipelineContext {
         const headers = headerTransforms.forResponse(this);
         const res     = this.res as http.ServerResponse;
 
-        if (this.isHTMLPage && this.session.disablePageCaching)
+        if (this.isHTMLPage && this.session.options.disablePageCaching)
             headerTransforms.setupPreventCachingHeaders(headers);
 
         logger.proxy('Proxy response %s %d %j', this.requestId, this.destRes.statusCode, headers);

--- a/src/request-pipeline/destination-request/default-request-timeout.ts
+++ b/src/request-pipeline/destination-request/default-request-timeout.ts
@@ -1,0 +1,7 @@
+const DEFAULT_REQUEST_TIMEOUT = {
+    ajax: 2 * 60 * 1000,
+    page: 25 * 1000
+};
+
+export default DEFAULT_REQUEST_TIMEOUT;
+

--- a/src/request-pipeline/request-options.ts
+++ b/src/request-pipeline/request-options.ts
@@ -5,6 +5,7 @@ import BUILTIN_HEADERS from './builtin-header-names';
 import * as headerTransforms from './header-transforms';
 import { inject as injectUpload } from '../upload';
 import matchUrl from 'match-url-wildcard';
+import { RequestTimeout } from '../typings/proxy';
 
 export default class RequestOptions {
     url: string;
@@ -25,6 +26,7 @@ export default class RequestOptions {
     agent?: any;
     ecdhCurve?: string;
     rejectUnauthorized?: boolean;
+    requestTimeout: RequestTimeout;
 
     constructor (ctx: RequestPipelineContext) {
         const bodyWithUploads = injectUpload(ctx.req.headers[BUILTIN_HEADERS.contentType] as string, ctx.reqBody);
@@ -37,25 +39,26 @@ export default class RequestOptions {
         const headers = headerTransforms.forRequest(ctx);
         const proxy   = ctx.session.externalProxySettings;
 
-        this.url         = ctx.dest.url;
-        this.protocol    = ctx.dest.protocol;
-        this.hostname    = ctx.dest.hostname;
-        this.host        = ctx.dest.host;
-        this.port        = ctx.dest.port;
-        this.path        = ctx.dest.partAfterHost;
-        this.auth        = ctx.dest.auth;
-        this.method      = ctx.req.method;
-        this.credentials = ctx.session.getAuthCredentials();
-        this.body        = ctx.reqBody;
-        this.isAjax      = ctx.isAjax;
-        this.rawHeaders  = ctx.req.rawHeaders;
-        this.headers     = headers;
-        this.requestId   = ctx.requestId;
+        this.url            = ctx.dest.url;
+        this.protocol       = ctx.dest.protocol;
+        this.hostname       = ctx.dest.hostname;
+        this.host           = ctx.dest.host;
+        this.port           = ctx.dest.port;
+        this.path           = ctx.dest.partAfterHost;
+        this.auth           = ctx.dest.auth;
+        this.method         = ctx.req.method;
+        this.credentials    = ctx.session.getAuthCredentials();
+        this.body           = ctx.reqBody;
+        this.isAjax         = ctx.isAjax;
+        this.rawHeaders     = ctx.req.rawHeaders;
+        this.headers        = headers;
+        this.requestId      = ctx.requestId;
+        this.requestTimeout = ctx.session.options.requestTimeout;
 
         this._applyExternalProxySettings(proxy, ctx, headers);
     }
 
-    _applyExternalProxySettings (proxy, ctx: RequestPipelineContext, headers: IncomingHttpHeaders): void {
+    private _applyExternalProxySettings (proxy, ctx: RequestPipelineContext, headers: IncomingHttpHeaders): void {
         if (!proxy || matchUrl(ctx.dest.url, proxy.bypassRules))
             return;
 

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -100,11 +100,13 @@ export default abstract class Session extends EventEmitter {
         this.options       = this._getOptions(options);
     }
 
-    private _getOptions (options: Partial<SessionOptions>): SessionOptions {
-        const requestTimeout = Object.assign({}, DEFAULT_REQUEST_TIMEOUT, (options || {}).requestTimeout);
+    private _getOptions (options: Partial<SessionOptions> = {}): SessionOptions {
+        const requestTimeout = {
+            page: options.requestTimeout && options.requestTimeout.page || DEFAULT_REQUEST_TIMEOUT.page,
+            ajax: options.requestTimeout && options.requestTimeout.ajax || DEFAULT_REQUEST_TIMEOUT.ajax,
+        };
 
-        if (options && options.requestTimeout)
-            delete options.requestTimeout;
+        delete options.requestTimeout;
 
         return Object.assign({
             disablePageCaching:   false,
@@ -307,10 +309,6 @@ export default abstract class Session extends EventEmitter {
 
     setRecordMode(): void {
         this._recordMode = true;
-    }
-
-    setRequestTimeout (requestTimeout: RequestTimeout): void {
-        this.options.requestTimeout = requestTimeout;
     }
 
     abstract async getIframePayloadScript (iframeWithoutSrc: boolean): Promise<string>;

--- a/src/typings/proxy.d.ts
+++ b/src/typings/proxy.d.ts
@@ -20,3 +20,17 @@ export interface StaticContent {
     etag?: string;
     isShadowUIStylesheet?: boolean;
 }
+
+interface RouterOptions {
+    staticContentCaching?: object;
+}
+
+interface RequestTimeout {
+    page?: number;
+    ajax?: number;
+}
+
+interface ProxyOptions extends RouterOptions {
+    ssl?: object;
+    developmentMode?: boolean;
+}

--- a/test/playground/create-session.js
+++ b/test/playground/create-session.js
@@ -2,21 +2,23 @@ const Session          = require('../../lib/session');
 const generateUniqueId = require('../../lib/utils/generate-unique-id');
 
 function createSession () {
-    const session = new Session(['test/playground/upload-storage']);
+    const opts = {
+        allowMultipleWindows: !!global.process.env.allowMultipleWindows
+    };
+
+    if (opts.allowMultipleWindows)
+        opts.windowId = generateUniqueId();
+
+    const session = new Session(['test/playground/upload-storage'], opts);
 
     session.getIframePayloadScript = async () => '';
     session.getPayloadScript       = async () => '';
     session.getAuthCredentials      = () => ({});
     session.handleFileDownload      = () => void 0;
     session.handlePageError         = (ctx, err) => {
-        console.log(ctx.req.url);
-        console.log(err);
+        console.error(ctx.req.url);
+        console.error(err);
     };
-
-    session.allowMultipleWindows = !!global.process.env.allowMultipleWindows;
-
-    if (session.allowMultipleWindows)
-        session.windowId = generateUniqueId();
 
     return session;
 }

--- a/test/server/auth-test.js
+++ b/test/server/auth-test.js
@@ -1,22 +1,21 @@
-const expect       = require('chai').expect;
-const express      = require('express');
-const ntlm         = require('express-ntlm');
-const auth         = require('basic-auth');
-const request      = require('request-promise-native');
-const Proxy        = require('../../lib/proxy');
-const Session      = require('../../lib/session');
+const expect  = require('chai').expect;
+const express = require('express');
+const ntlm    = require('express-ntlm');
+const auth    = require('basic-auth');
+const request = require('request-promise-native');
+
+const {
+    createProxy,
+    createSession
+} = require('./common/utils');
 
 describe('Authentication', () => {
     let proxy   = null;
     let session = null;
 
     beforeEach(() => {
-        session = new Session();
-
-        session.getAuthCredentials = () => null;
-        session.handleFileDownload = () => void 0;
-
-        proxy = new Proxy('127.0.0.1', 1836, 1837);
+        session = createSession();
+        proxy   = createProxy();
     });
 
     afterEach(() => {

--- a/test/server/charset-test.js
+++ b/test/server/charset-test.js
@@ -53,7 +53,8 @@ describe('Content charset', () => {
         const requestPipelineContextMock = {
             dest:    {},
             session: {
-                hasRequestEventListeners: () => false
+                hasRequestEventListeners: () => false,
+                options:                  { allowMultipleWindows: false }
             },
             serverInfo: {
                 crossDomainPort: 1338
@@ -173,7 +174,8 @@ describe('Content charset', () => {
             const requestPipelineContextMock = {
                 dest:    {},
                 session: {
-                    hasRequestEventListeners: () => false
+                    hasRequestEventListeners: () => false,
+                    options:                  { allowMultipleWindows: false }
                 },
                 serverInfo: {
                     crossDomainPort: 1338

--- a/test/server/common/constants.js
+++ b/test/server/common/constants.js
@@ -4,6 +4,7 @@ const SAME_DOMAIN_SERVER_PORT   = 2000;
 const CROSS_DOMAIN_SERVER_PORT  = 2002;
 const PROXY_PORT_1              = 1836;
 const PROXY_PORT_2              = 1837;
+const SAME_DOMAIN_SERVER_HOST   = `${PROXY_HOSTNAME}:${SAME_DOMAIN_SERVER_PORT}`;
 
 const TEST_OBJ = {
     prop1: 'value1',
@@ -20,6 +21,7 @@ module.exports = {
     SAME_DOMAIN_SERVER_PORT,
     CROSS_DOMAIN_SERVER_PORT,
     TEST_OBJ,
-    EMPTY_PAGE_MARKUP
+    EMPTY_PAGE_MARKUP,
+    SAME_DOMAIN_SERVER_HOST
 };
 

--- a/test/server/common/utils.js
+++ b/test/server/common/utils.js
@@ -9,10 +9,11 @@ const Proxy              = require('../../../lib/proxy');
 const {
     PROXY_HOSTNAME,
     PROXY_PORT_1,
-    PROXY_PORT_2
+    PROXY_PORT_2,
+    SAME_DOMAIN_SERVER_PORT
 } = require('./constants');
 
-exports.createDestinationServer = function (port) {
+exports.createDestinationServer = function (port = SAME_DOMAIN_SERVER_PORT) {
     const app    = express();
     const server = app.listen(port);
 
@@ -24,11 +25,7 @@ exports.createSession = function (parameters) {
         windowId: '12345'
     };
 
-    const session = new Session();
-
-    Object.entries(parameters).forEach(([key, value]) => {
-        session[key] = value;
-    });
+    const session = new Session('/test-upload-root', parameters);
 
     session.getAuthCredentials = () => null;
     session.handleFileDownload = () => void 0;
@@ -66,7 +63,7 @@ exports.getProxyUrl = function (url, resourceType, reqOrigin, isCrossDomain = fa
         proxyHostname: PROXY_HOSTNAME,
         proxyPort:     isCrossDomain ? PROXY_PORT_2 : PROXY_PORT_1,
         sessionId:     urlSession.id,
-        windowId:      urlSession.windowId,
+        windowId:      urlSession.options.windowId,
 
         resourceType, reqOrigin
     });

--- a/test/server/proxy/file-protocol-test.js
+++ b/test/server/proxy/file-protocol-test.js
@@ -3,11 +3,11 @@ const {
     createProxy,
     getFileProtocolUrl,
     compareCode
-} = require('./utils');
+} = require('../common/utils');
 
 const {
     PAGE_ACCEPT_HEADER
-} = require('./constants');
+} = require('../common/constants');
 
 const request    = require('request-promise-native');
 const fs         = require('fs');

--- a/test/server/proxy/https-test.js
+++ b/test/server/proxy/https-test.js
@@ -8,12 +8,11 @@ const {
     createProxy,
     compareCode,
     createDestinationServer
-} = require('./utils');
+} = require('../common/utils');
 
 const {
-    PAGE_ACCEPT_HEADER,
-    SAME_DOMAIN_SERVER_PORT
-} = require('./constants');
+    PAGE_ACCEPT_HEADER
+} = require('../common/constants');
 
 describe('https proxy', () => {
     let session    = null;
@@ -21,7 +20,7 @@ describe('https proxy', () => {
     let destServer = null;
 
     before(() => {
-        const sameDomainDestinationServer = createDestinationServer(SAME_DOMAIN_SERVER_PORT);
+        const sameDomainDestinationServer = createDestinationServer();
         const { app }                     = sameDomainDestinationServer;
 
         destServer = sameDomainDestinationServer.server;

--- a/test/server/proxy/index-test.js
+++ b/test/server/proxy/index-test.js
@@ -593,11 +593,6 @@ describe('Proxy', () => {
             expect(sessionWithDefaultParameters.options.requestTimeout.page).eql(25000);
             expect(sessionWithDefaultParameters.options.requestTimeout.ajax).eql(120000);
 
-            sessionWithDefaultParameters.setRequestTimeout({ page: 1, ajax: 2 });
-
-            expect(sessionWithDefaultParameters.options.requestTimeout.page).eql(1);
-            expect(sessionWithDefaultParameters.options.requestTimeout.ajax).eql(2);
-
             const sessionWithSpecifiedPageTimeout = new Session('/upload-root-folder', {
                 requestTimeout: { page: 100 }
             });
@@ -611,6 +606,16 @@ describe('Proxy', () => {
 
             expect(sessionWithSpecifiedBothTimeouts.options.requestTimeout.page).eql(100);
             expect(sessionWithSpecifiedBothTimeouts.options.requestTimeout.ajax).eql(200);
+
+            const sessionWithUndefinedTimeouts = new Session('/upload-root-folder', {
+                requestTimeout: {
+                    page: void 0,
+                    ajax: void 0
+                }
+            });
+
+            expect(sessionWithUndefinedTimeouts.options.requestTimeout.page).eql(25000);
+            expect(sessionWithUndefinedTimeouts.options.requestTimeout.ajax).eql(120000);
         });
     });
 

--- a/test/server/proxy/regression-test.js
+++ b/test/server/proxy/regression-test.js
@@ -750,7 +750,7 @@ describe('Regression', () => {
             requestTimeout: { page: 100 }
         });
 
-        destReq.on('error', () => noop);
+        destReq.on('error', noop);
         destReq.on('fatalError', () => {
             fatalErrorEventCount++;
         });

--- a/test/server/proxy/request-hooks-test.js
+++ b/test/server/proxy/request-hooks-test.js
@@ -6,9 +6,8 @@ const request           = require('request-promise-native');
 
 const {
     TEST_OBJ,
-    PAGE_ACCEPT_HEADER,
-    SAME_DOMAIN_SERVER_PORT
-} = require('./constants');
+    PAGE_ACCEPT_HEADER
+} = require('../common/constants');
 
 const SAME_ORIGIN_CHECK_FAILED_STATUS_CODE = require('../../../lib/request-pipeline/xhr/same-origin-check-failed-status-code');
 const INTERNAL_HEADERS                     = require('../../../lib/request-pipeline/internal-header-names');
@@ -20,7 +19,7 @@ const {
     compareCode,
     normalizeNewLine,
     createDestinationServer
-} = require('./utils');
+} = require('../common/utils');
 
 describe('Request Hooks', () => {
     let session    = null;
@@ -28,7 +27,7 @@ describe('Request Hooks', () => {
     let destServer = null;
 
     before(() => {
-        const sameDomainDestinationServer = createDestinationServer(SAME_DOMAIN_SERVER_PORT);
+        const sameDomainDestinationServer = createDestinationServer();
         const { app }                     = sameDomainDestinationServer;
 
         destServer = sameDomainDestinationServer.server;

--- a/test/server/proxy/web-socket-test.js
+++ b/test/server/proxy/web-socket-test.js
@@ -8,14 +8,14 @@ const {
     getProxyUrl: getBasicProxyUrl,
     createSession,
     createProxy
-} = require('./utils');
+} = require('../common/utils');
 
-const promisifyEvent              = require('promisify-event');
-const { expect }                  = require('chai');
-const { SAME_DOMAIN_SERVER_PORT } = require('./constants');
+const promisifyEvent = require('promisify-event');
+const { expect }     = require('chai');
 
 describe('WebSocket', () => {
     let session     = null;
+    let destServer  = null;
     let proxy       = null;
     let httpsServer = null;
     let wsServer    = null;
@@ -26,14 +26,16 @@ describe('WebSocket', () => {
     }
 
     before(() => {
-        const sameDomainDestinationServer = createDestinationServer(SAME_DOMAIN_SERVER_PORT);
+        const sameDomainDestinationServer = createDestinationServer();
+
+        destServer = sameDomainDestinationServer.server;
 
         httpsServer = https.createServer({
             key:  selfSignedCertificate.key,
             cert: selfSignedCertificate.cert
         }, () => void 0).listen(2001);
         wsServer    = new WebSocket.Server({
-            server: sameDomainDestinationServer.server,
+            server: destServer,
             path:   '/web-socket'
         });
         wssServer   = new WebSocket.Server({
@@ -57,6 +59,7 @@ describe('WebSocket', () => {
     });
 
     after(() => {
+        destServer.close();
         wsServer.close();
         wssServer.close();
         httpsServer.close();


### PR DESCRIPTION
Changes:
* configure destination request timeouts
* move `allowMultipleWindows`, `windowId`, and `disablePageCaching` to session parameters.
* move utils and settings code from the `Gulpfile.js`
* refactorings