### PR TITLE
Fixed storages not updating after the 'beforeunload' event

### DIFF
--- a/src/client/sandbox/event/unload.ts
+++ b/src/client/sandbox/event/unload.ts
@@ -107,9 +107,7 @@ export default class UnloadSandbox extends SandboxBase {
     }
 
     private _setEventListenerWrapper (eventProperties: EventProperties) {
-        this._listeners.setEventListenerWrapper(window, [eventProperties.nativeEventName], (e, listener) => {
-            this._createEventHandler(eventProperties)(e, listener)
-        });
+        this._listeners.setEventListenerWrapper(window, [eventProperties.nativeEventName], this._createEventHandler(eventProperties));
     }
 
     private _addEventListener (eventProperties: EventProperties) {

--- a/src/client/sandbox/event/unload.ts
+++ b/src/client/sandbox/event/unload.ts
@@ -18,7 +18,6 @@ export default class UnloadSandbox extends SandboxBase {
     BEFORE_UNLOAD_EVENT: string = 'hammerhead|event|before-unload';
     BEFORE_BEFORE_UNLOAD_EVENT: string = 'hammerhead|event|before-before-unload';
     UNLOAD_EVENT: string = 'hammerhead|event|unload';
-    NATIVE_UNLOAD_EVENT: string = 'unload';
 
     beforeUnloadProperties: EventProperties;
     unloadProperties: EventProperties;
@@ -39,7 +38,7 @@ export default class UnloadSandbox extends SandboxBase {
             storedReturnValue: '',
             prevented:         false,
             storedHandler:     null,
-            nativeEventName:   this.NATIVE_UNLOAD_EVENT,
+            nativeEventName:   'unload',
             eventName:         this.UNLOAD_EVENT,
             eventPropSetter:   nativeMethods.winOnUnloadSetter
         };

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -222,6 +222,7 @@ class NativeMethods {
     linkIntegritySetter: any;
     isEventPropsLocatedInProto: boolean;
     winOnBeforeUnloadSetter: any;
+    winOnUnloadSetter: any;
     winOnPageHideSetter: any;
     winOnMessageSetter: any;
     winOnErrorSetter: any;
@@ -585,12 +586,14 @@ class NativeMethods {
         const eventPropsOwner = this.isEventPropsLocatedInProto ? winProto : win;
 
         const winOnBeforeUnloadDescriptor = win.Object.getOwnPropertyDescriptor(eventPropsOwner, 'onbeforeunload');
+        const winOnUnloadDescriptor       = win.Object.getOwnPropertyDescriptor(eventPropsOwner, 'onunload');
         const winOnPageHideDescriptor     = win.Object.getOwnPropertyDescriptor(eventPropsOwner, 'onpagehide');
         const winOnMessageDescriptor      = win.Object.getOwnPropertyDescriptor(eventPropsOwner, 'onmessage');
         const winOnErrorDescriptor        = win.Object.getOwnPropertyDescriptor(eventPropsOwner, 'onerror');
         const winOnHashChangeDescriptor   = win.Object.getOwnPropertyDescriptor(eventPropsOwner, 'onhashchange');
 
         this.winOnBeforeUnloadSetter = winOnBeforeUnloadDescriptor && winOnBeforeUnloadDescriptor.set;
+        this.winOnUnloadSetter       = winOnUnloadDescriptor && winOnUnloadDescriptor.set;
         this.winOnPageHideSetter     = winOnPageHideDescriptor && winOnPageHideDescriptor.set;
         this.winOnMessageSetter      = winOnMessageDescriptor && winOnMessageDescriptor.set;
         this.winOnErrorSetter        = winOnErrorDescriptor && winOnErrorDescriptor.set;

--- a/src/client/sandbox/storages/index.ts
+++ b/src/client/sandbox/storages/index.ts
@@ -12,8 +12,6 @@ import Listeners from '../event/listeners';
 import UnloadSandbox from '../event/unload';
 import EventSimulator from '../event/simulator';
 
-const STORAGE_ACCESS_DENIED_ERROR_CODE = 18;
-
 export default class StorageSandbox extends SandboxBase {
     localStorageWrapper: StorageWrapper;
     sessionStorageWrapper: StorageWrapper;
@@ -67,15 +65,9 @@ export default class StorageSandbox extends SandboxBase {
             this.sessionStorageWrapper = new StorageWrapper(this.window, this.nativeMethods.winSessionStorageGetter.call(this.window), storageKey);
 
             const saveToNativeStorages = () => {
-                try {
-                    if (!this.isLocked) {
-                        this.localStorageWrapper.saveToNativeStorage();
-                        this.sessionStorageWrapper.saveToNativeStorage();
-                    }
-                }
-                catch (e) {
-                    if (e.code !== STORAGE_ACCESS_DENIED_ERROR_CODE)
-                        throw e;
+                if (!this.isLocked) {
+                    this.localStorageWrapper.saveToNativeStorage();
+                    this.sessionStorageWrapper.saveToNativeStorage();
                 }
             };
 

--- a/src/client/sandbox/storages/index.ts
+++ b/src/client/sandbox/storages/index.ts
@@ -71,7 +71,6 @@ export default class StorageSandbox extends SandboxBase {
                 }
             };
 
-            this._unloadSandbox.on(this._unloadSandbox.BEFORE_UNLOAD_EVENT, saveToNativeStorages);
             this._unloadSandbox.on(this._unloadSandbox.UNLOAD_EVENT, saveToNativeStorages);
 
             // NOTE: In some case, a browser does not emit the onBeforeUnload event and we need manually watch navigation (GH-1999).

--- a/test/client/data/storages/update-storages-on-unload.html
+++ b/test/client/data/storages/update-storages-on-unload.html
@@ -14,7 +14,7 @@
         window.sessionStorage.setItem('item', 'value');
         window.localStorage.setItem('item', 'value');
 
-        window.addEventListener('unload', () => {
+        window.addEventListener('unload', function () {
             window.sessionStorage.removeItem('item');
             window.localStorage.removeItem('item');
         });

--- a/test/client/data/storages/update-storages-on-unload.html
+++ b/test/client/data/storages/update-storages-on-unload.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script src="/hammerhead.js" class="script-hammerhead-shadow-ui"></script>
+    <script type="text/javascript">
+        var hammerhead  = window['%hammerhead%'];
+
+        // NOTE: clear the native storages before hammerhead is initialized
+        sessionStorage.clear();
+        localStorage.clear();
+
+        hammerhead.start({});
+
+        window.sessionStorage.setItem('item', 'value');
+        window.localStorage.setItem('item', 'value');
+
+        window.addEventListener('unload', () => {
+            window.sessionStorage.removeItem('item');
+            window.localStorage.removeItem('item');
+        });
+    </script>
+</body>
+</html>

--- a/test/client/data/storages/update-storages-on-unload.html
+++ b/test/client/data/storages/update-storages-on-unload.html
@@ -9,6 +9,7 @@
         sessionStorage.clear();
         localStorage.clear();
 
+        hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
         hammerhead.start({});
 
         window.sessionStorage.setItem('item', 'value');

--- a/test/client/data/storages/update-storages-result.html
+++ b/test/client/data/storages/update-storages-result.html
@@ -8,22 +8,11 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
+    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({});
 
     var INSTRUCTION    = hammerhead.get('../processing/script/instruction');
     var getPostMessage = window[INSTRUCTION.getPostMessage];
-
-    const loadStorage = function (storage) {
-        const KEY_IDX       = 0;
-        const VALUE_IDX     = 1;
-        const parsedStorage = JSON.parse(storage.nativeStorage['hammerhead|storage-wrapper|undefined|example.com'] || '[[],[]]');
-
-        for (let i = 0; i < parsedStorage[KEY_IDX].length; i++)
-            storage[parsedStorage[KEY_IDX][i]] = parsedStorage[VALUE_IDX][i];
-    };
-
-    loadStorage(sessionStorage);
-    loadStorage(localStorage);
 
     getPostMessage(top).call(top, '.', '.');
 </script>

--- a/test/client/data/storages/update-storages-result.html
+++ b/test/client/data/storages/update-storages-result.html
@@ -13,7 +13,7 @@
     var INSTRUCTION    = hammerhead.get('../processing/script/instruction');
     var getPostMessage = window[INSTRUCTION.getPostMessage];
 
-    const loadStorage = (storage) => {
+    const loadStorage = function (storage) {
         const KEY_IDX       = 0;
         const VALUE_IDX     = 1;
         const parsedStorage = JSON.parse(storage.nativeStorage['hammerhead|storage-wrapper|undefined|example.com'] || '[[],[]]');

--- a/test/client/data/storages/update-storages-result.html
+++ b/test/client/data/storages/update-storages-result.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="/hammerhead.js" class="script-hammerhead-shadow-ui"></script>
+</head>
+<body>
+<script type="text/javascript">
+    var hammerhead = window['%hammerhead%'];
+
+    hammerhead.start({});
+
+    var INSTRUCTION    = hammerhead.get('../processing/script/instruction');
+    var getPostMessage = window[INSTRUCTION.getPostMessage];
+
+    const loadStorage = (storage) => {
+        const KEY_IDX       = 0;
+        const VALUE_IDX     = 1;
+        const parsedStorage = JSON.parse(storage.nativeStorage['hammerhead|storage-wrapper|undefined|example.com'] || '[[],[]]');
+
+        for (let i = 0; i < parsedStorage[KEY_IDX].length; i++)
+            storage[parsedStorage[KEY_IDX][i]] = parsedStorage[VALUE_IDX][i];
+    };
+
+    loadStorage(sessionStorage);
+    loadStorage(localStorage);
+
+    getPostMessage(top).call(top, '.', '.');
+</script>
+</body>
+</html>

--- a/test/client/data/storages/update-storages-result.html
+++ b/test/client/data/storages/update-storages-result.html
@@ -8,7 +8,6 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({});
 
     var INSTRUCTION    = hammerhead.get('../processing/script/instruction');

--- a/test/client/fixtures/sandbox/event/unload-test.js
+++ b/test/client/fixtures/sandbox/event/unload-test.js
@@ -1,13 +1,13 @@
 var browserUtils = hammerhead.utils.browser;
 
-asyncTest('BEFORE_UNLOAD_EVENT must be called last (GH-400)', function () {
+asyncTest('UNLOAD_EVENT must be called last (GH-400)', function () {
     createTestIframe({ src: getSameDomainPageUrl('../../../data/unload/iframe.html') })
         .then(function (iframe) {
             var iframeWindow       = iframe.contentWindow;
             var unloadSandbox      = iframeWindow['%hammerhead%'].sandbox.event.unload;
             var uploadEventCounter = 0;
 
-            unloadSandbox.on(unloadSandbox.BEFORE_UNLOAD_EVENT, function () {
+            unloadSandbox.on(unloadSandbox.UNLOAD_EVENT, function () {
                 // NOTE: Removing an iframe on executing the beforeUnload
                 // handler occasionally causes problems with SourceLab
                 window.setTimeout(function () {
@@ -17,13 +17,13 @@ asyncTest('BEFORE_UNLOAD_EVENT must be called last (GH-400)', function () {
                 }, 0);
             });
 
-            iframeWindow.addEventListener(unloadSandbox.beforeUnloadEventName, function () {
+            iframeWindow.addEventListener(unloadSandbox.NATIVE_UNLOAD_EVENT, function () {
                 uploadEventCounter++;
             });
 
-            var beforeUnloadEventName = 'on' + unloadSandbox.beforeUnloadEventName;
+            var unloadEventName = 'on' + unloadSandbox.NATIVE_UNLOAD_EVENT;
 
-            iframeWindow[beforeUnloadEventName] = function () {
+            iframeWindow[unloadEventName] = function () {
                 uploadEventCounter++;
             };
 

--- a/test/client/fixtures/sandbox/event/unload-test.js
+++ b/test/client/fixtures/sandbox/event/unload-test.js
@@ -17,13 +17,11 @@ asyncTest('UNLOAD_EVENT must be called last (GH-400)', function () {
                 }, 0);
             });
 
-            iframeWindow.addEventListener(unloadSandbox.NATIVE_UNLOAD_EVENT, function () {
+            iframeWindow.addEventListener('unload', function () {
                 uploadEventCounter++;
             });
 
-            var unloadEventName = 'on' + unloadSandbox.NATIVE_UNLOAD_EVENT;
-
-            iframeWindow[unloadEventName] = function () {
+            iframeWindow['onunload'] = function () {
                 uploadEventCounter++;
             };
 

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -583,7 +583,7 @@ if (browserUtils.isChrome) {
 }
 
 test('window.onbeforeunload', function () {
-    var evName = 'on' + unloadSandbox.beforeUnloadEventName;
+    var evName = 'on' + unloadSandbox.beforeUnloadProperties.nativeEventName;
 
     strictEqual(window[evName], null);
 

--- a/test/client/fixtures/sandbox/storages-test.js
+++ b/test/client/fixtures/sandbox/storages-test.js
@@ -248,7 +248,7 @@ test('storages save their state on the beforeunload event', function () {
     ok(!nativeSessionStorage[storageWrapperKey]);
 
     // NOTE: Simulate page leaving
-    hammerhead.sandbox.event.unload._emitBeforeUnloadEvent();
+    hammerhead.sandbox.event.unload._emitEvent(hammerhead.sandbox.event.unload.beforeUnloadProperties);
 
     strictEqual(nativeLocalStorage[storageWrapperKey], JSON.stringify([['key1'], ['value1']]));
     strictEqual(nativeSessionStorage[storageWrapperKey], JSON.stringify([['key2'], ['value2']]));
@@ -399,5 +399,29 @@ test('localStorage should be saved after location.replace (GH-1999)', function (
         })
         .then(function () {
             strictEqual(event.data, 'data');
+        });
+});
+
+test('Storages are saved on the unload event (GH-4834)', function () {
+    var event = null;
+
+    window.addEventListener('message', function (e) {
+        event = e;
+    });
+
+    return createTestIframe({ src: getSameDomainPageUrl('../../data/storages/update-storages-on-unload.html') })
+        .then(function () {
+            strictEqual(this[0].sessionStorage.getItem('item'), 'value');
+            strictEqual(this[0].localStorage.getItem('item'), 'value');
+
+            this[0].location.href = getSameDomainPageUrl('../../data/storages/update-storages-result.html');
+
+            return window.QUnitGlobals.wait(function () {
+                return event !== null;
+            });
+        })
+        .then(function () {
+            strictEqual(this[0].sessionStorage.getItem('item'), null);
+            strictEqual(this[0].localStorage.getItem('item'), null);
         });
 });

--- a/test/client/fixtures/sandbox/storages-test.js
+++ b/test/client/fixtures/sandbox/storages-test.js
@@ -403,25 +403,28 @@ test('localStorage should be saved after location.replace (GH-1999)', function (
 });
 
 test('Storages are saved on the unload event (GH-4834)', function () {
-    var event = null;
+    var event        = null;
+    var iframeWindow = null;
 
     window.addEventListener('message', function (e) {
         event = e;
     });
 
     return createTestIframe({ src: getSameDomainPageUrl('../../data/storages/update-storages-on-unload.html') })
-        .then(function () {
-            strictEqual(this[0].sessionStorage.getItem('item'), 'value');
-            strictEqual(this[0].localStorage.getItem('item'), 'value');
+        .then(function (iframe) {
+            iframeWindow = iframe.contentWindow;
 
-            this[0].location.href = getSameDomainPageUrl('../../data/storages/update-storages-result.html');
+            strictEqual(iframeWindow.sessionStorage.getItem('item'), 'value');
+            strictEqual(iframeWindow.localStorage.getItem('item'), 'value');
+
+            iframeWindow.location.href = getSameDomainPageUrl('../../data/storages/update-storages-result.html');
 
             return window.QUnitGlobals.wait(function () {
                 return event !== null;
             });
         })
         .then(function () {
-            strictEqual(this[0].sessionStorage.getItem('item'), null);
-            strictEqual(this[0].localStorage.getItem('item'), null);
+            strictEqual(iframeWindow.sessionStorage.getItem('item'), null);
+            strictEqual(iframeWindow.localStorage.getItem('item'), null);
         });
 });

--- a/test/client/fixtures/sandbox/storages-test.js
+++ b/test/client/fixtures/sandbox/storages-test.js
@@ -11,6 +11,10 @@ var storageWrapperKey = 'hammerhead|storage-wrapper|' + settings.get().sessionId
 var nativeLocalStorage   = nativeMethods.winLocalStorageGetter.call(window);
 var nativeSessionStorage = nativeMethods.winSessionStorageGetter.call(window);
 
+// NOTE: Removes the last 'hammerhead|event|unload' listener (() => dispose())
+// so that tests don't crash when 'hammerhead|event|unload' is emitted
+storageSandbox._unloadSandbox.eventsListeners[storageSandbox._unloadSandbox.UNLOAD_EVENT].pop();
+
 QUnit.testStart(function () {
     // NOTE: Clean up storage wrappers
     nativeLocalStorage.clear();
@@ -46,7 +50,7 @@ test('clear', function () {
     strictEqual(nativeLocalStorage.getItem(localStorage.nativeStorageKey), null);
     strictEqual(nativeSessionStorage.getItem(sessionStorage.nativeStorageKey), null);
 
-    storageSandbox._unloadSandbox.emit(storageSandbox._unloadSandbox.BEFORE_UNLOAD_EVENT);
+    storageSandbox._unloadSandbox.emit(storageSandbox._unloadSandbox.UNLOAD_EVENT);
 
     strictEqual(nativeLocalStorage.getItem(localStorage.nativeStorageKey), '[["key11"],["value1"]]');
     strictEqual(nativeSessionStorage.getItem(sessionStorage.nativeStorageKey), '[["key12"],["value2"]]');
@@ -69,7 +73,7 @@ test('lock', function () {
     strictEqual(nativeSessionStorage.getItem(sessionStorage.nativeStorageKey), null);
 
     storageSandbox.lock();
-    storageSandbox._unloadSandbox.emit(storageSandbox._unloadSandbox.BEFORE_UNLOAD_EVENT);
+    storageSandbox._unloadSandbox.emit(storageSandbox._unloadSandbox.UNLOAD_EVENT);
 
     strictEqual(nativeLocalStorage.getItem(localStorage.nativeStorageKey), null);
     strictEqual(nativeSessionStorage.getItem(sessionStorage.nativeStorageKey), null);
@@ -240,7 +244,7 @@ test('storages load their state from native', function () {
     strictEqual(sessionSandboxWrapper.key2, 'value2');
 });
 
-test('storages save their state on the beforeunload event', function () {
+test('storages save their state on the unload event', function () {
     localStorage.key1   = 'value1';
     sessionStorage.key2 = 'value2';
 
@@ -248,7 +252,7 @@ test('storages save their state on the beforeunload event', function () {
     ok(!nativeSessionStorage[storageWrapperKey]);
 
     // NOTE: Simulate page leaving
-    hammerhead.sandbox.event.unload._emitEvent(hammerhead.sandbox.event.unload.beforeUnloadProperties);
+    hammerhead.sandbox.event.unload._emitEvent(hammerhead.sandbox.event.unload.unloadProperties);
 
     strictEqual(nativeLocalStorage[storageWrapperKey], JSON.stringify([['key1'], ['value1']]));
     strictEqual(nativeSessionStorage[storageWrapperKey], JSON.stringify([['key2'], ['value2']]));


### PR DESCRIPTION
## Purpose
Storage wrappers (for localStorage and sessionStorage) don't save changes in native storages if these changes take place after the `beforeunload` event. This means that changes that are applied between the `beforeunload` event and the moment the page is closed are discarded and won't be available after the redirect.

This caused an issue with the [msal](https://github.com/AzureAD/microsoft-authentication-library-for-js) library, which uses redirects for authentication and partially clears the sessionStorage between the `beforeunload` and `unload` events. These changes don't persist after redirecting to another page.

## Approach
I added another `saveToNativeStorages` [call](https://github.com/DevExpress/testcafe-hammerhead/compare/master...Ogurecher:msal-fix?expand=1#diff-1940e681e6c3016afc363e9745e22663444618fb5c3f02a14d57085886a9129fR83), which triggers on the `unload` event. In order to do that, I used the methods from [UnloadSandbox](https://github.com/DevExpress/testcafe-hammerhead/compare/master...Ogurecher:msal-fix?expand=1#diff-57d4b3422c7cd2243c2ec8626614685b5a30cad759278196b03ad3777114c5dcR17) class (and refactored them to be usable with events aside from `beforeunload`).

I had to modify some existing tests:
 - [unload-test](https://github.com/DevExpress/testcafe-hammerhead/compare/master...Ogurecher:msal-fix?expand=1#diff-b70d500509337b7e372d85574ab26a152f12c6e300f32b94811d09312fbc0980R3)
 - [attributes-test](https://github.com/DevExpress/testcafe-hammerhead/compare/master...Ogurecher:msal-fix?expand=1#diff-e4f92f4c8ea3d6fdb41dc09e18a2ad235e37b4ebc2d759d61ca5905f50c1df04R586)
 - [storage-test](https://github.com/DevExpress/testcafe-hammerhead/compare/master...Ogurecher:msal-fix?expand=1#diff-349214aaaa75be2700bed887d7c48c44ce73dd06d2aaad91e12ecd4145040d56R251)

In my opinion, we don't need to update storages on the `beforeunload` event anymore, but removing [the listener](https://github.com/DevExpress/testcafe-hammerhead/compare/master...Ogurecher:msal-fix?expand=1#diff-1940e681e6c3016afc363e9745e22663444618fb5c3f02a14d57085886a9129fL74) makes some existing tests fail (they are mostly hard-coded to check the `beforeunload` event). Please let me know your thoughts on this.

## References
Closes https://github.com/DevExpress/testcafe/issues/4834

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
