### PR TITLE
Fix document title processing in iframes

### DIFF
--- a/src/client/sandbox/child-window/index.ts
+++ b/src/client/sandbox/child-window/index.ts
@@ -13,6 +13,7 @@ import isKeywordTarget from '../../../utils/is-keyword-target';
 import Listeners from '../event/listeners';
 import INTERNAL_PROPS from '../../../processing/dom/internal-properties';
 import getTopOpenerWindow from '../../utils/get-top-opener-window';
+import { isIframeWindow } from '../../utils/dom';
 
 const DEFAULT_WINDOW_PARAMETERS = 'width=500px, height=500px';
 const STORE_CHILD_WINDOW_CMD    = 'hammerhead|command|store-child-window';
@@ -123,7 +124,7 @@ export default class ChildWindowSandbox extends SandboxBase {
     }
 
     private _setupChildWindowCollecting (window: Window) {
-        if (window !== window.top)
+        if (isIframeWindow(window))
             return;
 
         const topOpenerWindow = getTopOpenerWindow();

--- a/src/client/sandbox/code-instrumentation/location/wrapper.ts
+++ b/src/client/sandbox/code-instrumentation/location/wrapper.ts
@@ -26,6 +26,7 @@ import DOMStringListWrapper from './ancestor-origins-wrapper';
 import IntegerIdGenerator from '../../../utils/integer-id-generator';
 import { createOverriddenDescriptor, overrideStringRepresentation } from '../../../utils/overriding';
 import MessageSandbox from '../../event/message';
+import { isIframeWindow } from '../../../utils/dom';
 
 const GET_ORIGIN_CMD      = 'hammerhead|command|get-origin';
 const ORIGIN_RECEIVED_CMD = 'hammerhead|command|origin-received';
@@ -56,7 +57,7 @@ export default class LocationWrapper extends LocationInheritor {
         const locationPropsOwner     = isLocationPropsInProto ? window.Location.prototype : window.location;
         const locationProps: any     = {};
 
-        parsedResourceType.isIframe = parsedResourceType.isIframe || window !== window.top;
+        parsedResourceType.isIframe = parsedResourceType.isIframe || isIframeWindow(window);
 
         const resourceType   = getResourceTypeString({
             isIframe: parsedResourceType.isIframe,
@@ -64,7 +65,7 @@ export default class LocationWrapper extends LocationInheritor {
         });
         const getHref        = () => {
             // eslint-disable-next-line no-restricted-properties
-            if (window !== window.top && window.location.href === SPECIAL_BLANK_PAGE)
+            if (isIframeWindow(window) && window.location.href === SPECIAL_BLANK_PAGE)
                 return SPECIAL_BLANK_PAGE;
 
             const locationUrl    = getDestLocation();

--- a/src/client/sandbox/console.ts
+++ b/src/client/sandbox/console.ts
@@ -1,5 +1,5 @@
 import SandboxBase from './base';
-import { isCrossDomainWindows } from '../utils/dom';
+import { isCrossDomainWindows, isIframeWindow } from '../utils/dom';
 import nativeMethods from '../sandbox/native-methods';
 import MessageSandbox from './event/message';
 import { overrideFunction } from '../utils/overriding';
@@ -30,7 +30,7 @@ export default class ConsoleSandbox extends SandboxBase {
     private _proxyConsoleMeth (meth: keyof Console): void {
         overrideFunction(this.window.console, meth, (...args: any[]) => {
             if (!isCrossDomainWindows(window, window.top)) {
-                const sendToTopWindow = window !== window.top;
+                const sendToTopWindow = isIframeWindow(window);
                 const line            = nativeMethods.arrayMap.call(args, this._toString).join(' ');
 
                 if (sendToTopWindow) {

--- a/src/client/sandbox/event/active-window-tracker.ts
+++ b/src/client/sandbox/event/active-window-tracker.ts
@@ -1,5 +1,6 @@
 import SandboxBase from '../base';
 import MessageSandbox from './message';
+import { isIframeWindow } from '../../utils/dom';
 
 const WINDOW_ACTIVATED_EVENT   = 'hammerhead|event|window-activated';
 const WINDOW_DEACTIVATED_EVENT = 'hammerhead|event|window-deactivated';
@@ -29,7 +30,7 @@ export default class ActiveWindowTracker extends SandboxBase {
     attach (window: Window & typeof globalThis): void {
         super.attach(window);
 
-        this._isIframeWindow = window !== window.top;
+        this._isIframeWindow = isIframeWindow(window);
         this._activeWindow   = !this._isIframeWindow ? window.top : null;
         this._isActive       = !this._isIframeWindow;
 

--- a/src/client/sandbox/node/index.ts
+++ b/src/client/sandbox/node/index.ts
@@ -20,6 +20,7 @@ import * as browserUtils from '../../utils/browser';
 import ChildWindowSandbox from '../child-window';
 import DocumentTitleStorage from './document/title-storage';
 import DocumentTitleStorageInitializer from './document/title-storage-initializer';
+import { isIframeWindow } from '../../utils/dom';
 
 const ATTRIBUTE_SELECTOR_REG_EX          = /\[([\w-]+)(\^?=.+?)]/g;
 const ATTRIBUTE_OPERATOR_WITH_HASH_VALUE = /^\W+\s*#/;
@@ -58,7 +59,7 @@ export default class NodeSandbox extends SandboxBase {
     }
 
     private static _createDocumentTitleStorageInitializer (): DocumentTitleStorageInitializer | null {
-        if (window !== window.top)
+        if (isIframeWindow(window))
             return null;
 
         const documentTitleStorage = new DocumentTitleStorage(document);

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -76,6 +76,7 @@ import DefaultTarget from '../child-window/default-target';
 import { getNativeQuerySelectorAll } from '../../utils/query-selector';
 import DocumentTitleStorageInitializer from './document/title-storage-initializer';
 import { SET_BLOB_WORKER_SETTINGS, SET_SERVICE_WORKER_SETTINGS } from '../../worker/set-settings-command';
+import { isIframeWindow } from '../../utils/dom';
 
 const INSTRUCTION_VALUES = (() => {
     const values = [];
@@ -200,7 +201,7 @@ export default class WindowSandbox extends SandboxBase {
         if (isCrossDomainWindows(window, window.top))
             return;
 
-        const sendToTopWindow = window !== window.top;
+        const sendToTopWindow = isIframeWindow(window);
         const pageUrl         = destLocation.get();
         let msg               = null;
         let stack             = null;
@@ -375,6 +376,9 @@ export default class WindowSandbox extends SandboxBase {
     }
 
     private _setSandboxedTextForTitleElements (el: Node & ParentNode): void {
+        if (isIframeWindow(window))
+            return;
+
         const titleElements = getNativeQuerySelectorAll(el).call(el, 'title');
 
         for(const titleElement of titleElements) {

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -333,6 +333,10 @@ export function isCrossDomainWindows (window1: Window, window2: Window): boolean
     }
 }
 
+export function isIframeWindow (wnd: Window): boolean {
+    return wnd !== wnd.top;
+}
+
 export function isDomElement (el): boolean {
     if (el instanceof nativeMethods.elementClass)
         return true;

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -701,6 +701,17 @@ test("SVG's <title> element (GH-2364)", function () {
     div.parentNode.removeChild(div);
 });
 
+test('creation via "innerHTML" in iframe', function () {
+    return createTestIframe()
+        .then(function (iframe) {
+            var html = '<head><title>Test title</title></head><body></body>';
+
+            iframe.contentDocument.documentElement.innerHTML = html;
+
+            strictEqual(iframe.contentDocument.title, 'Test title');
+        });
+});
+
 module('regression');
 
 test('document.write for several tags in iframe (T215136)', function () {


### PR DESCRIPTION
Changes:
* create the `isIframeWindow` function
* don't synchronize `title` element states in iframe (https://github.com/DevExpress/testcafe-hammerhead/pull/2551/files#diff-1c867b70f2703892e0cf051b0769fd3d2a1dad201ec156a6c0ebf3205ad53ab4R379)