### PR TITLE
Added the strictBindCallApply rule to tsconfig

### DIFF
--- a/src/client/dom-processor/client-dom-adapter.ts
+++ b/src/client/dom-processor/client-dom-adapter.ts
@@ -89,8 +89,8 @@ export default class ClientDomAdapter extends BaseDomAdapter {
         }
     }
 
-    getProxyUrl (): string {
-        return getProxyUrl.apply(null, arguments);
+    getProxyUrl (...args): string {
+        return getProxyUrl.apply(null, args as [string, any?]);
     }
 
     isTopParentIframe (el: HTMLElement): boolean {

--- a/src/client/dom-processor/client-dom-adapter.ts
+++ b/src/client/dom-processor/client-dom-adapter.ts
@@ -89,8 +89,8 @@ export default class ClientDomAdapter extends BaseDomAdapter {
         }
     }
 
-    getProxyUrl (...args): string {
-        return getProxyUrl.apply(null, args as [string, any?]);
+    getProxyUrl (...args: [string, any?]): string {
+        return getProxyUrl.apply(null, args);
     }
 
     isTopParentIframe (el: HTMLElement): boolean {

--- a/src/client/dom-processor/client-dom-adapter.ts
+++ b/src/client/dom-processor/client-dom-adapter.ts
@@ -90,7 +90,7 @@ export default class ClientDomAdapter extends BaseDomAdapter {
     }
 
     getProxyUrl (...args: [string, any?]): string {
-        return getProxyUrl.apply(null, args);
+        return getProxyUrl(...args);
     }
 
     isTopParentIframe (el: HTMLElement): boolean {

--- a/src/client/sandbox/child-window/index.ts
+++ b/src/client/sandbox/child-window/index.ts
@@ -71,7 +71,7 @@ export default class ChildWindowSandbox extends SandboxBase {
         });
     }
 
-    handleWindowOpen (window: Window, args: any[]): Window {
+    handleWindowOpen (window: Window, args: [string?, string?, string?, boolean?]): Window {
         const [url, target, parameters] = args;
 
         if (settings.get().allowMultipleWindows && ChildWindowSandbox._shouldOpenInNewWindow(target, DefaultTarget.windowOpen)) {
@@ -80,7 +80,7 @@ export default class ChildWindowSandbox extends SandboxBase {
             return openedWindowInfo.wnd;
         }
 
-        return nativeMethods.windowOpen.apply(window, args as [string?, string?, string?, boolean?]);
+        return nativeMethods.windowOpen.apply(window, args);
     }
 
     _handleFormSubmitting (window: Window): void {

--- a/src/client/sandbox/child-window/index.ts
+++ b/src/client/sandbox/child-window/index.ts
@@ -80,7 +80,7 @@ export default class ChildWindowSandbox extends SandboxBase {
             return openedWindowInfo.wnd;
         }
 
-        return nativeMethods.windowOpen.apply(window, args);
+        return nativeMethods.windowOpen.apply(window, args as [string?, string?, string?, boolean?]);
     }
 
     _handleFormSubmitting (window: Window): void {

--- a/src/client/sandbox/fetch.ts
+++ b/src/client/sandbox/fetch.ts
@@ -166,9 +166,8 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
                 return sandbox.delayUntilGetSettings(() => this.fetch.apply(this, args));
 
             // NOTE: Safari processed the empty `fetch()` request without `Promise` rejection (GH-1613)
-            if (!args.length && !browserUtils.isSafari) {
+            if (!args.length && !browserUtils.isSafari)
                 return nativeMethods.fetch.apply(this, [] as unknown as [RequestInfo, RequestInit?]);
-            }
 
             try {
                 FetchSandbox._processArguments(args);

--- a/src/client/sandbox/fetch.ts
+++ b/src/client/sandbox/fetch.ts
@@ -102,8 +102,8 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
         return entry;
     }
 
-    static _entriesWrapper (...args) {
-        const iterator   = nativeMethods.headersEntries.apply(this, args as []);
+    static _entriesWrapper (...args: []) {
+        const iterator   = nativeMethods.headersEntries.apply(this, args);
         const nativeNext = iterator.next;
 
         iterator.next = () => FetchSandbox._entriesFilteredNext(iterator, nativeNext);
@@ -111,8 +111,8 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
         return iterator;
     }
 
-    static _valuesWrapper (...args) {
-        const iterator   = nativeMethods.headersEntries.apply(this, args as []);
+    static _valuesWrapper (...args: []) {
+        const iterator   = nativeMethods.headersEntries.apply(this, args);
         const nativeNext = iterator.next;
 
         iterator.next = () => {
@@ -167,7 +167,7 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
 
             // NOTE: Safari processed the empty `fetch()` request without `Promise` rejection (GH-1613)
             if (!args.length && !browserUtils.isSafari)
-                return nativeMethods.fetch.apply(this, [] as unknown as [RequestInfo, RequestInit?]);
+                return nativeMethods.fetch.apply(this, [] as unknown as [RequestInfo]);
 
             try {
                 FetchSandbox._processArguments(args);
@@ -220,7 +220,7 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
 
         overrideFunction(window.Headers.prototype, 'values', FetchSandbox._valuesWrapper);
 
-        overrideFunction(window.Headers.prototype, 'forEach', function (...args) {
+        overrideFunction(window.Headers.prototype, 'forEach', function (...args: [(value: any, name: any, headers: any) => void, any?]) {
             const callback = args[0];
 
             if (typeof callback === 'function') {
@@ -235,45 +235,45 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
                 };
             }
 
-            return nativeMethods.headersForEach.apply(this, args as [() => void, any?]);
+            return nativeMethods.headersForEach.apply(this, args);
         });
 
-        overrideFunction(window.Headers.prototype, 'get', function (...args) {
+        overrideFunction(window.Headers.prototype, 'get', function (...args: [string]) {
             const [headerName] = args;
 
             args[0] = transformHeaderNameToInternal(headerName);
 
-            const result = nativeMethods.headersGet.apply(this, args as [string]);
+            const result = nativeMethods.headersGet.apply(this, args);
 
             if (result === null) {
                 args[0] = headerName;
 
-                return nativeMethods.headersGet.apply(this, args as [string]);
+                return nativeMethods.headersGet.apply(this, args);
             }
 
             return result;
         });
 
-        overrideFunction(window.Headers.prototype, 'has', function (...args) {
+        overrideFunction(window.Headers.prototype, 'has', function (...args: [string]) {
             const [headerName] = args;
 
             args[0] = transformHeaderNameToInternal(headerName);
 
-            const result = nativeMethods.headersHas.apply(this, args as [string]);
+            const result = nativeMethods.headersHas.apply(this, args);
 
             if (!result) {
                 args[0] = headerName;
 
-                return nativeMethods.headersHas.apply(this, args as [string]);
+                return nativeMethods.headersHas.apply(this, args);
             }
 
             return result;
         });
 
-        overrideFunction(window.Headers.prototype, 'set', function (...args) {
+        overrideFunction(window.Headers.prototype, 'set', function (...args: [string, string]) {
             args[0] = transformHeaderNameToInternal(args[0]);
 
-            return nativeMethods.headersSet.apply(this, args as [string, string]);
+            return nativeMethods.headersSet.apply(this, args);
         });
     }
 }

--- a/src/client/sandbox/fetch.ts
+++ b/src/client/sandbox/fetch.ts
@@ -103,7 +103,7 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
     }
 
     static _entriesWrapper (...args) {
-        const iterator   = nativeMethods.headersEntries.apply(this, args);
+        const iterator   = nativeMethods.headersEntries.apply(this, args as []);
         const nativeNext = iterator.next;
 
         iterator.next = () => FetchSandbox._entriesFilteredNext(iterator, nativeNext);
@@ -112,7 +112,7 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
     }
 
     static _valuesWrapper (...args) {
-        const iterator   = nativeMethods.headersEntries.apply(this, args);
+        const iterator   = nativeMethods.headersEntries.apply(this, args as []);
         const nativeNext = iterator.next;
 
         iterator.next = () => {
@@ -166,8 +166,9 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
                 return sandbox.delayUntilGetSettings(() => this.fetch.apply(this, args));
 
             // NOTE: Safari processed the empty `fetch()` request without `Promise` rejection (GH-1613)
-            if (!args.length && !browserUtils.isSafari)
-                return nativeMethods.fetch.apply(this);
+            if (!args.length && !browserUtils.isSafari) {
+                return nativeMethods.fetch.apply(this, [] as unknown as [RequestInfo, RequestInit?]);
+            }
 
             try {
                 FetchSandbox._processArguments(args);
@@ -235,7 +236,7 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
                 };
             }
 
-            return nativeMethods.headersForEach.apply(this, args);
+            return nativeMethods.headersForEach.apply(this, args as [() => void, any?]);
         });
 
         overrideFunction(window.Headers.prototype, 'get', function (...args) {
@@ -243,12 +244,12 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
 
             args[0] = transformHeaderNameToInternal(headerName);
 
-            const result = nativeMethods.headersGet.apply(this, args);
+            const result = nativeMethods.headersGet.apply(this, args as [string]);
 
             if (result === null) {
                 args[0] = headerName;
 
-                return nativeMethods.headersGet.apply(this, args);
+                return nativeMethods.headersGet.apply(this, args as [string]);
             }
 
             return result;
@@ -259,12 +260,12 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
 
             args[0] = transformHeaderNameToInternal(headerName);
 
-            const result = nativeMethods.headersHas.apply(this, args);
+            const result = nativeMethods.headersHas.apply(this, args as [string]);
 
             if (!result) {
                 args[0] = headerName;
 
-                return nativeMethods.headersHas.apply(this, args);
+                return nativeMethods.headersHas.apply(this, args as [string]);
             }
 
             return result;
@@ -273,7 +274,7 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
         overrideFunction(window.Headers.prototype, 'set', function (...args) {
             args[0] = transformHeaderNameToInternal(args[0]);
 
-            return nativeMethods.headersSet.apply(this, args);
+            return nativeMethods.headersSet.apply(this, args as [string, string]);
         });
     }
 }

--- a/src/client/sandbox/fetch.ts
+++ b/src/client/sandbox/fetch.ts
@@ -161,13 +161,13 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
             }
         });
 
-        overrideFunction(window, 'fetch', function (...args: [Request | string, any]) {
+        overrideFunction(window, 'fetch', function (...args: [RequestInfo, RequestInit]) {
             if (sandbox.gettingSettingInProgress())
                 return sandbox.delayUntilGetSettings(() => this.fetch.apply(this, args));
 
             // NOTE: Safari processed the empty `fetch()` request without `Promise` rejection (GH-1613)
             if (!args.length && !browserUtils.isSafari)
-                return nativeMethods.fetch.apply(this, [] as unknown as [RequestInfo]);
+                return nativeMethods.fetch.apply(this, args);
 
             try {
                 FetchSandbox._processArguments(args);

--- a/src/client/sandbox/fetch.ts
+++ b/src/client/sandbox/fetch.ts
@@ -220,7 +220,7 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
 
         overrideFunction(window.Headers.prototype, 'values', FetchSandbox._valuesWrapper);
 
-        overrideFunction(window.Headers.prototype, 'forEach', function (...args: [(value: any, name: any, headers: any) => void, any?]) {
+        overrideFunction(window.Headers.prototype, 'forEach', function (...args: [(value: string, key: string, parent: Headers) => void, any?]) {
             const callback = args[0];
 
             if (typeof callback === 'function') {

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -490,7 +490,7 @@ class NativeMethods {
     refreshElementMeths (doc, win: Window & typeof globalThis) {
         win = win || window as Window & typeof globalThis;
 
-        const createElement = tagName => this.createElement.call(doc || document, tagName);
+        const createElement = (tagName => this.createElement.call(doc || document, tagName)) as Document['createElement'];
         const nativeElement = createElement('div');
 
         const createTextNode = data => this.createTextNode.call(doc || document, data);
@@ -508,9 +508,9 @@ class NativeMethods {
         this.getAttributeNS                = nativeElement.getAttributeNS;
         this.insertAdjacentHTML            = nativeElement.insertAdjacentHTML;
         this.insertBefore                  = nativeElement.insertBefore;
-        this.insertCell                    = (createElement('tr') as HTMLTableRowElement).insertCell;
-        this.insertTableRow                = (createElement('table') as HTMLTableElement).insertRow;
-        this.insertTBodyRow                = (createElement('tbody') as HTMLTableSectionElement).insertRow;
+        this.insertCell                    = createElement('tr').insertCell;
+        this.insertTableRow                = createElement('table').insertRow;
+        this.insertTBodyRow                = createElement('tbody').insertRow;
         this.removeAttribute               = nativeElement.removeAttribute;
         this.removeAttributeNS             = nativeElement.removeAttributeNS;
         this.removeChild                   = nativeElement.removeChild;
@@ -520,7 +520,7 @@ class NativeMethods {
         this.hasAttributeNS                = nativeElement.hasAttributeNS;
         this.hasAttributes                 = nativeElement.hasAttributes;
         this.anchorToString                = win.HTMLAnchorElement.prototype.toString;
-        this.matches                       = nativeElement.matches || (nativeElement as IEHTMLElement).msMatchesSelector;
+        this.matches                       = nativeElement.matches || (nativeElement as HTMLElement as IEHTMLElement).msMatchesSelector;
         this.closest                       = nativeElement.closest;
 
         // Text node
@@ -555,8 +555,8 @@ class NativeMethods {
         this.focus                     = nativeElement.focus;
         // @ts-ignore
         this.select                    = window.TextRange ? createElement('body').createTextRange().select : null;
-        this.setSelectionRange         = (createElement('input') as HTMLInputElement).setSelectionRange;
-        this.textAreaSetSelectionRange = (createElement('textarea') as HTMLTextAreaElement).setSelectionRange;
+        this.setSelectionRange         = createElement('input').setSelectionRange;
+        this.textAreaSetSelectionRange = createElement('textarea').setSelectionRange;
 
         this.svgFocus = win.SVGElement ? win.SVGElement.prototype.focus : this.focus;
         this.svgBlur  = win.SVGElement ? win.SVGElement.prototype.blur : this.blur;

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -4,10 +4,6 @@ import { isNativeFunction } from '../utils/overriding';
 
 const NATIVE_CODE_RE = /\[native code]/;
 
-interface IEHTMLElement extends HTMLElement {
-    msMatchesSelector: Function;
-}
-
 class NativeMethods {
     isStoragePropsLocatedInProto: boolean;
     createDocumentFragment: Document['createDocumentFragment'];

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -141,7 +141,7 @@ class NativeMethods {
     WindowInputEvent: any;
     WindowMouseEvent: any;
     windowOriginGetter: () => string;
-    windowOriginSetter: () => any;
+    windowOriginSetter: (this: Window, value: string) => void;
     canvasContextDrawImage: any;
     formDataAppend: FormData['append'];
     date: DateConstructor;

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -4,6 +4,10 @@ import { isNativeFunction } from '../utils/overriding';
 
 const NATIVE_CODE_RE = /\[native code]/;
 
+interface IEHTMLElement extends HTMLElement {
+    msMatchesSelector: Function;
+}
+
 class NativeMethods {
     isStoragePropsLocatedInProto: boolean;
     createDocumentFragment: Document['createDocumentFragment'];
@@ -490,8 +494,16 @@ class NativeMethods {
     refreshElementMeths (doc, win: Window & typeof globalThis) {
         win = win || window as Window & typeof globalThis;
 
-        const createElement = tagName => this.createElement.call(doc || document, tagName);
-        const nativeElement = createElement('div');
+        const createElement   = tagName => this.createElement.call(doc || document, tagName);
+        const nativeElement   = createElement('div');
+        const nativeIEElement = nativeElement as IEHTMLElement;
+
+        const tableRowElement     = createElement('tr') as HTMLTableRowElement;
+        const tableElement        = createElement('table') as HTMLTableElement;
+        const tableSectionElement = createElement('tbody') as HTMLTableSectionElement;
+
+        const inputElement    = createElement('input') as HTMLInputElement;
+        const textareaElement = createElement('textarea') as HTMLTextAreaElement;
 
         const createTextNode = data => this.createTextNode.call(doc || document, data);
         const textNode       = createTextNode('text');
@@ -508,9 +520,9 @@ class NativeMethods {
         this.getAttributeNS                = nativeElement.getAttributeNS;
         this.insertAdjacentHTML            = nativeElement.insertAdjacentHTML;
         this.insertBefore                  = nativeElement.insertBefore;
-        this.insertCell                    = createElement('tr').insertCell;
-        this.insertTableRow                = createElement('table').insertRow;
-        this.insertTBodyRow                = createElement('tbody').insertRow;
+        this.insertCell                    = tableRowElement.insertCell;
+        this.insertTableRow                = tableElement.insertRow;
+        this.insertTBodyRow                = tableSectionElement.insertRow;
         this.removeAttribute               = nativeElement.removeAttribute;
         this.removeAttributeNS             = nativeElement.removeAttributeNS;
         this.removeChild                   = nativeElement.removeChild;
@@ -520,7 +532,7 @@ class NativeMethods {
         this.hasAttributeNS                = nativeElement.hasAttributeNS;
         this.hasAttributes                 = nativeElement.hasAttributes;
         this.anchorToString                = win.HTMLAnchorElement.prototype.toString;
-        this.matches                       = nativeElement.matches || nativeElement.msMatchesSelector;
+        this.matches                       = nativeElement.matches || nativeIEElement.msMatchesSelector;
         this.closest                       = nativeElement.closest;
 
         // Text node
@@ -555,8 +567,8 @@ class NativeMethods {
         this.focus                     = nativeElement.focus;
         // @ts-ignore
         this.select                    = window.TextRange ? createElement('body').createTextRange().select : null;
-        this.setSelectionRange         = createElement('input').setSelectionRange;
-        this.textAreaSetSelectionRange = createElement('textarea').setSelectionRange;
+        this.setSelectionRange         = inputElement.setSelectionRange;
+        this.textAreaSetSelectionRange = textareaElement.setSelectionRange;
 
         this.svgFocus = win.SVGElement ? win.SVGElement.prototype.focus : this.focus;
         this.svgBlur  = win.SVGElement ? win.SVGElement.prototype.blur : this.blur;

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -520,7 +520,7 @@ class NativeMethods {
         this.hasAttributeNS                = nativeElement.hasAttributeNS;
         this.hasAttributes                 = nativeElement.hasAttributes;
         this.anchorToString                = win.HTMLAnchorElement.prototype.toString;
-        this.matches                       = nativeElement.matches || (nativeElement as HTMLElement as IEHTMLElement).msMatchesSelector;
+        this.matches                       = nativeElement.matches || nativeElement.msMatchesSelector;
         this.closest                       = nativeElement.closest;
 
         // Text node

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -494,16 +494,8 @@ class NativeMethods {
     refreshElementMeths (doc, win: Window & typeof globalThis) {
         win = win || window as Window & typeof globalThis;
 
-        const createElement   = tagName => this.createElement.call(doc || document, tagName);
-        const nativeElement   = createElement('div');
-        const nativeIEElement = nativeElement as IEHTMLElement;
-
-        const tableRowElement     = createElement('tr') as HTMLTableRowElement;
-        const tableElement        = createElement('table') as HTMLTableElement;
-        const tableSectionElement = createElement('tbody') as HTMLTableSectionElement;
-
-        const inputElement    = createElement('input') as HTMLInputElement;
-        const textareaElement = createElement('textarea') as HTMLTextAreaElement;
+        const createElement = tagName => this.createElement.call(doc || document, tagName);
+        const nativeElement = createElement('div');
 
         const createTextNode = data => this.createTextNode.call(doc || document, data);
         const textNode       = createTextNode('text');
@@ -520,9 +512,9 @@ class NativeMethods {
         this.getAttributeNS                = nativeElement.getAttributeNS;
         this.insertAdjacentHTML            = nativeElement.insertAdjacentHTML;
         this.insertBefore                  = nativeElement.insertBefore;
-        this.insertCell                    = tableRowElement.insertCell;
-        this.insertTableRow                = tableElement.insertRow;
-        this.insertTBodyRow                = tableSectionElement.insertRow;
+        this.insertCell                    = (<HTMLTableRowElement>createElement('tr')).insertCell;
+        this.insertTableRow                = (<HTMLTableElement>createElement('table')).insertRow;
+        this.insertTBodyRow                = (<HTMLTableSectionElement>createElement('tbody')).insertRow;
         this.removeAttribute               = nativeElement.removeAttribute;
         this.removeAttributeNS             = nativeElement.removeAttributeNS;
         this.removeChild                   = nativeElement.removeChild;
@@ -532,7 +524,7 @@ class NativeMethods {
         this.hasAttributeNS                = nativeElement.hasAttributeNS;
         this.hasAttributes                 = nativeElement.hasAttributes;
         this.anchorToString                = win.HTMLAnchorElement.prototype.toString;
-        this.matches                       = nativeElement.matches || nativeIEElement.msMatchesSelector;
+        this.matches                       = nativeElement.matches || (<IEHTMLElement>nativeElement).msMatchesSelector;
         this.closest                       = nativeElement.closest;
 
         // Text node
@@ -567,8 +559,8 @@ class NativeMethods {
         this.focus                     = nativeElement.focus;
         // @ts-ignore
         this.select                    = window.TextRange ? createElement('body').createTextRange().select : null;
-        this.setSelectionRange         = inputElement.setSelectionRange;
-        this.textAreaSetSelectionRange = textareaElement.setSelectionRange;
+        this.setSelectionRange         = (<HTMLInputElement>createElement('input')).setSelectionRange;
+        this.textAreaSetSelectionRange = (<HTMLTextAreaElement>createElement('textarea')).setSelectionRange;
 
         this.svgFocus = win.SVGElement ? win.SVGElement.prototype.focus : this.focus;
         this.svgBlur  = win.SVGElement ? win.SVGElement.prototype.blur : this.blur;

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -512,9 +512,9 @@ class NativeMethods {
         this.getAttributeNS                = nativeElement.getAttributeNS;
         this.insertAdjacentHTML            = nativeElement.insertAdjacentHTML;
         this.insertBefore                  = nativeElement.insertBefore;
-        this.insertCell                    = (<HTMLTableRowElement>createElement('tr')).insertCell;
-        this.insertTableRow                = (<HTMLTableElement>createElement('table')).insertRow;
-        this.insertTBodyRow                = (<HTMLTableSectionElement>createElement('tbody')).insertRow;
+        this.insertCell                    = (createElement('tr') as HTMLTableRowElement).insertCell;
+        this.insertTableRow                = (createElement('table') as HTMLTableElement).insertRow;
+        this.insertTBodyRow                = (createElement('tbody') as HTMLTableSectionElement).insertRow;
         this.removeAttribute               = nativeElement.removeAttribute;
         this.removeAttributeNS             = nativeElement.removeAttributeNS;
         this.removeChild                   = nativeElement.removeChild;
@@ -524,7 +524,7 @@ class NativeMethods {
         this.hasAttributeNS                = nativeElement.hasAttributeNS;
         this.hasAttributes                 = nativeElement.hasAttributes;
         this.anchorToString                = win.HTMLAnchorElement.prototype.toString;
-        this.matches                       = nativeElement.matches || (<IEHTMLElement>nativeElement).msMatchesSelector;
+        this.matches                       = nativeElement.matches || (nativeElement as IEHTMLElement).msMatchesSelector;
         this.closest                       = nativeElement.closest;
 
         // Text node
@@ -559,8 +559,8 @@ class NativeMethods {
         this.focus                     = nativeElement.focus;
         // @ts-ignore
         this.select                    = window.TextRange ? createElement('body').createTextRange().select : null;
-        this.setSelectionRange         = (<HTMLInputElement>createElement('input')).setSelectionRange;
-        this.textAreaSetSelectionRange = (<HTMLTextAreaElement>createElement('textarea')).setSelectionRange;
+        this.setSelectionRange         = (createElement('input') as HTMLInputElement).setSelectionRange;
+        this.textAreaSetSelectionRange = (createElement('textarea') as HTMLTextAreaElement).setSelectionRange;
 
         this.svgFocus = win.SVGElement ? win.SVGElement.prototype.focus : this.focus;
         this.svgBlur  = win.SVGElement ? win.SVGElement.prototype.blur : this.blur;

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -229,7 +229,7 @@ export default class DocumentSandbox extends SandboxBase {
         overrideFunction(docPrototype, 'createDocumentFragment', function (...args: []) {
             const fragment = nativeMethods.createDocumentFragment.apply(this, args);
 
-            documentSandbox._nodeSandbox.processNodes(fragment as unknown as HTMLElement);
+            documentSandbox._nodeSandbox.processNodes(fragment);
 
             return fragment;
         });

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -229,7 +229,7 @@ export default class DocumentSandbox extends SandboxBase {
         overrideFunction(docPrototype, 'createDocumentFragment', function (...args: []) {
             const fragment = nativeMethods.createDocumentFragment.apply(this, args);
 
-            documentSandbox._nodeSandbox.processNodes(fragment);
+            documentSandbox._nodeSandbox.processNodes(fragment as unknown as HTMLElement);
 
             return fragment;
         });

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -130,7 +130,7 @@ export default class DocumentSandbox extends SandboxBase {
         const docPrototype    = window.Document.prototype;
 
         const overriddenMethods = {
-            open: function (...args) {
+            open: function (...args: [string?, string?, string?, boolean?]) {
                 const isUninitializedIframe = documentSandbox._isUninitializedIframeWithoutSrc(window);
 
                 if (!isUninitializedIframe)
@@ -139,7 +139,7 @@ export default class DocumentSandbox extends SandboxBase {
                 if (isIE)
                     return window.parent[INTERNAL_PROPS.hammerhead].sandbox.node.doc.iframeDocumentOpen(window, this, args);
 
-                const result = nativeMethods.documentOpen.apply(this, args as [string?, string?, string?, boolean?]);
+                const result = nativeMethods.documentOpen.apply(this, args);
 
                 // NOTE: Chrome does not remove the "%hammerhead%" property from window
                 // after document.open call
@@ -159,7 +159,7 @@ export default class DocumentSandbox extends SandboxBase {
                 return result;
             },
 
-            close: function (...args) {
+            close: function (...args: []) {
                 // NOTE: IE11 raise the "load" event only when the document.close method is called. We need to
                 // restore the overridden document.open and document.write methods before Hammerhead injection, if the
                 // window is not initialized.
@@ -170,7 +170,7 @@ export default class DocumentSandbox extends SandboxBase {
                 if (DocumentSandbox._isDocumentInDesignMode(this))
                     ShadowUI.removeSelfRemovingScripts(this);
 
-                const result = nativeMethods.documentClose.apply(this, args as []);
+                const result = nativeMethods.documentClose.apply(this, args);
 
                 if (!documentSandbox._isUninitializedIframeWithoutSrc(window))
                     documentSandbox._onDocumentClosed();
@@ -206,8 +206,8 @@ export default class DocumentSandbox extends SandboxBase {
         if (document.open !== overriddenMethods.open)
             overrideFunction(document, 'open', overriddenMethods.open);
 
-        overrideFunction(docPrototype, 'createElement', function (...args) {
-            const el = nativeMethods.createElement.apply(this, args as [string, ElementCreationOptions?]);
+        overrideFunction(docPrototype, 'createElement', function (...args: [string, ElementCreationOptions?]) {
+            const el = nativeMethods.createElement.apply(this, args);
 
             DocumentSandbox.forceProxySrcForImageIfNecessary(el);
             domProcessor.processElement(el, urlUtils.convertToProxyUrl);
@@ -216,8 +216,8 @@ export default class DocumentSandbox extends SandboxBase {
             return el;
         });
 
-        overrideFunction(docPrototype, 'createElementNS', function (...args) {
-            const el = nativeMethods.createElementNS.apply(this, args as [string, string, (string | ElementCreationOptions)?]);
+        overrideFunction(docPrototype, 'createElementNS', function (...args: [string, string, (string | ElementCreationOptions)?]) {
+            const el = nativeMethods.createElementNS.apply(this, args);
 
             if (el instanceof HTMLElement) {
                 DocumentSandbox.forceProxySrcForImageIfNecessary(el);
@@ -228,8 +228,8 @@ export default class DocumentSandbox extends SandboxBase {
             return el;
         });
 
-        overrideFunction(docPrototype, 'createDocumentFragment', function (...args) {
-            const fragment = nativeMethods.createDocumentFragment.apply(this, args as []);
+        overrideFunction(docPrototype, 'createDocumentFragment', function (...args: []) {
+            const fragment = nativeMethods.createDocumentFragment.apply(this, args);
 
             documentSandbox._nodeSandbox.processNodes(fragment as unknown as HTMLElement);
 

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -231,7 +231,7 @@ export default class DocumentSandbox extends SandboxBase {
         overrideFunction(docPrototype, 'createDocumentFragment', function (...args: []) {
             const fragment = nativeMethods.createDocumentFragment.apply(this, args);
 
-            documentSandbox._nodeSandbox.processNodes(fragment as unknown as HTMLElement);
+            documentSandbox._nodeSandbox.processNodes(fragment);
 
             return fragment;
         });

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -231,7 +231,7 @@ export default class DocumentSandbox extends SandboxBase {
         overrideFunction(docPrototype, 'createDocumentFragment', function (...args) {
             const fragment = nativeMethods.createDocumentFragment.apply(this, args as []);
 
-            documentSandbox._nodeSandbox.processNodes(fragment);
+            documentSandbox._nodeSandbox.processNodes(fragment as unknown as HTMLElement);
 
             return fragment;
         });

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -28,7 +28,7 @@ export default class DocumentSandbox extends SandboxBase {
         this.documentWriter = null;
     }
 
-    static forceProxySrcForImageIfNecessary (element: HTMLElement): void {
+    static forceProxySrcForImageIfNecessary (element: Element): void {
         if (isImgElement(element) && settings.get().forceProxySrcForImage)
             element[INTERNAL_PROPS.forceProxySrcForImage] = true;
     }

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -219,11 +219,9 @@ export default class DocumentSandbox extends SandboxBase {
         overrideFunction(docPrototype, 'createElementNS', function (...args: [string, string, (string | ElementCreationOptions)?]) {
             const el = nativeMethods.createElementNS.apply(this, args);
 
-            if (el instanceof HTMLElement) {
-                DocumentSandbox.forceProxySrcForImageIfNecessary(el);
-                domProcessor.processElement(el, urlUtils.convertToProxyUrl);
-                documentSandbox._nodeSandbox.processNodes(el);
-            }
+            DocumentSandbox.forceProxySrcForImageIfNecessary(el);
+            domProcessor.processElement(el, urlUtils.convertToProxyUrl);
+            documentSandbox._nodeSandbox.processNodes(el);
 
             return el;
         });

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -139,7 +139,7 @@ export default class DocumentSandbox extends SandboxBase {
                 if (isIE)
                     return window.parent[INTERNAL_PROPS.hammerhead].sandbox.node.doc.iframeDocumentOpen(window, this, args);
 
-                const result = nativeMethods.documentOpen.apply(this, args);
+                const result = nativeMethods.documentOpen.apply(this, args as [string?, string?, string?, boolean?]);
 
                 // NOTE: Chrome does not remove the "%hammerhead%" property from window
                 // after document.open call
@@ -170,7 +170,7 @@ export default class DocumentSandbox extends SandboxBase {
                 if (DocumentSandbox._isDocumentInDesignMode(this))
                     ShadowUI.removeSelfRemovingScripts(this);
 
-                const result = nativeMethods.documentClose.apply(this, args);
+                const result = nativeMethods.documentClose.apply(this, args as []);
 
                 if (!documentSandbox._isUninitializedIframeWithoutSrc(window))
                     documentSandbox._onDocumentClosed();
@@ -207,7 +207,7 @@ export default class DocumentSandbox extends SandboxBase {
             overrideFunction(document, 'open', overriddenMethods.open);
 
         overrideFunction(docPrototype, 'createElement', function (...args) {
-            const el = nativeMethods.createElement.apply(this, args);
+            const el = nativeMethods.createElement.apply(this, args as [string, ElementCreationOptions?]);
 
             DocumentSandbox.forceProxySrcForImageIfNecessary(el);
             domProcessor.processElement(el, urlUtils.convertToProxyUrl);
@@ -217,17 +217,19 @@ export default class DocumentSandbox extends SandboxBase {
         });
 
         overrideFunction(docPrototype, 'createElementNS', function (...args) {
-            const el = nativeMethods.createElementNS.apply(this, args);
+            const el = nativeMethods.createElementNS.apply(this, args as [string, string, (string | ElementCreationOptions)?]);
 
-            DocumentSandbox.forceProxySrcForImageIfNecessary(el);
-            domProcessor.processElement(el, urlUtils.convertToProxyUrl);
-            documentSandbox._nodeSandbox.processNodes(el);
+            if (el instanceof HTMLElement) {
+                DocumentSandbox.forceProxySrcForImageIfNecessary(el);
+                domProcessor.processElement(el, urlUtils.convertToProxyUrl);
+                documentSandbox._nodeSandbox.processNodes(el);
+            }
 
             return el;
         });
 
         overrideFunction(docPrototype, 'createDocumentFragment', function (...args) {
-            const fragment = nativeMethods.createDocumentFragment.apply(this, args);
+            const fragment = nativeMethods.createDocumentFragment.apply(this, args as []);
 
             documentSandbox._nodeSandbox.processNodes(fragment);
 

--- a/src/client/sandbox/node/document/title-storage.ts
+++ b/src/client/sandbox/node/document/title-storage.ts
@@ -23,7 +23,7 @@ export default class DocumentTitleStorage extends EventEmitter {
         if (firstTitle)
             return firstTitle;
 
-        firstTitle = nativeMethods.createElement('title') as HTMLTitleElement;
+        firstTitle = nativeMethods.createElement.call(this._document, 'title') as HTMLTitleElement;
 
         nativeMethods.appendChild.call(this._document.head, firstTitle);
 

--- a/src/client/sandbox/node/document/title-storage.ts
+++ b/src/client/sandbox/node/document/title-storage.ts
@@ -23,9 +23,7 @@ export default class DocumentTitleStorage extends EventEmitter {
         if (firstTitle)
             return firstTitle;
 
-        const createElement = (tagName => nativeMethods.createElement.call(this._document, tagName)) as Document['createElement'];
-
-        firstTitle = createElement('title');
+        firstTitle = nativeMethods.createElement('title') as HTMLTitleElement;
 
         nativeMethods.appendChild.call(this._document.head, firstTitle);
 

--- a/src/client/sandbox/node/document/title-storage.ts
+++ b/src/client/sandbox/node/document/title-storage.ts
@@ -23,7 +23,9 @@ export default class DocumentTitleStorage extends EventEmitter {
         if (firstTitle)
             return firstTitle;
 
-        firstTitle = nativeMethods.createElement.call(this._document, 'title') as HTMLTitleElement;
+        const createElement = (tagName => nativeMethods.createElement.call(this._document, tagName)) as Document['createElement'];
+
+        firstTitle = createElement('title');
 
         nativeMethods.appendChild.call(this._document.head, firstTitle);
 

--- a/src/client/sandbox/node/document/title-storage.ts
+++ b/src/client/sandbox/node/document/title-storage.ts
@@ -23,7 +23,7 @@ export default class DocumentTitleStorage extends EventEmitter {
         if (firstTitle)
             return firstTitle;
 
-        firstTitle = nativeMethods.createElement.call(this._document, 'title') as HTMLTitleElement;
+        firstTitle = <HTMLTitleElement>nativeMethods.createElement.call(this._document, 'title');
 
         nativeMethods.appendChild.call(this._document.head, firstTitle);
 

--- a/src/client/sandbox/node/document/title-storage.ts
+++ b/src/client/sandbox/node/document/title-storage.ts
@@ -23,7 +23,7 @@ export default class DocumentTitleStorage extends EventEmitter {
         if (firstTitle)
             return firstTitle;
 
-        firstTitle = nativeMethods.createElement.call(this._document, 'title');
+        firstTitle = nativeMethods.createElement.call(this._document, 'title') as HTMLTitleElement;
 
         nativeMethods.appendChild.call(this._document.head, firstTitle);
 

--- a/src/client/sandbox/node/document/title-storage.ts
+++ b/src/client/sandbox/node/document/title-storage.ts
@@ -23,7 +23,7 @@ export default class DocumentTitleStorage extends EventEmitter {
         if (firstTitle)
             return firstTitle;
 
-        firstTitle = <HTMLTitleElement>nativeMethods.createElement.call(this._document, 'title');
+        firstTitle = nativeMethods.createElement.call(this._document, 'title') as HTMLTitleElement;
 
         nativeMethods.appendChild.call(this._document.head, firstTitle);
 

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -951,7 +951,7 @@ export default class ElementSandbox extends SandboxBase {
             domProcessor.processElement(el, urlUtils.convertToProxyUrl);
     }
 
-    processElement (el: Element): void {
+    processElement (el: Element | DocumentFragment): void {
         const tagName = domUtils.getTagName(el);
 
         switch (tagName) {
@@ -973,8 +973,9 @@ export default class ElementSandbox extends SandboxBase {
                 break;
         }
 
-        // NOTE: we need to reprocess a tag client-side if it wasn't processed on the server.
-        // See the usage of Parse5DomAdapter.needToProcessUrl
-        this._reProcessElementWithTargetAttr(el, tagName);
+        if (DomProcessor.isIframeFlagTag(tagName))
+            // NOTE: we need to reprocess a tag client-side if it wasn't processed on the server.
+            // See the usage of Parse5DomAdapter.needToProcessUrl
+            this._reProcessElementWithTargetAttr(el as Element, tagName);
     }
 }

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -944,14 +944,14 @@ export default class ElementSandbox extends SandboxBase {
             urlResolver.updateBase(storedUrlAttr, el.ownerDocument || this.document);
     }
 
-    private _reProcessElementWithTargetAttr (el: HTMLElement, tagName: string): void {
+    private _reProcessElementWithTargetAttr (el: Element, tagName: string): void {
         const targetAttr = domProcessor.getTargetAttr(el);
 
         if (DomProcessor.isIframeFlagTag(tagName) && nativeMethods.getAttribute.call(el, targetAttr) === '_parent')
             domProcessor.processElement(el, urlUtils.convertToProxyUrl);
     }
 
-    processElement (el: HTMLElement): void {
+    processElement (el: Element): void {
         const tagName = domUtils.getTagName(el);
 
         switch (tagName) {

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -951,7 +951,7 @@ export default class ElementSandbox extends SandboxBase {
             domProcessor.processElement(el, urlUtils.convertToProxyUrl);
     }
 
-    processElement (el: Element | DocumentFragment): void {
+    processElement (el: Element): void {
         const tagName = domUtils.getTagName(el);
 
         switch (tagName) {
@@ -973,9 +973,8 @@ export default class ElementSandbox extends SandboxBase {
                 break;
         }
 
-        if (DomProcessor.isIframeFlagTag(tagName))
-            // NOTE: we need to reprocess a tag client-side if it wasn't processed on the server.
-            // See the usage of Parse5DomAdapter.needToProcessUrl
-            this._reProcessElementWithTargetAttr(el as Element, tagName);
+        // NOTE: we need to reprocess a tag client-side if it wasn't processed on the server.
+        // See the usage of Parse5DomAdapter.needToProcessUrl
+        this._reProcessElementWithTargetAttr(el, tagName);
     }
 }

--- a/src/client/sandbox/node/index.ts
+++ b/src/client/sandbox/node/index.ts
@@ -106,14 +106,14 @@ export default class NodeSandbox extends SandboxBase {
             this._documentTitleStorageInitializer.onPageTitleLoaded();
     }
 
-    processNodes (el: HTMLElement, doc?: Document): void {
+    processNodes (el: Node, doc?: Document): void {
         if (!el) {
             doc = doc || this.document;
 
             if (doc.documentElement)
                 this.processNodes(doc.documentElement);
         }
-        else if (el.querySelectorAll) {
+        else if (el instanceof HTMLElement && el.querySelectorAll) {
             this._processElement(el);
 
             const children = getNativeQuerySelectorAll(el).call(el, '*');

--- a/src/client/sandbox/node/index.ts
+++ b/src/client/sandbox/node/index.ts
@@ -106,14 +106,14 @@ export default class NodeSandbox extends SandboxBase {
             this._documentTitleStorageInitializer.onPageTitleLoaded();
     }
 
-    processNodes (el: Node, doc?: Document): void {
+    processNodes (el: HTMLElement, doc?: Document): void {
         if (!el) {
             doc = doc || this.document;
 
             if (doc.documentElement)
                 this.processNodes(doc.documentElement);
         }
-        else if (el instanceof HTMLElement && el.querySelectorAll) {
+        else if (el.querySelectorAll) {
             this._processElement(el);
 
             const children = getNativeQuerySelectorAll(el).call(el, '*');

--- a/src/client/sandbox/node/index.ts
+++ b/src/client/sandbox/node/index.ts
@@ -106,7 +106,7 @@ export default class NodeSandbox extends SandboxBase {
             this._documentTitleStorageInitializer.onPageTitleLoaded();
     }
 
-    processNodes (el: Element, doc?: Document): void {
+    processNodes (el?: Element | DocumentFragment, doc?: Document): void {
         if (!el) {
             doc = doc || this.document;
 
@@ -114,7 +114,8 @@ export default class NodeSandbox extends SandboxBase {
                 this.processNodes(doc.documentElement);
         }
         else if (el.querySelectorAll) {
-            this._processElement(el);
+            if (el.nodeType !== Node.DOCUMENT_FRAGMENT_NODE)
+                this._processElement(el as Element);
 
             const children = getNativeQuerySelectorAll(el).call(el, '*');
             const length   = nativeMethods.nodeListLengthGetter.call(children);

--- a/src/client/sandbox/node/index.ts
+++ b/src/client/sandbox/node/index.ts
@@ -71,7 +71,7 @@ export default class NodeSandbox extends SandboxBase {
         this.mutation.onBodyCreated(this.document.body as HTMLBodyElement);
     }
 
-    private _processElement (el: HTMLElement): void {
+    private _processElement (el: Element): void {
         const processedContext = el[INTERNAL_PROPS.processedContext];
 
         if (domUtils.isShadowUIElement(el) || processedContext === this.window)
@@ -106,7 +106,7 @@ export default class NodeSandbox extends SandboxBase {
             this._documentTitleStorageInitializer.onPageTitleLoaded();
     }
 
-    processNodes (el: HTMLElement, doc?: Document): void {
+    processNodes (el: Element, doc?: Document): void {
         if (!el) {
             doc = doc || this.document;
 

--- a/src/client/sandbox/node/live-node-list/html-collection-wrapper.ts
+++ b/src/client/sandbox/node/live-node-list/html-collection-wrapper.ts
@@ -88,7 +88,7 @@ if (HTMLCollection.prototype.namedItem) {
         value:        function (this: HTMLCollectionWrapper, ...args) {
             this._refreshCollection();
 
-            const namedItem = this._collection.namedItem.apply(this._collection, args);
+            const namedItem = this._collection.namedItem.apply(this._collection, args as [string]);
 
             return namedItem && isShadowUIElement(namedItem) ? null : namedItem;
         },

--- a/src/client/sandbox/node/live-node-list/html-collection-wrapper.ts
+++ b/src/client/sandbox/node/live-node-list/html-collection-wrapper.ts
@@ -85,10 +85,10 @@ const additionalProtoMethods = {
 
 if (HTMLCollection.prototype.namedItem) {
     additionalProtoMethods.namedItem = {
-        value:        function (this: HTMLCollectionWrapper, ...args) {
+        value:        function (this: HTMLCollectionWrapper, ...args: [string]) {
             this._refreshCollection();
 
-            const namedItem = this._collection.namedItem.apply(this._collection, args as [string]);
+            const namedItem = this._collection.namedItem.apply(this._collection, args);
 
             return namedItem && isShadowUIElement(namedItem) ? null : namedItem;
         },

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -498,7 +498,7 @@ export default class WindowSandbox extends SandboxBase {
                 else
                     args = nativeMethods.arrayConcat.call(args, sources);
 
-                return nativeMethods.objectAssign.apply(this, args);
+                return nativeMethods.objectAssign.apply(this, args as [object, any[]]);
             });
         }
 
@@ -529,7 +529,7 @@ export default class WindowSandbox extends SandboxBase {
                     scriptURL = getProxyUrl(scriptURL, { resourceType: stringifyResourceType({ isScript: true }) });
 
                 if (isCalledWithoutNewKeyword)
-                    return nativeMethods.Worker.apply(this, arguments);
+                    return nativeMethods.Worker.apply(this, arguments as unknown as [string | URL, WorkerOptions?]);
 
                 const worker = arguments.length === 1
                     ? new nativeMethods.Worker(scriptURL)
@@ -824,7 +824,7 @@ export default class WindowSandbox extends SandboxBase {
                     nativeMethods.formDataAppend.call(this, name, value, value.name);
                 }
                 else
-                    nativeMethods.formDataAppend.apply(this, arguments);
+                    nativeMethods.formDataAppend.apply(this, arguments as unknown as [string, string | Blob, string?]);
             });
         }
 
@@ -1544,7 +1544,7 @@ export default class WindowSandbox extends SandboxBase {
                 },
 
                 setter: function (value) {
-                    return nativeMethods.windowOriginSetter.call(this, value);
+                    return nativeMethods.windowOriginSetter.apply(this, [value] as unknown as []);
                 }
             });
         }

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -469,11 +469,8 @@ export default class WindowSandbox extends SandboxBase {
         });
 
         if (nativeMethods.objectAssign) {
-            overrideFunction(window.Object, 'assign', function (target: object, ...sources) {
-                let args: any[] = [];
-
-                args.push(target);
-
+            overrideFunction(window.Object, 'assign', function (target: object, ...sources: any[]) {
+                let args         = [target] as [object, ...any[]];
                 const targetType = typeof target;
 
                 if (target && (targetType === 'object' || targetType === 'function') && sources.length) {
@@ -498,7 +495,7 @@ export default class WindowSandbox extends SandboxBase {
                 else
                     args = nativeMethods.arrayConcat.call(args, sources);
 
-                return nativeMethods.objectAssign.apply(this, args as [object, any[]]);
+                return nativeMethods.objectAssign.apply(this, args);
             });
         }
 

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -517,7 +517,7 @@ export default class WindowSandbox extends SandboxBase {
         if (window.Worker) {
             overrideConstructor(window, 'Worker', function WorkerWrapper (...args: [string | URL, WorkerOptions?]) {
                 const isCalledWithoutNewKeyword = constructorIsCalledWithoutNewKeyword(this, WorkerWrapper);
-            
+
                 if (arguments.length === 0)
                     // @ts-ignore
                     return isCalledWithoutNewKeyword ? nativeMethods.Worker() : new nativeMethods.Worker();
@@ -816,7 +816,7 @@ export default class WindowSandbox extends SandboxBase {
                 // because our input may have incorrect value if the input with the file has been removed from DOM.
                 if (name === INTERNAL_ATTRS.uploadInfoHiddenInputName)
                     return;
-            
+
                 // NOTE: If we append our file wrapper to FormData, we will lose the file name.
                 // This happens because the file wrapper is an instance of Blob
                 // and a browser thinks that Blob does not contain the "name" property.

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -1543,7 +1543,7 @@ export default class WindowSandbox extends SandboxBase {
                 },
 
                 setter: function (value) {
-                    return nativeMethods.windowOriginSetter.apply(this, [value]);
+                    return nativeMethods.windowOriginSetter.call(this, value);
                 }
             });
         }

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -469,8 +469,8 @@ export default class WindowSandbox extends SandboxBase {
         });
 
         if (nativeMethods.objectAssign) {
-            overrideFunction(window.Object, 'assign', function (target, ...sources) {
-                let args = [];
+            overrideFunction(window.Object, 'assign', function (target: object, ...sources) {
+                let args: any[] = [];
 
                 args.push(target);
 
@@ -502,7 +502,7 @@ export default class WindowSandbox extends SandboxBase {
             });
         }
 
-        overrideFunction(window, 'open', function (...args) {
+        overrideFunction(window, 'open', function (...args: [string?, string?, string?, boolean?]) {
             args[0] = getProxyUrl(args[0]);
             args[1] = windowSandbox._getWindowOpenTarget(args[1]);
 

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -809,21 +809,21 @@ export default class WindowSandbox extends SandboxBase {
         }
 
         if (window.FormData) {
-            overrideFunction(window.FormData.prototype, 'append', function (name, value) {
+            overrideFunction(window.FormData.prototype, 'append', function (...args: [string, string | Blob, string?]) {
+                const [name, value] = args;
+            
                 // NOTE: We should not send our hidden input's value along with the file info,
                 // because our input may have incorrect value if the input with the file has been removed from DOM.
                 if (name === INTERNAL_ATTRS.uploadInfoHiddenInputName)
                     return;
-
+            
                 // NOTE: If we append our file wrapper to FormData, we will lose the file name.
                 // This happens because the file wrapper is an instance of Blob
                 // and a browser thinks that Blob does not contain the "name" property.
-                if (arguments.length === 2 && isBlob(value) && 'name' in value) {
-                    // @ts-ignore
-                    nativeMethods.formDataAppend.call(this, name, value, value.name);
-                }
-                else
-                    nativeMethods.formDataAppend.apply(this, arguments as unknown as [string, string | Blob, string?]);
+                if (args.length === 2 && isBlob(value) && 'name' in value)
+                    args[2] = value['name'] as string;
+            
+                nativeMethods.formDataAppend.apply(this, args);
             });
         }
 

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -1543,7 +1543,7 @@ export default class WindowSandbox extends SandboxBase {
                 },
 
                 setter: function (value) {
-                    return nativeMethods.windowOriginSetter.apply(this, [value] as unknown as []);
+                    return nativeMethods.windowOriginSetter.apply(this, [value]);
                 }
             });
         }

--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -265,11 +265,11 @@ export default class ShadowUI extends SandboxBase {
         const shadowUI = this;
         const docProto = window.Document.prototype;
 
-        overrideFunction(docProto, 'elementFromPoint', function (...args) {
+        overrideFunction(docProto, 'elementFromPoint', function (...args: [number, number]) {
             // NOTE: T212974
             shadowUI.addClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
-            const res = ShadowUI._filterElement(nativeMethods.elementFromPoint.apply(this, args as [number, number]));
+            const res = ShadowUI._filterElement(nativeMethods.elementFromPoint.apply(this, args));
 
             shadowUI.removeClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
@@ -306,12 +306,12 @@ export default class ShadowUI extends SandboxBase {
             });
         }
 
-        overrideFunction(docProto, 'getElementById', function (...args) {
-            return ShadowUI._filterElement(nativeMethods.getElementById.apply(this, args as [string]));
+        overrideFunction(docProto, 'getElementById', function (...args: [string]) {
+            return ShadowUI._filterElement(nativeMethods.getElementById.apply(this, args));
         });
 
-        overrideFunction(docProto, 'getElementsByName', function (...args) {
-            const elements = nativeMethods.getElementsByName.apply(this, args as [string]);
+        overrideFunction(docProto, 'getElementsByName', function (...args: [string]) {
+            const elements = nativeMethods.getElementsByName.apply(this, args);
             const length   = getElementsByNameReturnsHTMLCollection
                 ? nativeMethods.htmlCollectionLengthGetter.call(elements)
                 : nativeMethods.nodeListLengthGetter.call(elements);

--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -269,7 +269,7 @@ export default class ShadowUI extends SandboxBase {
             // NOTE: T212974
             shadowUI.addClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
-            const res = ShadowUI._filterElement(nativeMethods.elementFromPoint.apply(this, args));
+            const res = ShadowUI._filterElement(nativeMethods.elementFromPoint.apply(this, args as [number, number]));
 
             shadowUI.removeClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
@@ -307,11 +307,11 @@ export default class ShadowUI extends SandboxBase {
         }
 
         overrideFunction(docProto, 'getElementById', function (...args) {
-            return ShadowUI._filterElement(nativeMethods.getElementById.apply(this, args));
+            return ShadowUI._filterElement(nativeMethods.getElementById.apply(this, args as [string]));
         });
 
         overrideFunction(docProto, 'getElementsByName', function (...args) {
-            const elements = nativeMethods.getElementsByName.apply(this, args);
+            const elements = nativeMethods.getElementsByName.apply(this, args as [string]);
             const length   = getElementsByNameReturnsHTMLCollection
                 ? nativeMethods.htmlCollectionLengthGetter.call(elements)
                 : nativeMethods.nodeListLengthGetter.call(elements);

--- a/src/client/sandbox/upload/hidden-info.ts
+++ b/src/client/sandbox/upload/hidden-info.ts
@@ -4,7 +4,7 @@ import * as JSON from 'json-hammerhead';
 import ShadowUI from '../shadow-ui';
 
 function createInput (form: HTMLFormElement) {
-    const hiddenInput = nativeMethods.createElement.call(document, 'input');
+    const hiddenInput = nativeMethods.createElement.call(document, 'input') as HTMLInputElement;
 
     hiddenInput.type  = 'hidden';
     hiddenInput.name  = INTERNAL_ATTRS.uploadInfoHiddenInputName;

--- a/src/client/utils/feature-detection.ts
+++ b/src/client/utils/feature-detection.ts
@@ -34,9 +34,7 @@ if (nativeMethods.createElement) {
     hasDataTransfer = !!window.DataTransfer;
 
     // NOTE: In the Edge 17, the getNamedItem method of attributes object is not enumerable
-    attrGetNamedItemIsNotEnumerable = nativeMethods.objectGetOwnPropertyDescriptor
-    // @ts-ignore
-        .call(window.Object, NamedNodeMap.prototype, 'getNamedItem') as boolean;
+    attrGetNamedItemIsNotEnumerable = !!nativeMethods.objectGetOwnPropertyDescriptor.call(window.Object, NamedNodeMap.prototype, 'getNamedItem');
 
     // Both IE and Edge return an HTMLCollection, not a NodeList
     // @ts-ignore

--- a/src/client/utils/feature-detection.ts
+++ b/src/client/utils/feature-detection.ts
@@ -36,7 +36,7 @@ if (nativeMethods.createElement) {
     // NOTE: In the Edge 17, the getNamedItem method of attributes object is not enumerable
     attrGetNamedItemIsNotEnumerable = nativeMethods.objectGetOwnPropertyDescriptor
     // @ts-ignore
-        .call(window.Object, NamedNodeMap.prototype, 'getNamedItem');
+        .call(window.Object, NamedNodeMap.prototype, 'getNamedItem') as boolean;
 
     // Both IE and Edge return an HTMLCollection, not a NodeList
     // @ts-ignore

--- a/src/client/utils/url.ts
+++ b/src/client/utils/url.ts
@@ -210,7 +210,7 @@ export function parseProxyUrl (proxyUrl: string) {
     return sharedUrlUtils.parseProxyUrl(proxyUrl);
 }
 
-export function parseUrl (url: string) {
+export function parseUrl (url: string | URL) {
     return sharedUrlUtils.parseUrl(url);
 }
 

--- a/src/processing/dom/base-dom-adapter.ts
+++ b/src/processing/dom/base-dom-adapter.ts
@@ -21,7 +21,7 @@ export default abstract class BaseDomAdapter {
     abstract hasAttr (el: HTMLElement | ASTNode, attr: string): boolean;
     abstract isSVGElement (el: HTMLElement | ASTNode): boolean;
     abstract hasEventHandler (el: HTMLElement | ASTNode): boolean;
-    abstract getTagName (el: HTMLElement | ASTNode): string;
+    abstract getTagName (el: Element | ASTNode): string;
     abstract setAttr (el: HTMLElement | ASTNode, attr: string, value: string): void;
     abstract setScriptContent (el: HTMLElement | ASTNode, content: string): void;
     abstract getScriptContent (el: HTMLElement | ASTNode): string;
@@ -33,7 +33,7 @@ export default abstract class BaseDomAdapter {
     abstract getProxyUrl (resourceUrl: string, opts: object): string;
     abstract isTopParentIframe (el: HTMLElement | ASTNode): boolean;
     abstract sameOriginCheck (destUrl: string, resourceUrl: string): boolean;
-    abstract getClassName (el: HTMLElement | ASTNode): string;
+    abstract getClassName (el: Element | ASTNode): string;
     abstract isExistingTarget (target: string, el?: HTMLElement | ASTNode): boolean;
     abstract processSrcdocAttr (string: string): string;
 }

--- a/src/processing/dom/index.ts
+++ b/src/processing/dom/index.ts
@@ -266,7 +266,7 @@ export default class DomProcessor {
     }
 
     // API
-    processElement (el: Element | DocumentFragment, urlReplacer: UrlReplacer): void {
+    processElement (el: Element, urlReplacer: UrlReplacer): void {
         // @ts-ignore
         if (el[ELEMENT_PROCESSED])
             return;
@@ -359,11 +359,8 @@ export default class DomProcessor {
         return false;
     }
 
-    _isShadowElement (el: Element | DocumentFragment): boolean {
-        if (el.nodeType === Node.DOCUMENT_FRAGMENT_NODE)
-            return false;
-        
-        const className = this.adapter.getClassName(el as Element);
+    _isShadowElement (el: Element): boolean {
+        const className = this.adapter.getClassName(el);
 
         return typeof className === 'string' && className.indexOf(SHADOW_UI_CLASSNAME.postfix) > -1;
     }

--- a/src/processing/dom/index.ts
+++ b/src/processing/dom/index.ts
@@ -266,7 +266,7 @@ export default class DomProcessor {
     }
 
     // API
-    processElement (el: Element, urlReplacer: UrlReplacer): void {
+    processElement (el: Element | DocumentFragment, urlReplacer: UrlReplacer): void {
         // @ts-ignore
         if (el[ELEMENT_PROCESSED])
             return;
@@ -359,8 +359,11 @@ export default class DomProcessor {
         return false;
     }
 
-    _isShadowElement (el: Element): boolean {
-        const className = this.adapter.getClassName(el);
+    _isShadowElement (el: Element | DocumentFragment): boolean {
+        if (el.nodeType === Node.DOCUMENT_FRAGMENT_NODE)
+            return false;
+        
+        const className = this.adapter.getClassName(el as Element);
 
         return typeof className === 'string' && className.indexOf(SHADOW_UI_CLASSNAME.postfix) > -1;
     }

--- a/src/processing/dom/index.ts
+++ b/src/processing/dom/index.ts
@@ -266,7 +266,7 @@ export default class DomProcessor {
     }
 
     // API
-    processElement (el: HTMLElement, urlReplacer: UrlReplacer): void {
+    processElement (el: Element, urlReplacer: UrlReplacer): void {
         // @ts-ignore
         if (el[ELEMENT_PROCESSED])
             return;
@@ -313,7 +313,7 @@ export default class DomProcessor {
         return this.adapter.isSVGElement(el) && (attr === 'xml:base' || attr === 'base' && ns === XML_NAMESPACE);
     }
 
-    getUrlAttr (el: HTMLElement): string | null {
+    getUrlAttr (el: Element): string | null {
         const tagName = this.adapter.getTagName(el);
 
         for (const urlAttr of URL_ATTRS) {
@@ -325,7 +325,7 @@ export default class DomProcessor {
         return null;
     }
 
-    getTargetAttr (el: HTMLElement | ASTNode): string | null {
+    getTargetAttr (el: Element | ASTNode): string | null {
         const tagName = this.adapter.getTagName(el);
 
         for (const targetAttr of TARGET_ATTRS) {
@@ -359,7 +359,7 @@ export default class DomProcessor {
         return false;
     }
 
-    _isShadowElement (el: HTMLElement): boolean {
+    _isShadowElement (el: Element): boolean {
         const className = this.adapter.getClassName(el);
 
         return typeof className === 'string' && className.indexOf(SHADOW_UI_CLASSNAME.postfix) > -1;

--- a/src/processing/dom/parse5-dom-adapter.ts
+++ b/src/processing/dom/parse5-dom-adapter.ts
@@ -83,7 +83,7 @@ export default class Parse5DomAdapter extends BaseDomAdapter {
     }
 
     getProxyUrl (...args: [string, any]): string {
-        return urlUtils.getProxyUrl.apply(urlUtils, args);
+        return urlUtils.getProxyUrl(...args);
     }
 
     isTopParentIframe (): boolean {

--- a/src/processing/dom/parse5-dom-adapter.ts
+++ b/src/processing/dom/parse5-dom-adapter.ts
@@ -83,7 +83,7 @@ export default class Parse5DomAdapter extends BaseDomAdapter {
     }
 
     getProxyUrl (): string {
-        return urlUtils.getProxyUrl.apply(urlUtils, arguments);
+        return urlUtils.getProxyUrl.apply(urlUtils, arguments as unknown as [string, any]);
     }
 
     isTopParentIframe (): boolean {

--- a/src/processing/dom/parse5-dom-adapter.ts
+++ b/src/processing/dom/parse5-dom-adapter.ts
@@ -82,8 +82,8 @@ export default class Parse5DomAdapter extends BaseDomAdapter {
         return this.isIframe;
     }
 
-    getProxyUrl (): string {
-        return urlUtils.getProxyUrl.apply(urlUtils, arguments as unknown as [string, any]);
+    getProxyUrl (...args: [string, any]): string {
+        return urlUtils.getProxyUrl.apply(urlUtils, args);
     }
 
     isTopParentIframe (): boolean {

--- a/src/typings/extend-html-element.d.ts
+++ b/src/typings/extend-html-element.d.ts
@@ -1,3 +1,5 @@
-interface IEHTMLElement extends HTMLElement {
+// NOTE: This type is extended for compatibility with IE11.
+// see https://docs.microsoft.com/en-us/previous-versions/ff975201(v=vs.85)
+interface HTMLElement {
     msMatchesSelector: Function;
 }

--- a/src/typings/extend-html-element.d.ts
+++ b/src/typings/extend-html-element.d.ts
@@ -1,0 +1,3 @@
+interface IEHTMLElement extends HTMLElement {
+    msMatchesSelector: Function;
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -135,7 +135,7 @@ function convertHostToLowerCase (url: string): string {
     return formatUrl(parsedUrl);
 }
 
-export function getURLString (url: string): string {
+export function getURLString (url: string | URL): string {
     // TODO: fix it
     // eslint-disable-next-line no-undef
     if (url === null && /iPad|iPhone/i.test(window.navigator.userAgent))
@@ -261,7 +261,7 @@ export function getPathname (path: string): string {
     return path.replace(QUERY_AND_HASH_RE, '');
 }
 
-export function parseUrl (url: string): ParsedUrl {
+export function parseUrl (url: string | URL): ParsedUrl {
     const parsed: any = {};
 
     url = processSpecialChars(url);
@@ -390,7 +390,7 @@ export function correctMultipleSlashes (url: string, pageProtocol = ''): string 
     return url.replace(/^(https?:)?\/+(\/\/.*$)/i, '$1$2');
 }
 
-export function processSpecialChars (url: string): string {
+export function processSpecialChars (url: string | URL): string {
     return correctMultipleSlashes(getURLString(url));
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,22 @@
 {
   "compilerOptions": {
-    "target": "esnext",
-    "moduleResolution": "node",
+    "target": "es2017",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "allowJs": true,
+    "checkJs": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "types": ["node"],
+    "strict": false,
+    "newLine": "lf",
     "allowSyntheticDefaultImports": true,
+    "alwaysStrict": true,
+    "strictBindCallApply": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "strictFunctionTypes": true,
-    "strict": false,
-    "newLine": "lf"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Purpose
Synchronize typescript options with testcafe for monorepo migration.

## Approach
Added the strictBindCallApply rule to tsconfig, fixed errors (mostly type casting). Also added alwaysStrict (no errors occured).

## References
Part of https://github.com/DevExpress/testcafe/issues/5666

## Pre-Merge TODO
- [x] Make sure that existing tests do not fail
