### PR TITLE
Added the noImplicitThis rule to tsconfig

### DIFF
--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -65,7 +65,7 @@ export default class Listeners extends EventEmitter {
     }
 
     private static _getEventListenerWrapper (eventCtx, listener) {
-        return function (this: unknown, e: Event) {
+        return function (this: EventTarget, e: Event) {
             // NOTE: Ignore IE11's and Edge's service handlers (GH-379)
             if (Listeners._isIEServiceHandler(listener) || eventCtx.cancelOuterHandlers)
                 return null;
@@ -98,7 +98,7 @@ export default class Listeners extends EventEmitter {
     private _createEventHandler (): Function {
         const listeners = this;
 
-        return function (this: unknown, e: Event) {
+        return function (this: EventTarget, e: Event) {
             const el                  = this as HTMLElement;
             const elWindow            = el[INTERNAL_PROPS.processedContext] || window;
             let eventPrevented        = false;

--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -65,7 +65,7 @@ export default class Listeners extends EventEmitter {
     }
 
     private static _getEventListenerWrapper (eventCtx, listener) {
-        return function (e: Event) {
+        return function (this: unknown, e: Event) {
             // NOTE: Ignore IE11's and Edge's service handlers (GH-379)
             if (Listeners._isIEServiceHandler(listener) || eventCtx.cancelOuterHandlers)
                 return null;
@@ -98,7 +98,7 @@ export default class Listeners extends EventEmitter {
     private _createEventHandler (): Function {
         const listeners = this;
 
-        return function (e: Event) {
+        return function (this: unknown, e: Event) {
             const el                  = this as HTMLElement;
             const elWindow            = el[INTERNAL_PROPS.processedContext] || window;
             let eventPrevented        = false;
@@ -147,7 +147,7 @@ export default class Listeners extends EventEmitter {
         const listeners = this;
 
         return {
-            addEventListener: function (...args: any[]) {
+            addEventListener: function (this: Window | HTMLElement | Document, ...args: any[]) {
                 const [eventType, listener]  = args;
                 const el                     = this;
                 const useCapture             = Listeners._getUseCaptureParam(args[2]);
@@ -175,7 +175,7 @@ export default class Listeners extends EventEmitter {
 
                 return res;
             },
-            removeEventListener: function (...args: any[]) {
+            removeEventListener: function (this: Window | HTMLElement | Document, ...args: any[]) {
                 const [eventType, listener]     = args;
                 const el                        = this;
                 const useCapture                = Listeners._getUseCaptureParam(args[2]);

--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -148,7 +148,7 @@ export default class MessageSandbox extends SandboxBase {
 
         // @ts-ignore
         overrideDescriptor(window.MessageEvent.prototype, 'data', {
-            getter: function () {
+            getter: function (this: MessageEvent) {
                 const target = this.target;
                 const data   = nativeMethods.messageEventDataGetter.call(this);
 

--- a/src/client/sandbox/event/selection.ts
+++ b/src/client/sandbox/event/selection.ts
@@ -102,7 +102,9 @@ export default class Selection {
         };
 
         this.selectWrapper = function (this: HTMLElement) {
-            const element = this.parentElement;
+            // NOTE: Non-standard IE Only class TextRange
+            // @ts-ignore
+            const element = this.parentElement();
 
             if (!element || domUtils.getActiveElement(domUtils.findDocument(element)) === element)
                 return nativeMethods.select.call(this);

--- a/src/client/sandbox/event/selection.ts
+++ b/src/client/sandbox/event/selection.ts
@@ -27,7 +27,7 @@ export default class Selection {
         const listeners      = this.listeners;
         const timersSandbox  = this.timersSandbox;
 
-        this.setSelectionRangeWrapper = function () {
+        this.setSelectionRangeWrapper = function (this: HTMLInputElement | HTMLTextAreaElement) {
             const selectionStart     = arguments[0];
             const selectionEnd       = arguments[1];
             const selectionDirection = arguments[2] || 'none';
@@ -45,7 +45,7 @@ export default class Selection {
                 let res;
 
                 if (useInternalSelection)
-                    el.type = 'text';
+                    el.setAttribute('type', 'text');
 
                 // NOTE: In MSEdge, an error occurs when the setSelectionRange method is called for an input with
                 // 'display = none' and selectionStart !== selectionEnd in other IEs, the error doesn't occur, but
@@ -64,7 +64,7 @@ export default class Selection {
                         selectionDirection: el.selectionDirection
                     };
 
-                    el.type = savedType;
+                    el.setAttribute('type', savedType);
                     // HACK: (A problem with input type = 'number' after Chrome is updated to v.33.0.1750.117 and
                     // in Firefox 29.0.  T101195) To set right selection: if the input type is 'number' or 'email',
                     // we need to change the type to text, and then restore it after setting selection.(B254340).
@@ -101,8 +101,8 @@ export default class Selection {
             return selection.wrapSetterSelection(el, selectionSetter, needFocus);
         };
 
-        this.selectWrapper = function () {
-            const element = this.parentElement();
+        this.selectWrapper = function (this: HTMLElement) {
+            const element = this.parentElement;
 
             if (!element || domUtils.getActiveElement(domUtils.findDocument(element)) === element)
                 return nativeMethods.select.call(this);

--- a/src/client/sandbox/fetch.ts
+++ b/src/client/sandbox/fetch.ts
@@ -161,7 +161,7 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
             }
         });
 
-        overrideFunction(window, 'fetch', function (...args: [RequestInfo, RequestInit]) {
+        overrideFunction(window, 'fetch', function (this: Window, ...args: [RequestInfo, RequestInit]) {
             if (sandbox.gettingSettingInProgress())
                 return sandbox.delayUntilGetSettings(() => this.fetch.apply(this, args));
 
@@ -220,7 +220,7 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
 
         overrideFunction(window.Headers.prototype, 'values', FetchSandbox._valuesWrapper);
 
-        overrideFunction(window.Headers.prototype, 'forEach', function (...args: [(value: string, key: string, parent: Headers) => void, any?]) {
+        overrideFunction(window.Headers.prototype, 'forEach', function (this: Headers, ...args: [(value: string, key: string, parent: Headers) => void, any?]) {
             const callback = args[0];
 
             if (typeof callback === 'function') {
@@ -238,7 +238,7 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
             return nativeMethods.headersForEach.apply(this, args);
         });
 
-        overrideFunction(window.Headers.prototype, 'get', function (...args: [string]) {
+        overrideFunction(window.Headers.prototype, 'get', function (this: Headers, ...args: [string]) {
             const [headerName] = args;
 
             args[0] = transformHeaderNameToInternal(headerName);
@@ -254,7 +254,7 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
             return result;
         });
 
-        overrideFunction(window.Headers.prototype, 'has', function (...args: [string]) {
+        overrideFunction(window.Headers.prototype, 'has', function (this: Headers, ...args: [string]) {
             const [headerName] = args;
 
             args[0] = transformHeaderNameToInternal(headerName);
@@ -270,7 +270,7 @@ export default class FetchSandbox extends SandboxBaseWithDelayedSettings {
             return result;
         });
 
-        overrideFunction(window.Headers.prototype, 'set', function (...args: [string, string]) {
+        overrideFunction(window.Headers.prototype, 'set', function (this: Headers, ...args: [string, string]) {
             args[0] = transformHeaderNameToInternal(args[0]);
 
             return nativeMethods.headersSet.apply(this, args);

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -130,7 +130,7 @@ export default class DocumentSandbox extends SandboxBase {
         const docPrototype    = window.Document.prototype;
 
         const overriddenMethods = {
-            open: function (...args: [string?, string?, string?, boolean?]) {
+            open: function (this: Document, ...args: [string?, string?, string?, boolean?]) {
                 const isUninitializedIframe = documentSandbox._isUninitializedIframeWithoutSrc(window);
 
                 if (!isUninitializedIframe)
@@ -159,7 +159,7 @@ export default class DocumentSandbox extends SandboxBase {
                 return result;
             },
 
-            close: function (...args: []) {
+            close: function (this: Document, ...args: []) {
                 // NOTE: IE11 raise the "load" event only when the document.close method is called. We need to
                 // restore the overridden document.open and document.write methods before Hammerhead injection, if the
                 // window is not initialized.
@@ -206,7 +206,7 @@ export default class DocumentSandbox extends SandboxBase {
         if (document.open !== overriddenMethods.open)
             overrideFunction(document, 'open', overriddenMethods.open);
 
-        overrideFunction(docPrototype, 'createElement', function (...args: [string, ElementCreationOptions?]) {
+        overrideFunction(docPrototype, 'createElement', function (this: Document, ...args: [string, ElementCreationOptions?]) {
             const el = nativeMethods.createElement.apply(this, args);
 
             DocumentSandbox.forceProxySrcForImageIfNecessary(el);
@@ -216,7 +216,7 @@ export default class DocumentSandbox extends SandboxBase {
             return el;
         });
 
-        overrideFunction(docPrototype, 'createElementNS', function (...args: [string, string, (string | ElementCreationOptions)?]) {
+        overrideFunction(docPrototype, 'createElementNS', function (this: Document, ...args: [string, string, (string | ElementCreationOptions)?]) {
             const el = nativeMethods.createElementNS.apply(this, args);
 
             DocumentSandbox.forceProxySrcForImageIfNecessary(el);
@@ -226,7 +226,7 @@ export default class DocumentSandbox extends SandboxBase {
             return el;
         });
 
-        overrideFunction(docPrototype, 'createDocumentFragment', function (...args: []) {
+        overrideFunction(docPrototype, 'createDocumentFragment', function (this: Document, ...args: []) {
             const fragment = nativeMethods.createDocumentFragment.apply(this, args);
 
             documentSandbox._nodeSandbox.processNodes(fragment);
@@ -296,7 +296,7 @@ export default class DocumentSandbox extends SandboxBase {
         });
 
         overrideDescriptor(docPrototype, 'activeElement', {
-            getter: function () {
+            getter: function (this: Document) {
                 const activeElement = nativeMethods.documentActiveElementGetter.call(this);
 
                 if (activeElement && isShadowUIElement(activeElement))

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -352,7 +352,7 @@ export default class WindowSandbox extends SandboxBase {
     _createOverriddenDOMTokenListMethod (nativeMethod): Function {
         const windowSandbox = this;
 
-        return function (this: unknown) {
+        return function (this: DOMTokenList) {
             const executionResult = nativeMethod.apply(this, arguments);
             const tokenListOwner  = this[SANDBOX_DOM_TOKEN_LIST_OWNER];
 
@@ -469,7 +469,7 @@ export default class WindowSandbox extends SandboxBase {
         });
 
         if (nativeMethods.objectAssign) {
-            overrideFunction(window.Object, 'assign', function (this: Object, target: object, ...sources: any[]) {
+            overrideFunction(window.Object, 'assign', function (this: ObjectConstructor, target: object, ...sources: any[]) {
                 let args         = [target] as [object, ...any[]];
                 const targetType = typeof target;
 

--- a/src/client/sandbox/shadow-ui.ts
+++ b/src/client/sandbox/shadow-ui.ts
@@ -161,7 +161,7 @@ export default class ShadowUI extends SandboxBase {
 
         return {
             getElementsByClassName (nativeGetElementsByClassNameFnName) {
-                return function (...args) {
+                return function (this: HTMLElement, ...args) {
                     const elements = nativeMethods[nativeGetElementsByClassNameFnName].apply(this, args);
                     const length   = nativeMethods.htmlCollectionLengthGetter.call(elements);
 
@@ -170,7 +170,7 @@ export default class ShadowUI extends SandboxBase {
             },
 
             getElementsByTagName (nativeGetElementsByTagNameFnName) {
-                return function (...args) {
+                return function (this: HTMLElement, ...args) {
                     const nativeCollection = nativeMethods[nativeGetElementsByTagNameFnName].apply(this, args);
                     const tagName          = args[0];
 
@@ -191,7 +191,7 @@ export default class ShadowUI extends SandboxBase {
             },
 
             querySelector (nativeQuerySelectorFnName, nativeQuerySelectorAllFnName) {
-                return function (...args) {
+                return function (this: HTMLElement, ...args) {
                     if (typeof args[0] === 'string')
                         args[0] = NodeSandbox.processSelector(args[0]);
 
@@ -206,7 +206,7 @@ export default class ShadowUI extends SandboxBase {
             },
 
             querySelectorAll (nativeQuerySelectorAllFnName) {
-                return function (...args) {
+                return function (this: HTMLElement, ...args) {
                     if (typeof args[0] === 'string')
                         args[0] = NodeSandbox.processSelector(args[0]);
 
@@ -265,7 +265,7 @@ export default class ShadowUI extends SandboxBase {
         const shadowUI = this;
         const docProto = window.Document.prototype;
 
-        overrideFunction(docProto, 'elementFromPoint', function (...args: [number, number]) {
+        overrideFunction(docProto, 'elementFromPoint', function (this: Document, ...args: [number, number]) {
             // NOTE: T212974
             shadowUI.addClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
@@ -277,7 +277,7 @@ export default class ShadowUI extends SandboxBase {
         });
 
         if (document.caretRangeFromPoint) {
-            overrideFunction(docProto, 'caretRangeFromPoint', function (...args) {
+            overrideFunction(docProto, 'caretRangeFromPoint', function (this: Document, ...args) {
                 shadowUI.addClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
                 let res = nativeMethods.caretRangeFromPoint.apply(this, args);
@@ -292,7 +292,7 @@ export default class ShadowUI extends SandboxBase {
         }
 
         if (document.caretPositionFromPoint) {
-            overrideFunction(docProto, 'caretPositionFromPoint', function (...args) {
+            overrideFunction(docProto, 'caretPositionFromPoint', function (this: Document, ...args) {
                 shadowUI.addClass(shadowUI.getRoot(), shadowUI.HIDDEN_CLASS);
 
                 let res = nativeMethods.caretPositionFromPoint.apply(this, args);
@@ -306,11 +306,11 @@ export default class ShadowUI extends SandboxBase {
             });
         }
 
-        overrideFunction(docProto, 'getElementById', function (...args: [string]) {
+        overrideFunction(docProto, 'getElementById', function (this: Document, ...args: [string]) {
             return ShadowUI._filterElement(nativeMethods.getElementById.apply(this, args));
         });
 
-        overrideFunction(docProto, 'getElementsByName', function (...args: [string]) {
+        overrideFunction(docProto, 'getElementsByName', function (this: Document, ...args: [string]) {
             const elements = nativeMethods.getElementsByName.apply(this, args);
             const length   = getElementsByNameReturnsHTMLCollection
                 ? nativeMethods.htmlCollectionLengthGetter.call(elements)

--- a/src/client/sandbox/storages/index.ts
+++ b/src/client/sandbox/storages/index.ts
@@ -86,7 +86,7 @@ export default class StorageSandbox extends SandboxBase {
 
     _overrideStorageEvent () {
         // @ts-ignore
-        this.window.StorageEvent = function (type, opts) {
+        this.window.StorageEvent = function (this: Window, type, opts) {
             if (arguments.length === 0)
                 throw new TypeError();
 
@@ -95,10 +95,10 @@ export default class StorageSandbox extends SandboxBase {
             if (storedArea)
                 delete opts.storageArea;
 
-            const event = new this.nativeMethods.StorageEvent(type, opts);
+            const event = new this['nativeMethods'].StorageEvent(type, opts);
 
             if (storedArea) {
-                this.nativeMethods.objectDefineProperty(event, 'storageArea', {
+                this['nativeMethods'].objectDefineProperty(event, 'storageArea', {
                     get: () => storedArea,
                     set: () => void 0
                 });

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -130,7 +130,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
             nativeMethods.xhrOpen.apply(this, arguments);
         });
 
-        overrideFunction(xmlHttpRequestProto, 'send', function (this: XMLHttpRequest, ...args: [(string | Document | Blob | ArrayBufferView | ArrayBuffer | FormData | URLSearchParams | ReadableStream<Uint8Array>)?]) {
+        overrideFunction(xmlHttpRequestProto, 'send', function (this: XMLHttpRequest, ...args: [any]) {
             if (xhrSandbox.gettingSettingInProgress()) {
                 xhrSandbox.delayUntilGetSettings(() => this.send.apply(this, args));
 

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -92,9 +92,9 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
             value: xmlHttpRequestWrapper
         });
 
-        overrideFunction(xmlHttpRequestProto, 'abort', function (this: XMLHttpRequest, ...args) {
+        overrideFunction(xmlHttpRequestProto, 'abort', function (this: XMLHttpRequest, ...args: []) {
             if (xhrSandbox.gettingSettingInProgress()) {
-                xhrSandbox.delayUntilGetSettings(() => this.abort.apply(this, args as unknown as []));
+                xhrSandbox.delayUntilGetSettings(() => this.abort.apply(this, args));
 
                 return;
             }
@@ -108,7 +108,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
 
         // NOTE: Redirect all requests to the Hammerhead proxy and ensure that requests don't
         // violate Same Origin Policy.
-        overrideFunction(xmlHttpRequestProto, 'open', function (this: XMLHttpRequest, ...args) {
+        overrideFunction(xmlHttpRequestProto, 'open', function (this: XMLHttpRequest, ...args: [string, string, boolean, string?, string?]) {
             const url = arguments[1];
 
             if (getProxyUrl(url) === url) {
@@ -118,7 +118,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
             }
 
             if (xhrSandbox.gettingSettingInProgress()) {
-                xhrSandbox.delayUntilGetSettings(() => this.open.apply(this, args as [string, string, boolean, string?, string?]));
+                xhrSandbox.delayUntilGetSettings(() => this.open.apply(this, args));
 
                 return;
             }
@@ -130,9 +130,9 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
             nativeMethods.xhrOpen.apply(this, arguments);
         });
 
-        overrideFunction(xmlHttpRequestProto, 'send', function (this: XMLHttpRequest, ...args) {
+        overrideFunction(xmlHttpRequestProto, 'send', function (this: XMLHttpRequest, ...args: [(string | Document | Blob | ArrayBufferView | ArrayBuffer | FormData | URLSearchParams | ReadableStream<Uint8Array>)?]) {
             if (xhrSandbox.gettingSettingInProgress()) {
-                xhrSandbox.delayUntilGetSettings(() => this.send.apply(this, args as [(string | Document | Blob | ArrayBufferView | ArrayBuffer | FormData | URLSearchParams | ReadableStream<Uint8Array>)?]));
+                xhrSandbox.delayUntilGetSettings(() => this.send.apply(this, args));
 
                 return;
             }

--- a/src/client/transport-worker/request.ts
+++ b/src/client/transport-worker/request.ts
@@ -38,8 +38,8 @@ function handleReject (ctx: RequestContext, e: ProgressEvent) {
     }
 }
 
-function handleEvent (this: unknown, e: ProgressEvent) {
-    const ctx = this as RequestContext;
+function handleEvent (this: RequestContext, e: ProgressEvent) {
+    const ctx = this;
 
     if (e.type === 'load')
         handleResolve(ctx, e);

--- a/src/client/transport-worker/request.ts
+++ b/src/client/transport-worker/request.ts
@@ -38,7 +38,7 @@ function handleReject (ctx: RequestContext, e: ProgressEvent) {
     }
 }
 
-function handleEvent (e: ProgressEvent) {
+function handleEvent (this: unknown, e: ProgressEvent) {
     const ctx = this as RequestContext;
 
     if (e.type === 'load')

--- a/src/processing/script/transform.ts
+++ b/src/processing/script/transform.ts
@@ -116,7 +116,7 @@ function addTempVarsDeclaration (node: BlockStatement | Program, changes: CodeCh
     addChangeForTransformedNode(state, changes, declaration, node.type);
 }
 
-function beforeTransform (wrapLastExprWithProcessHtml = false, resolver?: Function) {
+function beforeTransform (this: unknown, wrapLastExprWithProcessHtml = false, resolver?: Function) {
     jsProtocolLastExpression.wrapLastExpr = wrapLastExprWithProcessHtml;
     staticImportTransformer.resolver = resolver;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "strictFunctionTypes": true,
+    "noImplicitThis": true
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Purpose
Synchronize typescript options with testcafe for monorepo migration.

## Approach
Added the noImplicitThis rule to tsconfig, fixed errors.

## References
Part of https://github.com/DevExpress/testcafe/issues/5666

## Pre-Merge TODO
- [x] Make sure that existing tests do not fail
