### PR TITLE
fix: don't override deprecated electron func

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "17.1.24",
+  "version": "17.1.25",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/client/sandbox/electron.ts
+++ b/src/client/sandbox/electron.ts
@@ -52,7 +52,11 @@ export default class ElectronSandbox extends SandboxBase {
 
         if (nativeMethods.refreshElectronMeths(vm)) {
             overrideFunction(vm, 'createScript', ElectronSandbox._createFnWrapper(vm, nativeMethods.createScript));
-            overrideFunction(vm, 'runInDebugContext', ElectronSandbox._createFnWrapper(vm, nativeMethods.runInDebugContext));
+
+            // NOTE: DebugContext has been removed in V8 and is not available in Node.js 10+
+            if (vm.runInDebugContext)
+                overrideFunction(vm, 'runInDebugContext', ElectronSandbox._createFnWrapper(vm, nativeMethods.runInDebugContext));
+
             overrideFunction(vm, 'runInContext', ElectronSandbox._createFnWrapper(vm, nativeMethods.runInContext));
             overrideFunction(vm, 'runInNewContext', ElectronSandbox._createFnWrapper(vm, nativeMethods.runInNewContext));
             overrideFunction(vm, 'runInThisContext', ElectronSandbox._createFnWrapper(vm, nativeMethods.runInThisContext));

--- a/test/client/fixtures/sandbox/electron-test.js
+++ b/test/client/fixtures/sandbox/electron-test.js
@@ -1,0 +1,20 @@
+const nativeMethods = hammerhead.nativeMethods;
+const browserUtils  = hammerhead.utils.browser;
+
+if (browserUtils.isElectron) {
+    const vm = window.require('vm');
+
+    if (vm) {
+        test('wrappers of native functions should return the correct string representations', function () {
+            window.checkStringRepresentation(vm.createScript, nativeMethods.createScript, 'vm.createScript');
+
+            // NOTE: DebugContext has been removed in V8 and is not available in Node.js 10+
+            if (vm.runInDebugContext)
+                window.checkStringRepresentation(vm.runInDebugContext, nativeMethods.runInDebugContext, 'vm.runInDebugContext');
+
+            window.checkStringRepresentation(vm.runInContext, nativeMethods.runInContext, 'vm.runInContext');
+            window.checkStringRepresentation(vm.runInNewContext, nativeMethods.runInNewContext, 'vm.runInNewContext');
+            window.checkStringRepresentation(vm.runInThisContext, nativeMethods.runInThisContext, 'vm.runInThisContext');
+        });
+    }
+}

--- a/test/client/fixtures/sandbox/electron-test.js
+++ b/test/client/fixtures/sandbox/electron-test.js
@@ -1,10 +1,10 @@
-const ElectronSandbox = hammerhead.get('./sandbox/electron');
-const overriding      = hammerhead.get('./utils/overriding');
+var ElectronSandbox = hammerhead.get('./sandbox/electron');
+var overriding      = hammerhead.get('./utils/overriding');
 
-const nativeEval = window.eval;
+var nativeEval = window.eval;
 
 QUnit.testStart(function () {
-    const vmMock = {
+    window.vmMock = {
         createScript:      window.noop,
         runInContext:      window.noop,
         runInNewContext:   window.noop,
@@ -14,7 +14,7 @@ QUnit.testStart(function () {
 
     window.windowMock = {
         require: function () {
-            return vmMock;
+            return window.vmMock;
         }
     };
 
@@ -30,6 +30,7 @@ QUnit.testStart(function () {
 });
 
 QUnit.testDone(function () {
+    delete window.vmMock;
     delete window.windowMock;
     delete window.nativeMethodsMock;
 
@@ -39,29 +40,25 @@ QUnit.testDone(function () {
 module('vm.runInDebugContext');
 
 test('should not be overwritten if it doesn\'t exist', function () {
-    const vmMock = window.windowMock.require('vm');
+    delete window.vmMock.runInDebugContext;
 
-    delete vmMock.runInDebugContext;
-
-    const electronSandbox = new ElectronSandbox();
+    var electronSandbox = new ElectronSandbox();
 
     electronSandbox.nativeMethods = window.nativeMethodsMock;
     electronSandbox.attach(window.windowMock);
 
-    notOk(vmMock.runInDebugContext);
+    notOk(window.vmMock.runInDebugContext);
 });
 
 test('should be overwritten if it exists', function () {
-    const vmMock = window.windowMock.require('vm');
-
-    const electronSandbox = new ElectronSandbox();
+    var electronSandbox = new ElectronSandbox();
 
     electronSandbox.nativeMethods = window.nativeMethodsMock;
 
-    ok(overriding.isNativeFunction(vmMock.runInDebugContext), 'should be native before overriding');
+    ok(overriding.isNativeFunction(window.vmMock.runInDebugContext), 'should be native before overriding');
 
     electronSandbox.attach(window.windowMock);
 
-    ok(vmMock.runInDebugContext, 'should exist');
-    notOk(overriding.isNativeFunction(vmMock.runInDebugContext), 'should be overwritten');
+    ok(window.vmMock.runInDebugContext, 'should exist');
+    notOk(overriding.isNativeFunction(window.vmMock.runInDebugContext), 'should be overwritten');
 });

--- a/test/client/fixtures/sandbox/electron-test.js
+++ b/test/client/fixtures/sandbox/electron-test.js
@@ -2,19 +2,22 @@ const nativeMethods = hammerhead.nativeMethods;
 const browserUtils  = hammerhead.utils.browser;
 
 if (browserUtils.isElectron) {
-    const vm = window.require('vm');
+    // NOTE: Electron window created without `nodeIntegration: true` doesn't have `window.require`
+    if (window.require) {
+        const vm = window.require('vm');
 
-    if (vm) {
-        test('wrappers of native functions should return the correct string representations', function () {
-            window.checkStringRepresentation(vm.createScript, nativeMethods.createScript, 'vm.createScript');
+        if (vm) {
+            test('wrappers of native functions should return the correct string representations', function () {
+                window.checkStringRepresentation(vm.createScript, nativeMethods.createScript, 'vm.createScript');
 
-            // NOTE: DebugContext has been removed in V8 and is not available in Node.js 10+
-            if (vm.runInDebugContext)
-                window.checkStringRepresentation(vm.runInDebugContext, nativeMethods.runInDebugContext, 'vm.runInDebugContext');
+                // NOTE: DebugContext has been removed in V8 and is not available in Node.js 10+
+                if (vm.runInDebugContext)
+                    window.checkStringRepresentation(vm.runInDebugContext, nativeMethods.runInDebugContext, 'vm.runInDebugContext');
 
-            window.checkStringRepresentation(vm.runInContext, nativeMethods.runInContext, 'vm.runInContext');
-            window.checkStringRepresentation(vm.runInNewContext, nativeMethods.runInNewContext, 'vm.runInNewContext');
-            window.checkStringRepresentation(vm.runInThisContext, nativeMethods.runInThisContext, 'vm.runInThisContext');
-        });
+                window.checkStringRepresentation(vm.runInContext, nativeMethods.runInContext, 'vm.runInContext');
+                window.checkStringRepresentation(vm.runInNewContext, nativeMethods.runInNewContext, 'vm.runInNewContext');
+                window.checkStringRepresentation(vm.runInThisContext, nativeMethods.runInThisContext, 'vm.runInThisContext');
+            });
+        }
     }
 }


### PR DESCRIPTION
vm.runInDebugContext [deprecated](https://nodejs.org/api/deprecations.html#deprecations_dep0069_vm_runindebugcontext_string) in V8 and in Node.js 10+. We should not override it without additional check. 