### PR TITLE
Request hook options typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "19.4.1",
+  "version": "20.0.0",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/request-pipeline/request-hooks/matchers.ts
+++ b/src/request-pipeline/request-hooks/matchers.ts
@@ -1,0 +1,38 @@
+import { isRegExp } from 'lodash';
+import { ensureOriginTrailingSlash } from '../../utils/url';
+
+export function matchUrl (optionValue: string | RegExp | void, checkedValue: string) {
+    if (optionValue === void 0)
+        return true;
+
+    if (typeof optionValue === 'string') {
+        optionValue = ensureOriginTrailingSlash(optionValue);
+
+        return optionValue === checkedValue;
+    }
+
+    else if (isRegExp(optionValue))
+        return optionValue.test(checkedValue);
+
+    return false;
+}
+
+export function matchMethod (optionValue: string | void, checkedValue: string) {
+    if (optionValue === void 0)
+        return true;
+
+    if (typeof optionValue === 'string')
+        return optionValue === checkedValue;
+
+    return false;
+}
+
+export function matchIsAjax (optionValue: boolean | void, checkedValue: boolean) {
+    if (optionValue === void 0)
+        return true;
+
+    if (typeof optionValue === 'boolean')
+        return optionValue === checkedValue;
+
+    return false;
+}

--- a/src/request-pipeline/request-hooks/request-filter-options.ts
+++ b/src/request-pipeline/request-hooks/request-filter-options.ts
@@ -1,7 +1,7 @@
 import { isRegExp, isString } from 'lodash';
 import { ObjectInitializer, Predicate } from '../../typings/request-filter-rule';
 import { RequestInfo } from '../../session/events/info';
-import { ensureOriginTrailingSlash } from '../../utils/url';
+import { matchUrl, matchMethod, matchIsAjax } from './matchers';
 import RequestFilterRule from './request-filter-rule';
 
 export interface RequestFilterRuleOptions {
@@ -27,46 +27,10 @@ export class ObjectOptions implements RequestFilterRuleOptions {
         }
     }
 
