### PR TITLE
Fix `JavaScript erro occurred in ODOO v13 CRM demo when running with TestCafe` (closes #2554)

### DIFF
--- a/src/client/sandbox/iframe.ts
+++ b/src/client/sandbox/iframe.ts
@@ -3,7 +3,7 @@ import SandboxBase from './base';
 import settings from '../settings';
 import nativeMethods from '../sandbox/native-methods';
 import DomProcessor from '../../processing/dom';
-import { isShadowUIElement, isIframeWithoutSrc, getTagName } from '../utils/dom';
+import { isShadowUIElement, isIframeWithoutSrc, isIframeElement, isFrameElement } from '../utils/dom';
 import { isFirefox, isWebKit, isIE } from '../utils/browser';
 import * as JSON from 'json-hammerhead';
 import NodeMutation from './node/mutation';
@@ -153,10 +153,8 @@ export default class IframeSandbox extends SandboxBase {
         if (isShadowUIElement(el))
             return;
 
-        const tagName = getTagName(el);
-
-        if (tagName === 'iframe' && nativeMethods.contentWindowGetter.call(el) ||
-            tagName === 'frame' && nativeMethods.frameContentWindowGetter.call(el))
+        if (isIframeElement(el) && nativeMethods.contentWindowGetter.call(el) ||
+            isFrameElement(el) && nativeMethods.frameContentWindowGetter.call(el))
             this._raiseReadyToInitEvent(el);
 
         // NOTE: This handler exists for iframes without the src attribute. In some the browsers (e.g. Chrome)

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -397,6 +397,10 @@ export function isIframeElement (el: any): el is HTMLIFrameElement {
     return instanceToString(el) === '[object HTMLIFrameElement]';
 }
 
+export function isFrameElement (el: any): el is HTMLFrameElement {
+    return instanceToString(el) === '[object HTMLFrameElement]';
+}
+
 export function isIframeWithoutSrc (iframe: HTMLIFrameElement | HTMLFrameElement): boolean {
     const iframeLocation         = getIframeLocation(iframe);
     const iframeSrcLocation      = iframeLocation.srcLocation;

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -147,6 +147,26 @@ if (nativeMethods.iframeSrcdocGetter) {
     });
 }
 
+test('should not call the contentWindow getter while cloning iframe/frame from XMLDocument (GH-2554)', function () {
+    expect(0);
+
+    var str = '<document><iframe /><frame /></document>';
+
+    var parser      = new DOMParser();
+    var xmlDocument = parser.parseFromString(str, 'text/xml');
+    var iframe      = xmlDocument.childNodes[0].childNodes[0];
+    var frame       = xmlDocument.childNodes[0].childNodes[1];
+
+    try {
+        // NOTE: in this case we have the "Element" iframe/frame prototype that doesn't have the contentWindow getter.
+        iframe.cloneNode(true);
+        frame.cloneNode(true);
+    }
+    catch (e) {
+        ok(false, e);
+    }
+});
+
 module('regression');
 
 test('take sequences starting with "$" into account when generating task scripts (GH-389)', function () {

--- a/test/client/fixtures/utils/dom-test.js
+++ b/test/client/fixtures/utils/dom-test.js
@@ -931,6 +931,7 @@ if (!browserUtils.isFirefox) {
 
 test("An object with the 'tagName' and 'nodeName' properties shouldn't be recognized as a dom element", function () {
     notOk(domUtils.isIframeElement({ tagName: 'iframe', nodeName: 'iframe' }), 'iframe');
+    notOk(domUtils.isFrameElement({ tagName: 'frame', nodeName: 'frame' }), 'frame');
     notOk(domUtils.isImgElement({ tagName: 'img', nodeName: 'img' }), 'img');
     notOk(domUtils.isInputElement({ tagName: 'input', nodeName: 'input' }), 'input');
     notOk(domUtils.isHtmlElement({ tagName: 'html', nodeName: 'html' }), 'html');
@@ -956,6 +957,7 @@ test("An object with the 'tagName' and 'nodeName' properties shouldn't be recogn
 test('inspect html elements', function () {
     const htmlElements = [
         { tagName: 'iframe', assertFn: domUtils.isIframeElement },
+        { tagName: 'frame', assertFn: domUtils.isFrameElement },
         { tagName: 'img', assertFn: domUtils.isImgElement },
         { tagName: 'input', assertFn: domUtils.isInputElement },
         { tagName: 'html', assertFn: domUtils.isHtmlElement },


### PR DESCRIPTION
## Purpose
`iframe`/`frame` elements have no `contentWindow` getter while cloning from XMLDocument: these elements are `Element` instances in XMLDocument. This leads to the `Illegal invocation` error when trying to call `contentWindowGetter`/`frameContentWindowGetter`.

## Approach
A more strict condition was used to determine `iframe`/`frame` elements in the `processIframe` function (instead of using `tagName`).

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
