### PR TITLE
upgrade lodash dependency to 4.17.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "debug": "4.3.1",
     "esotope-hammerhead": "0.5.7",
     "iconv-lite": "0.5.1",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.20",
     "lru-cache": "2.6.3",
     "match-url-wildcard": "0.0.4",
     "merge-stream": "^1.0.1",


### PR DESCRIPTION
Upgraded the lodash dependency due to vulnerability that was found in version 4.17.19.