### PR TITLE
Refactoring

### DIFF
--- a/src/processing/resources/script.ts
+++ b/src/processing/resources/script.ts
@@ -1,5 +1,5 @@
 import ResourceProcessorBase from './resource-processor-base';
-import Lru from 'lru-cache';
+import LRUCache from 'lru-cache';
 import { processScript } from '../script';
 import RequestPipelineContext from '../../request-pipeline/context';
 import Charset from '../encoding/charset';
@@ -7,12 +7,12 @@ import { updateScriptImportUrls } from '../../utils/url';
 import BUILTIN_HEADERS from '../../request-pipeline/builtin-header-names';
 
 class ScriptResourceProcessor extends ResourceProcessorBase {
-    jsCache: Lru<string, string>;
+    jsCache: LRUCache<string, string>;
 
     constructor () {
         super();
 
-        this.jsCache = new Lru({
+        this.jsCache = new LRUCache({
             max:    50 * 1024 * 1024, // NOTE: Max cache size is 50 MBytes.
             length: n => n.length // NOTE: 1 char ~ 1 byte.
         });

--- a/src/request-pipeline/context.ts
+++ b/src/request-pipeline/context.ts
@@ -7,7 +7,7 @@ import ResponseMock from './request-hooks/response-mock';
 import { parseClientSyncCookieStr } from '../utils/cookie';
 import { ParsedClientSyncCookie } from '../typings/cookie';
 import RequestFilterRule from './request-hooks/request-filter-rule';
-import IncomingMessageMock from './incoming-message-mock';
+import IncomingMessageLike from './incoming-message-like';
 import RequestOptions from './request-options';
 import { ParsedProxyUrl } from '../typings/url';
 import { OnResponseEventData } from '../typings/context';
@@ -73,7 +73,7 @@ export default class RequestPipelineContext {
     session: Session = null;
     reqBody: Buffer = null;
     dest: DestInfo = null;
-    destRes: http.IncomingMessage | FileStream | IncomingMessageMock = null;
+    destRes: http.IncomingMessage | FileStream | IncomingMessageLike = null;
     isDestResReadableEnded = false;
     destResBody: Buffer = null;
     isAjax = false;

--- a/src/request-pipeline/create-special-page-response.ts
+++ b/src/request-pipeline/create-special-page-response.ts
@@ -1,11 +1,8 @@
-import IncomingMessageMock from './incoming-message-mock';
+import IncomingMessageLike from './incoming-message-like';
 import BUILTIN_HEADERS from './builtin-header-names';
 
 export default function createSpecialPageResponse () {
-    return new IncomingMessageMock({
-        _body:      Buffer.alloc(0),
-        statusCode: 200,
-        trailers:   {},
+    return new IncomingMessageLike({
         headers:    {
             [BUILTIN_HEADERS.contentType]:   'text/html',
             [BUILTIN_HEADERS.contentLength]: '0'

--- a/src/request-pipeline/destination-request/index.ts
+++ b/src/request-pipeline/destination-request/index.ts
@@ -29,15 +29,13 @@ export default class DestinationRequest extends EventEmitter implements Destinat
     private hasResponse = false;
     private credentialsSent = false;
     private aborted = false;
-    private readonly opts: RequestOptions;
     private readonly isHttps: boolean;
     private readonly protocolInterface: any;
     private readonly timeout: number;
 
-    constructor (opts: RequestOptions) {
+    constructor (readonly opts: RequestOptions) {
         super();
 
-        this.opts              = opts;
         this.isHttps           = opts.protocol === 'https:';
         this.protocolInterface = this.isHttps ? https : http;
         this.timeout           = this.opts.isAjax ? opts.requestTimeout.ajax : opts.requestTimeout.page;

--- a/src/request-pipeline/incoming-message-like.ts
+++ b/src/request-pipeline/incoming-message-like.ts
@@ -5,22 +5,35 @@ interface InitOptions {
     headers: { [name: string]: string|string[] };
     trailers: { [key: string]: string | undefined };
     statusCode: number;
-    _body: object|string|Buffer|null;
+    body: object|string|Buffer|null;
 }
 
-export default class IncomingMessageMock extends Readable {
+const DEFAULT_STATUS_CODE = 200;
+
+export default class IncomingMessageLike extends Readable {
     private _body: Buffer|null;
     headers: IncomingHttpHeaders;
     trailers: { [key: string]: string | undefined };
     statusCode: number;
 
-    constructor (init: InitOptions) {
+    constructor (init: Partial<InitOptions> = {}) {
         super();
 
-        this.headers    = init.headers;
-        this.trailers   = init.trailers;
-        this.statusCode = init.statusCode;
-        this._body      = this._getBody(init._body);
+        const { headers, trailers, statusCode, body } = this._getOptions(init);
+
+        this.headers    = headers;
+        this.trailers   = trailers;
+        this.statusCode = statusCode;
+        this._body      = this._getBody(body);
+    }
+
+    private _getOptions (init: Partial<InitOptions>): InitOptions {
+        return {
+            headers:    Object.assign({}, init.headers),
+            trailers:   Object.assign({}, init.trailers),
+            statusCode: init.statusCode || DEFAULT_STATUS_CODE,
+            body:       init.body || Buffer.alloc(0)
+        }
     }
 
     _read (): void {

--- a/src/request-pipeline/request-hooks/response-mock.ts
+++ b/src/request-pipeline/request-hooks/response-mock.ts
@@ -1,4 +1,4 @@
-import IncomingMessageMock from '../incoming-message-mock';
+import IncomingMessageLike from '../incoming-message-like';
 import { JSON_MIME } from '../../utils/content-type';
 import BUILTIN_HEADERS from '../builtin-header-names';
 import RequestOptions from '../request-options';
@@ -85,21 +85,20 @@ export default class ResponseMock {
         this.requestOptions = opts;
     }
 
-    async getResponse (): Promise<IncomingMessageMock> {
+    async getResponse (): Promise<IncomingMessageLike> {
         let response: any = {
             headers:    { [BUILTIN_HEADERS.contentType]: this._getContentType() },
-            trailers:   {},
-            statusCode: this.statusCode || 200
+            statusCode: this.statusCode
         };
 
         if (this.headers)
             response.headers = Object.assign(response.headers, this.headers);
 
         if (this.body === void 0)
-            response._body = EMPTY_PAGE_HTML;
+            response.body = EMPTY_PAGE_HTML;
         else if (typeof this.body === 'function') {
             response.setBody = value => {
-                response._body = value;
+                response.body = value;
             };
 
             response = Object.assign(response, await this.body(this.requestOptions, response));
@@ -107,10 +106,10 @@ export default class ResponseMock {
             delete response.setBody;
         }
         else
-            response._body = this.body;
+            response.body = this.body;
 
         response.headers = this._lowerCaseHeaderNames(response.headers);
 
-        return new IncomingMessageMock(response);
+        return new IncomingMessageLike(response);
     }
 }

--- a/src/request-pipeline/stages.ts
+++ b/src/request-pipeline/stages.ts
@@ -2,7 +2,7 @@ import RequestPipelineContext from './context';
 import logger from '../utils/logger';
 import { fetchBody } from '../utils/http';
 import RequestOptions from './request-options';
-import createSpecialPageResponse from "./special-page";
+import createSpecialPageResponse from './create-special-page-response';
 import { RequestInfo } from '../session/events/info';
 import {
     callOnConfigureResponseEventForNonProcessedRequest,
@@ -61,6 +61,7 @@ export default [
             ctx.destRes = createSpecialPageResponse();
 
             ctx.buildContentInfo();
+
             return;
         }
 
@@ -92,6 +93,7 @@ export default [
             await ctx.session.callRequestEventCallback(RequestEventNames.onConfigureResponse, rule, configureResponseEvent);
             await callOnResponseEventCallbackForFailedSameOriginCheck(ctx, rule, ConfigureResponseEventOptions.DEFAULT);
         });
+
         logger.proxy.onCORSFailed(ctx);
     },
 


### PR DESCRIPTION
Changes:
* Standartize the `lru-cache` module import
* Rename the `IncomingMessageMock` class to `IncomingMessageLike`. I used the similar naming as TypeScript declaration uses for the base classes/objects (`ArrayLike`, `ArrayBufferLike`, `FunctionLikeDeclaration`, etc.)
* Add default values for `IncomingMessageLike` constructor parameters