### PR TITLE
Fix `It takes too much time to process a large css file on a certain website` (closes #2475)

### DIFF
--- a/src/processing/style.ts
+++ b/src/processing/style.ts
@@ -22,12 +22,9 @@ class StyleProcessor {
     STYLESHEET_PROCESSING_START_COMMENT: string = STYLESHEET_PROCESSING_START_COMMENT;
     STYLESHEET_PROCESSING_END_COMMENT: string = STYLESHEET_PROCESSING_END_COMMENT;
 
-    process (css: string, urlReplacer: Function, shouldIncludeProcessingComment?: boolean): string {
-        if (!css || typeof css !== 'string' || shouldIncludeProcessingComment && IS_STYLE_SHEET_PROCESSED_RE.test(css))
+    process (css: string, urlReplacer: Function, shouldIncludeProcessingComments?: boolean): string {
+        if (!css || typeof css !== 'string' || shouldIncludeProcessingComments && IS_STYLE_SHEET_PROCESSED_RE.test(css))
             return css;
-
-        const prefix  = shouldIncludeProcessingComment ? STYLESHEET_PROCESSING_START_COMMENT + '\n' : '';
-        const postfix = shouldIncludeProcessingComment ? '\n' + STYLESHEET_PROCESSING_END_COMMENT : '';
 
         // NOTE: Replace the :hover pseudo-class.
         css = css.replace(HOVER_PSEUDO_CLASS_RE, '[' + INTERNAL_ATTRS.hoverPseudoClass + ']$1');
@@ -36,7 +33,12 @@ class StyleProcessor {
         css = css.replace(SOURCE_MAP_RE, '');
 
         // NOTE: Replace URLs in CSS rules with proxy URLs.
-        return prefix + this._replaceStylsheetUrls(css, urlReplacer) + postfix;
+        css = this._replaceStylsheetUrls(css, urlReplacer);
+
+        if (shouldIncludeProcessingComments)
+            css = `${STYLESHEET_PROCESSING_START_COMMENT}\n${css}\n${STYLESHEET_PROCESSING_END_COMMENT}`;
+
+        return css;
     }
 
     cleanUp (css: string, parseProxyUrl: Function): string {

--- a/src/processing/style.ts
+++ b/src/processing/style.ts
@@ -12,7 +12,7 @@ const SOURCE_MAP_RE                       = /(?:\/\*\s*(?:#|@)\s*sourceMappingUR
 const CSS_URL_PROPERTY_VALUE_PATTERN      = /(url\s*\(\s*)(?:(')([^\s']*)(')|(")([^\s"]*)(")|([^\s)]*))(\s*\))|(@import\s+)(?:(')([^\s']*)(')|(")([^\s"]*)("))/g;
 const STYLESHEET_PROCESSING_START_COMMENT = '/*hammerhead|stylesheet|start*/';
 const STYLESHEET_PROCESSING_END_COMMENT   = '/*hammerhead|stylesheet|end*/';
-const HOVER_PSEUDO_CLASS_RE               = /\s*:\s*hover(\W)/gi;
+const HOVER_PSEUDO_CLASS_RE               = /:\s*hover(\W)/gi;
 const PSEUDO_CLASS_RE                     = new RegExp(`\\[${ INTERNAL_ATTRS.hoverPseudoClass }\\](\\W)`, 'ig');
 const IS_STYLE_SHEET_PROCESSED_RE         = new RegExp(`\\s*${ reEscape(STYLESHEET_PROCESSING_START_COMMENT) }`, 'gi');
 const STYLESHEET_PROCESSING_COMMENTS_RE   = new RegExp(`\\s*${ reEscape(STYLESHEET_PROCESSING_START_COMMENT) }\n?|` +
@@ -22,12 +22,12 @@ class StyleProcessor {
     STYLESHEET_PROCESSING_START_COMMENT: string = STYLESHEET_PROCESSING_START_COMMENT;
     STYLESHEET_PROCESSING_END_COMMENT: string = STYLESHEET_PROCESSING_END_COMMENT;
 
-    process (css: string, urlReplacer: Function, isStylesheetTable?: boolean): string {
-        if (!css || typeof css !== 'string' || IS_STYLE_SHEET_PROCESSED_RE.test(css))
+    process (css: string, urlReplacer: Function, shouldIncludeProcessingComment?: boolean): string {
+        if (!css || typeof css !== 'string' || shouldIncludeProcessingComment && IS_STYLE_SHEET_PROCESSED_RE.test(css))
             return css;
 
-        const prefix  = isStylesheetTable ? STYLESHEET_PROCESSING_START_COMMENT + '\n' : '';
-        const postfix = isStylesheetTable ? '\n' + STYLESHEET_PROCESSING_END_COMMENT : '';
+        const prefix  = shouldIncludeProcessingComment ? STYLESHEET_PROCESSING_START_COMMENT + '\n' : '';
+        const postfix = shouldIncludeProcessingComment ? '\n' + STYLESHEET_PROCESSING_END_COMMENT : '';
 
         // NOTE: Replace the :hover pseudo-class.
         css = css.replace(HOVER_PSEUDO_CLASS_RE, '[' + INTERNAL_ATTRS.hoverPseudoClass + ']$1');

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -252,6 +252,15 @@ describe('Proxy', () => {
             res.end(fs.readFileSync('test/server/data/stylesheet/src.css').toString());
         });
 
+        app.get('/stylesheet-with-many-spaces', (req, res) => {
+            let cssWithManySpaces = '.c{border:1px solid #ffffff;color:#000000}';
+
+            cssWithManySpaces += ' '.repeat(400000);
+            cssWithManySpaces += '.c1{border:1px solid #ffffff;color:#000000}';
+
+            res.end(cssWithManySpaces);
+        });
+
         app.get('/manifest', (req, res) => {
             res.setHeader('content-type', 'text/cache-manifest');
             res.end(fs.readFileSync('test/server/data/manifest/src.manifest')).toString();
@@ -1525,6 +1534,22 @@ describe('Proxy', () => {
                     compareCode(body, expected);
                 });
         });
+
+        it('Should process stylesheets with many spaces in a reasonable time frame (GH-2475)', () => {
+            session.id = 'sessionId';
+
+            const options = {
+                url:     proxy.openSession('http://127.0.0.1:2000/stylesheet-with-many-spaces', session),
+                headers: {
+                    accept: 'text/css'
+                }
+            };
+
+            return request(options)
+                .then(() => {
+                    expect(true).eql(true);
+                });
+        }).timeout(1000);
 
         it('Should process upload info', () => {
             const src      = newLineReplacer(fs.readFileSync('test/server/data/upload/src.formdata'));


### PR DESCRIPTION
#2475

## Changes
1. The `HOVER_PSEUDO_CLASS_RE` regular expression is changed to reduce the processing time.
2. The **unnecessary** `IS_STYLE_SHEET_PROCESSED_RE.test(css)` check is excluded from the CSS file processing case.

### Workaround
We can remove all `/\s{2,}/g` spaces in CSS resources. But it is better not to add any pre-processing procedure. That's why I suggest these changes.

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
