### PR TITLE
fix: remove error instance assumption on property access

### DIFF
--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -153,7 +153,7 @@ export default class Proxy extends Router {
             catch (err) {
                 logger.serviceMsg('Service message %j, error %o', msg, err);
 
-                respond500(res, err.toString());
+                respond500(res, (err && err.toString) ? err.toString() : "");
             }
         }
         else


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose

Correct invalid assumption that `err` is guaranteed to be an `Error` instance.

## Approach

- only call toString if it exists

## References

https://github.com/DevExpress/testcafe-hammerhead/issues/2480

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
