### PR TITLE
convert local storage value type if it set using setter (closes #2313)

### DIFF
--- a/src/client/sandbox/storages/index.ts
+++ b/src/client/sandbox/storages/index.ts
@@ -59,10 +59,8 @@ export default class StorageSandbox extends SandboxBase {
         }
         // NOTE: Or create new.
         else {
-            // @ts-ignore
-            this.localStorageWrapper   = new StorageWrapper(this.window, this.nativeMethods.winLocalStorageGetter.call(this.window), storageKey);
-            // @ts-ignore
-            this.sessionStorageWrapper = new StorageWrapper(this.window, this.nativeMethods.winSessionStorageGetter.call(this.window), storageKey);
+            this.localStorageWrapper   = StorageWrapper.create(this.window, this.nativeMethods.winLocalStorageGetter.call(this.window), storageKey);
+            this.sessionStorageWrapper = StorageWrapper.create(this.window, this.nativeMethods.winSessionStorageGetter.call(this.window), storageKey);
 
             const saveToNativeStorages = () => {
                 if (!this.isLocked) {

--- a/src/client/sandbox/storages/wrapper.ts
+++ b/src/client/sandbox/storages/wrapper.ts
@@ -47,7 +47,7 @@ export default class StorageWrapper {
     STORAGE_CHANGED_EVENT = 'hammerhead|event|storage-changed';
     EMPTY_OLD_VALUE_ARG: any;
 
-    constructor (window, nativeStorage, nativeStorageKey) {
+    protected constructor (window, nativeStorage, nativeStorageKey) {
         this.eventEmitter      = new EventEmitter();
         this.on                = (ev, handler) => this.eventEmitter.on(ev, handler);
         this.off               = (ev, handler) => this.eventEmitter.off(ev, handler);
@@ -255,6 +255,26 @@ export default class StorageWrapper {
         this.wrapperMethods = getWrapperMethods();
 
         init();
+    }
+
+    public static create (window, nativeStorage, nativeStorageKey) {
+        const storageWrapper = new StorageWrapper(window, nativeStorage, nativeStorageKey);
+
+        if (!window.Proxy)
+            return storageWrapper;
+
+        return new nativeMethods.Proxy(storageWrapper, {
+            set: (target, property, value) => {
+                const isInitialProperty = target.initialProperties.includes(property);
+
+                if (!isInitialProperty)
+                    target.setItem(property, value);
+                else
+                    target[property] = value;
+
+                return true;
+            }
+        });
     }
 }
 

--- a/src/client/sandbox/storages/wrapper.ts
+++ b/src/client/sandbox/storages/wrapper.ts
@@ -276,8 +276,10 @@ export default class StorageWrapper {
             },
 
             deleteProperty: (target, key) => {
-                if (getAddedProperties(target).includes(key))
-                    target.removeItem(key);
+                if (!getAddedProperties(target).includes(key))
+                    return false;
+
+                target.removeItem(key);
 
                 return true;
             }

--- a/src/client/sandbox/storages/wrapper.ts
+++ b/src/client/sandbox/storages/wrapper.ts
@@ -18,6 +18,21 @@ function getWrapperMethods () {
     return methods;
 }
 
+const getAddedProperties = (storageWrapper: StorageWrapper) => {
+    // NOTE: The standard doesn't regulate the order in which properties are enumerated.
+    // But we rely on the fact that they are enumerated in the order they were created in all the supported browsers.
+    // In this case we cannot use Object.getOwnPropertyNames
+    // because the enumeration order in Android 6.0 is different from all other browsers.
+    const properties = [];
+
+    for (const property in storageWrapper) {
+        if (nativeMethods.objectHasOwnProperty.call(storageWrapper, property) && storageWrapper.initialProperties.indexOf(property) === -1)
+            properties.push(property);
+    }
+
+    return properties;
+};
+
 export default class StorageWrapper {
     eventEmitter: any;
     on: any;
@@ -63,23 +78,8 @@ export default class StorageWrapper {
 
         this.EMPTY_OLD_VALUE_ARG   = isIE ? '' : null;
 
-        const getAddedProperties = () => {
-            // NOTE: The standard doesn't regulate the order in which properties are enumerated.
-            // But we rely on the fact that they are enumerated in the order they were created in all the supported browsers.
-            // In this case we cannot use Object.getOwnPropertyNames
-            // because the enumeration order in Android 6.0 is different from all other browsers.
-            const properties = [];
-
-            for (const property in this) {
-                if (nativeMethods.objectHasOwnProperty.call(this, property) && this.initialProperties.indexOf(property) === -1)
-                    properties.push(property);
-            }
-
-            return properties;
-        };
-
         nativeMethods.objectDefineProperty(this, 'length', {
-            get: () => getAddedProperties().length,
+            get: () => getAddedProperties(this).length,
             set: () => void 0
         });
 
@@ -136,7 +136,7 @@ export default class StorageWrapper {
         };
 
         const clearStorage = () => {
-            const addedProperties = getAddedProperties();
+            const addedProperties = getAddedProperties(this);
             let changed           = false;
 
             for (const addedProperty of addedProperties) {
@@ -168,7 +168,7 @@ export default class StorageWrapper {
         };
 
         this.getCurrentState = () => {
-            const addedProperties = getAddedProperties();
+            const addedProperties = getAddedProperties(this);
             const state           = [[], []];
 
             for (const addedProperty of addedProperties) {
@@ -223,7 +223,7 @@ export default class StorageWrapper {
             // NOTE: http://w3c-test.org/webstorage/storage_key.html
             keyNum %= 0x100000000;
 
-            const addedProperties = getAddedProperties();
+            const addedProperties = getAddedProperties(this);
 
             return keyNum >= 0 && keyNum < addedProperties.length ? addedProperties[keyNum] : null;
         };
@@ -271,6 +271,13 @@ export default class StorageWrapper {
                     target.setItem(property, value);
                 else
                     target[property] = value;
+
+                return true;
+            },
+
+            deleteProperty: (target, key) => {
+                if (getAddedProperties(target).includes(key))
+                    target.removeItem(key);
 
                 return true;
             }

--- a/test/client/fixtures/sandbox/storages-test.js
+++ b/test/client/fixtures/sandbox/storages-test.js
@@ -212,6 +212,18 @@ test('getter', function () {
     strictEqual(localStorage.null, void 0);
 });
 
+if (window.Proxy) {
+    test('convert value type on setter', function () {
+        sessionStorage.key1 = 111;
+        strictEqual(sessionStorage.getItem('key1'), '111');
+        strictEqual(sessionStorage.length, 1);
+
+        sessionStorage.key1 = 222;
+        strictEqual(sessionStorage.getItem('key1'), '222');
+        strictEqual(sessionStorage.length, 1);
+    });
+}
+
 module('area of visibility');
 
 test('iframe with empty src', function () {

--- a/test/client/fixtures/sandbox/storages-test.js
+++ b/test/client/fixtures/sandbox/storages-test.js
@@ -222,6 +222,29 @@ if (window.Proxy) {
         strictEqual(sessionStorage.getItem('key1'), '222');
         strictEqual(sessionStorage.length, 1);
     });
+
+    test('clear storage via delete properties', function () {
+        sessionStorage.key1 = 'value1';
+        strictEqual(sessionStorage.getItem('key1'), 'value1');
+        strictEqual(sessionStorage.length, 1);
+
+        sessionStorage.key2 = 'value2';
+        strictEqual(sessionStorage.getItem('key2'), 'value2');
+        strictEqual(sessionStorage.length, 2);
+
+        var previousKeyCount = Object.keys(sessionStorage).length;
+
+        for (var key in sessionStorage)
+            delete sessionStorage[key];
+
+        var currentKeyCount = Object.keys(sessionStorage).length;
+        var deletedKeyCount = 2;
+
+        strictEqual(currentKeyCount, previousKeyCount - deletedKeyCount);
+        strictEqual(sessionStorage.getItem('key1'), null);
+        strictEqual(sessionStorage.getItem('key2'), null);
+        strictEqual(sessionStorage.length, 0);
+    });
 }
 
 module('area of visibility');

--- a/test/client/fixtures/sandbox/storages-test.js
+++ b/test/client/fixtures/sandbox/storages-test.js
@@ -221,6 +221,9 @@ if (window.Proxy) {
         sessionStorage.key1 = 222;
         strictEqual(sessionStorage.getItem('key1'), '222');
         strictEqual(sessionStorage.length, 1);
+
+        sessionStorage.length = 3;
+        strictEqual(sessionStorage.length, 1);
     });
 
     test('clear storage via delete properties', function () {


### PR DESCRIPTION
https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-delete-p

According to the spec, we need to return false inside the `delete` trap to prevent errors on deleting non-configurable properties