-    private static matchUrl (optionValue: string | RegExp | void, checkedValue: string) {
-        if (optionValue === void 0)
-            return true;
-
-        if (typeof optionValue === 'string') {
-            optionValue = ensureOriginTrailingSlash(optionValue);
-
-            return optionValue === checkedValue;
-        }
-
-        else if (isRegExp(optionValue))
-            return optionValue.test(checkedValue);
-
-        return false;
-    }
-
-    private static matchMethod (optionValue: string | void, checkedValue: string) {
-        if (optionValue === void 0)
-            return true;
-
-        if (typeof optionValue === 'string')
-            return optionValue === checkedValue;
-
-        return false;
-    }
-
-    private static matchIsAjax (optionValue: boolean | void, checkedValue: boolean) {
-        if (optionValue === void 0)
-            return true;
-
-        if (typeof optionValue === 'boolean')
-            return optionValue === checkedValue;
-
-        return false;
-    }
-
     async match (requestInfo: RequestInfo) {
-        return ObjectOptions.matchUrl(this.url, requestInfo.url) &&
-               ObjectOptions.matchMethod(this.method, requestInfo.method) &&
-               ObjectOptions.matchIsAjax(this.isAjax, requestInfo.isAjax);
+        return matchUrl(this.url, requestInfo.url) &&
+               matchMethod(this.method, requestInfo.method) &&
+               matchIsAjax(this.isAjax, requestInfo.isAjax);
     }
 
     toString () {

--- a/src/request-pipeline/request-hooks/request-filter-options.ts
+++ b/src/request-pipeline/request-hooks/request-filter-options.ts
@@ -1,0 +1,107 @@
+import { isRegExp, isString } from 'lodash';
+import { ObjectInitializer, Predicate } from '../../typings/request-filter-rule';
+import { RequestInfo } from '../../session/events/info';
+import { ensureOriginTrailingSlash } from '../../utils/url';
+import RequestFilterRule from './request-filter-rule';
+
+export interface RequestFilterRuleOptions {
+    match: (requestInfo: RequestInfo, rule?: RequestFilterRule) => Promise<boolean>;
+    toString: () => string;
+}
+
+export class ObjectOptions implements RequestFilterRuleOptions {
+    url?: string | RegExp = void 0;
+    method?: string = void 0;
+    isAjax?: boolean = void 0;
+
+    constructor (initOptions: string | RegExp | ObjectInitializer) {
+        if (typeof initOptions === 'string' || isRegExp(initOptions))
+            this.url = initOptions;
+        else if (typeof initOptions === 'object') {
+            this.url = initOptions.url;
+            this.method = initOptions.method;
+            this.isAjax = initOptions.isAjax;
+
+            if (typeof this.method === 'string')
+                this.method = this.method.toLowerCase();
+        }
+    }
+
+    private static matchUrl (optionValue: string | RegExp | void, checkedValue: string) {
+        if (optionValue === void 0)
+            return true;
+
+        if (typeof optionValue === 'string') {
+            optionValue = ensureOriginTrailingSlash(optionValue);
+
+            return optionValue === checkedValue;
+        }
+
+        else if (isRegExp(optionValue))
+            return optionValue.test(checkedValue);
+
+        return false;
+    }
+
+    private static matchMethod (optionValue: string | void, checkedValue: string) {
+        if (optionValue === void 0)
+            return true;
+
+        if (typeof optionValue === 'string')
+            return optionValue === checkedValue;
+
+        return false;
+    }
+
+    private static matchIsAjax (optionValue: boolean | void, checkedValue: boolean) {
+        if (optionValue === void 0)
+            return true;
+
+        if (typeof optionValue === 'boolean')
+            return optionValue === checkedValue;
+
+        return false;
+    }
+
+    async match (requestInfo: RequestInfo) {
+        return ObjectOptions.matchUrl(this.url, requestInfo.url) &&
+               ObjectOptions.matchMethod(this.method, requestInfo.method) &&
+               ObjectOptions.matchIsAjax(this.isAjax, requestInfo.isAjax);
+    }
+
+    toString () {
+        const { url, method, isAjax } = this;
+
+        const stringifiedOptions = [
+            { name: 'url', value: url },
+            { name: 'method', value: method },
+            { name: 'isAjax', value: isAjax }
+        ];
+
+        const msg = stringifiedOptions.filter(option => !!option.value)
+            .map(option => {
+                const stringifiedOptionValue = isString(option.value) ? `"${option.value}"` : option.value;
+
+                return `${option.name}: ${stringifiedOptionValue}`;
+            })
+            .join(', ');
+
+        return `{ ${msg} }`;
+    }
+}
+
+const STRINGIFIED_FUNCTION_OPTIONS = '{ <predicate> }';
+
+const predicatePrototype: RequestFilterRuleOptions = {
+    match: async function (requestInfo: RequestInfo, rule: RequestFilterRule) {
+        return !!await (this as unknown as Predicate).call(rule, requestInfo);
+    },
+
+    toString () {
+        return STRINGIFIED_FUNCTION_OPTIONS;
+    }
+}
+
+export function PredicateOptions (predicate: Predicate): RequestFilterRuleOptions {
+    return Object.assign(predicate, predicatePrototype);
+}

--- a/src/request-pipeline/request-hooks/request-filter-options.ts
+++ b/src/request-pipeline/request-hooks/request-filter-options.ts
@@ -92,16 +92,18 @@ export class ObjectOptions implements RequestFilterRuleOptions {
 
 const STRINGIFIED_FUNCTION_OPTIONS = '{ <predicate> }';
 
-const predicatePrototype: RequestFilterRuleOptions = {
-    match: async function (requestInfo: RequestInfo, rule: RequestFilterRule) {
-        return !!await (this as unknown as Predicate).call(rule, requestInfo);
-    },
+export class PredicateOptions implements RequestFilterRuleOptions {
+    private predicate: Predicate;
+
+    constructor (predicate: Predicate) {
+        this.predicate = predicate;
+    }
+
+    async match (requestInfo: RequestInfo, rule: RequestFilterRule) {
+        return !!this.predicate.call(rule, requestInfo);
+    }
 
     toString () {
         return STRINGIFIED_FUNCTION_OPTIONS;
     }
-}
-
-export function PredicateOptions (predicate: Predicate): RequestFilterRuleOptions {
-    return Object.assign(predicate, predicatePrototype);
 }

--- a/src/request-pipeline/request-hooks/request-filter-rule.ts
+++ b/src/request-pipeline/request-hooks/request-filter-rule.ts
@@ -1,119 +1,20 @@
-import { isRegExp, isString } from 'lodash';
-import { ensureOriginTrailingSlash } from '../../utils/url';
 import { RequestInfo } from '../../session/events/info';
-import { Options, Predicate } from '../../typings/request-filter-rule';
-
-const DEFAULT_OPTIONS: Options = {
-    url:    void 0,
-    method: void 0,
-    isAjax: void 0
-};
+import { Predicate, ObjectInitializer } from '../../typings/request-filter-rule';
+import { PredicateOptions, ObjectOptions, RequestFilterRuleOptions } from './request-filter-options';
 
 const MATCH_ANY_REQUEST_REG_EX = /.*/;
 
-const STRINGIFIED_FUNCTION_OPTIONS = '{ <predicate> }';
-
 export default class RequestFilterRule {
-    private readonly options: Options | Predicate;
+    private readonly options: RequestFilterRuleOptions;
 
-    constructor (options: string | RegExp | Predicate | Options) {
-        this.options = this._initializeOptions(options);
-    }
-
-    _initializeOptions (options: string | RegExp | Predicate | Options) {
-        let tmpOptions: Options | Predicate = Object.assign({}, DEFAULT_OPTIONS);
-
-        if (typeof options === 'string' || isRegExp(options))
-            tmpOptions.url = options;
-        else if (typeof options === 'function')
-            tmpOptions = options;
-        else if (typeof options === 'object') {
-            tmpOptions = Object.assign(tmpOptions, options);
-
-            if (typeof tmpOptions.method === 'string')
-                tmpOptions.method = tmpOptions.method.toLowerCase();
-        }
-        else
-            throw new TypeError('Wrong options have been passed to a request filter.');
-
-        return tmpOptions;
-    }
-
-    _matchUrl (optionValue: any, checkedValue: any) {
-        if (optionValue === void 0)
-            return true;
-
-        if (typeof optionValue === 'string') {
-            optionValue = ensureOriginTrailingSlash(optionValue);
-
-            return optionValue === checkedValue;
-        }
-
-        else if (isRegExp(optionValue))
-            return optionValue.test(checkedValue);
-
-        return false;
-    }
-
-    _matchMethod (optionValue: any, checkedValue: any) {
-        if (optionValue === void 0)
-            return true;
-
-        if (typeof optionValue === 'string')
-            return optionValue === checkedValue;
-
-        return false;
-    }
-
-    _matchIsAjax (optionValue: any, checkedValue: any) {
-        if (optionValue === void 0)
-            return true;
-
-        if (typeof optionValue === 'boolean')
-            return optionValue === checkedValue;
-
-        return false;
-    }
-
-    _matchUsingObjectOptions (requestInfo: RequestInfo) {
-        const { url, method, isAjax } = this.options as Options;
-
-        return this._matchUrl(url, requestInfo.url) &&
-               this._matchMethod(method, requestInfo.method) &&
-               this._matchIsAjax(isAjax, requestInfo.isAjax);
-    }
-
-    async _matchUsingFunctionOptions (requestInfo: RequestInfo): Promise<boolean> {
-        const predicate = this.options as Predicate;
-
-        return !!predicate.call(this, requestInfo);
-    }
-
-    _stringifyObjectOptions () {
-        const { url, method, isAjax } = this.options as Options;
-
-        const stringifiedOptions = [
-            { name: 'url', value: url },
-            { name: 'method', value: method },
-            { name: 'isAjax', value: isAjax }
-        ];
-
-        const msg = stringifiedOptions.filter(option => !!option.value)
-            .map(option => {
-                const stringifiedOptionValue = isString(option.value) ? `"${option.value}"` : option.value;
-
-                return `${option.name}: ${stringifiedOptionValue}`;
-            })
-            .join(', ');
-
-        return `{ ${msg} }`;
+    constructor (options: string | RegExp | Predicate | ObjectInitializer) {
+        this.options = typeof options === 'function' ?
+            PredicateOptions(options) :
+            new ObjectOptions(options);
     }
 
     async match (requestInfo: RequestInfo): Promise<boolean> {
-        if (typeof this.options === 'function')
-            return await this._matchUsingFunctionOptions(requestInfo);
-
-        return this._matchUsingObjectOptions(requestInfo);
+        return this.options.match(requestInfo, this);
     }
 
     static get ANY (): RequestFilterRule {
@@ -127,8 +28,6 @@ export default class RequestFilterRule {
     }
 
     toString (): string {
-        const isFunctionOptions = typeof this.options === 'function';
-
-        return isFunctionOptions ? STRINGIFIED_FUNCTION_OPTIONS : this._stringifyObjectOptions();
+        return this.options.toString();
     }
 }

--- a/src/request-pipeline/request-hooks/request-filter-rule.ts
+++ b/src/request-pipeline/request-hooks/request-filter-rule.ts
@@ -9,7 +9,7 @@ export default class RequestFilterRule {
 
     constructor (options: string | RegExp | Predicate | ObjectInitializer) {
         this.options = typeof options === 'function' ?
-            PredicateOptions(options) :
+            new PredicateOptions(options) :
             new ObjectOptions(options);
     }
 

--- a/src/typings/request-filter-rule.d.ts
+++ b/src/typings/request-filter-rule.d.ts
@@ -1,8 +1,8 @@
 import { RequestInfo } from '../session/events/info';
 
-export type Predicate = (requestInfo: RequestInfo) => boolean;
+export type Predicate = (requestInfo: RequestInfo) => boolean | Promise<boolean>;
 
-export type Options = {
+export type ObjectInitializer = {
     url?:    string | RegExp,
     method?: string,
     isAjax?: boolean

--- a/src/typings/request-filter-rule.d.ts
+++ b/src/typings/request-filter-rule.d.ts
@@ -1,0 +1,9 @@
+import { RequestInfo } from '../session/events/info';
+
+export type Predicate = (requestInfo: RequestInfo) => boolean;
+
+export type Options = {
+    url?:    string | RegExp,
+    method?: string,
+    isAjax?: boolean
+}

--- a/test/server/request-hook-test.js
+++ b/test/server/request-hook-test.js
@@ -185,7 +185,7 @@ describe('RequestFilterRule', () => {
         const filterFn = () => false;
 
         hook = new RequestFilterRule(filterFn);
-        expect(hook.options).eql(filterFn);
+        expect(hook.options.predicate).eql(filterFn);
         expect(hook.toString()).eql('{ <predicate> }');
     });
 

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -51,10 +51,13 @@ declare module 'testcafe-hammerhead' {
 
     type RequestFilterPredicate = (requestInfo: RequestInfo) => boolean;
 
+    /** Specifies which requests the hook should handle **/
+    export type RequestFilterRuleOptions = string | RegExp | RequestFilterPredicate | ObjectInitializer;
+
     /** The RequestFilterRule class is used to create URL filtering rules for request hook **/
     export class RequestFilterRule {
         /** Creates a request filter rule instance **/
-        constructor (options: string | RegExp | RequestFilterPredicate | ObjectInitializer);
+        constructor (options: RequestFilterRuleOptions);
 
         /** Returns the value that accepts any request  **/
         static ANY: RequestFilterRule;

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -16,6 +16,14 @@ interface Session {
     handleFileDownload (): void;
 }
 
+type Predicate = (requestInfo: RequestInfo) => boolean;
+
+type ObjectInitializer = {
+    url?: string | RegExp;
+    method?: string;
+    isAjax?: boolean;
+};
+
 declare module 'testcafe-hammerhead' {
     import { IncomingHttpHeaders } from 'http';
 
@@ -46,7 +54,7 @@ declare module 'testcafe-hammerhead' {
     /** The RequestFilterRule class is used to create URL filtering rules for request hook **/
     export class RequestFilterRule {
         /** Creates a request filter rule instance **/
-        constructor (options: any);
+        constructor (options: string | RegExp | Predicate | ObjectInitializer);
 
         /** Returns the value that accepts any request  **/
         static ANY: RequestFilterRule;

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -16,8 +16,6 @@ interface Session {
     handleFileDownload (): void;
 }
 
-type Predicate = (requestInfo: RequestInfo) => boolean;
-
 type ObjectInitializer = {
     url?: string | RegExp;
     method?: string;
@@ -51,10 +49,12 @@ declare module 'testcafe-hammerhead' {
         unRegisterRoute (route: string, method: string): void;
     }
 
+    type RequestFilterPredicate = (requestInfo: RequestInfo) => boolean;
+
     /** The RequestFilterRule class is used to create URL filtering rules for request hook **/
     export class RequestFilterRule {
         /** Creates a request filter rule instance **/
-        constructor (options: string | RegExp | Predicate | ObjectInitializer);
+        constructor (options: string | RegExp | RequestFilterPredicate | ObjectInitializer);
 
         /** Returns the value that accepts any request  **/
         static ANY: RequestFilterRule;


### PR DESCRIPTION
## Purpose
Introducing a breaking change.
This PR extends `RequestFilterRule` typings and related types in the type declaration file.

## Approach
I also introduced a small refactoring of `RequestFilterRule` class since `_matchUsingFunctionOptions`, `_matchUsingObjectOptions`, and `_stringifyObjectOptions` were not type safe in general. I extracted `RequestFilterRuleOptions` interface and delegated mentioned functionality to it's implementations.

## References
Issue: https://github.com/DevExpress/testcafe/issues/4599
PR in testcafe repository: https://github.com/DevExpress/testcafe/pull/5770

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
