### PR TITLE
Fix the Chrome 88 domParser test, remove unnecessary old IE conditions

### DIFF
--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -136,30 +136,28 @@ test('url attributes overridden by descriptor', function () {
         testUrlAttr(testData[i].tagName, testData[i].attr, testData[i].getter);
 });
 
-if (!browserUtils.isIE || browserUtils.version > 9) {
-    test('formaction attribute in the form', function () {
-        var form   = document.createElement('form');
-        var input  = document.createElement('input');
-        var button = document.createElement('button');
+test('formaction attribute in the form', function () {
+    var form   = document.createElement('form');
+    var input  = document.createElement('input');
+    var button = document.createElement('button');
 
-        input.type = 'submit';
+    input.type = 'submit';
 
-        form.appendChild(input);
-        form.appendChild(button);
+    form.appendChild(input);
+    form.appendChild(button);
 
-        nativeMethods.setAttribute.call(form, 'action', urlUtils.getProxyUrl('./action.html', { resourceType: 'f' }));
-        input.setAttribute('formaction', './input.html');
-        button.setAttribute('formaction', './button.html');
-        strictEqual(urlUtils.parseProxyUrl(nativeMethods.inputFormActionGetter.call(input)).resourceType, 'f');
-        strictEqual(urlUtils.parseProxyUrl(nativeMethods.buttonFormActionGetter.call(button)).resourceType, 'f');
+    nativeMethods.setAttribute.call(form, 'action', urlUtils.getProxyUrl('./action.html', { resourceType: 'f' }));
+    input.setAttribute('formaction', './input.html');
+    button.setAttribute('formaction', './button.html');
+    strictEqual(urlUtils.parseProxyUrl(nativeMethods.inputFormActionGetter.call(input)).resourceType, 'f');
+    strictEqual(urlUtils.parseProxyUrl(nativeMethods.buttonFormActionGetter.call(button)).resourceType, 'f');
 
-        nativeMethods.setAttribute.call(form, 'action', urlUtils.getProxyUrl('./action.html', { resourceType: 'fi' }));
-        input.setAttribute('formaction', './input.html');
-        button.setAttribute('formaction', './button.html');
-        strictEqual(urlUtils.parseProxyUrl(nativeMethods.inputFormActionGetter.call(input)).resourceType, 'fi');
-        strictEqual(urlUtils.parseProxyUrl(nativeMethods.buttonFormActionGetter.call(button)).resourceType, 'fi');
-    });
-}
+    nativeMethods.setAttribute.call(form, 'action', urlUtils.getProxyUrl('./action.html', { resourceType: 'fi' }));
+    input.setAttribute('formaction', './input.html');
+    button.setAttribute('formaction', './button.html');
+    strictEqual(urlUtils.parseProxyUrl(nativeMethods.inputFormActionGetter.call(input)).resourceType, 'fi');
+    strictEqual(urlUtils.parseProxyUrl(nativeMethods.buttonFormActionGetter.call(button)).resourceType, 'fi');
+});
 
 test('set and remove "formtarget" attribute on form child element with existing "formaction" attribute', function () {
     var iframe = document.createElement('iframe');

--- a/test/client/fixtures/sandbox/node/methods-test.js
+++ b/test/client/fixtures/sandbox/node/methods-test.js
@@ -303,17 +303,10 @@ if (window.DOMParser) {
 
             strictEqual(nativeMethods.getAttribute.call(anchor, 'href'), '/path');
 
-            if (!browserUtils.isChrome || browserUtils.version < 88) {
-                parsedDocument = domParser.parseFromString(htmlStr, 'text/html', 'third argument');
-                anchor = parsedDocument.querySelector('a');
+            parsedDocument = domParser.parseFromString(htmlStr, 'text/html');
+            anchor         = parsedDocument.querySelector('a');
 
-                strictEqual(nativeMethods.anchorHrefGetter.call(anchor), proxyUrl);
-            }
-            else {
-                throws(function () {
-                    domParser.parseFromString(htmlStr, 'text/html', 'third argument');
-                }, TypeError);
-            }
+            strictEqual(nativeMethods.anchorHrefGetter.call(anchor), proxyUrl);
         });
 
         test('parseFromString result Document should not contain self-removing scripts (GH-1619)', function () {

--- a/test/client/fixtures/sandbox/node/methods-test.js
+++ b/test/client/fixtures/sandbox/node/methods-test.js
@@ -303,10 +303,17 @@ if (window.DOMParser) {
 
             strictEqual(nativeMethods.getAttribute.call(anchor, 'href'), '/path');
 
-            parsedDocument = domParser.parseFromString(htmlStr, 'text/html', 'third argument');
-            anchor         = parsedDocument.querySelector('a');
+            if (!browserUtils.isChrome || browserUtils.version < 88) {
+                parsedDocument = domParser.parseFromString(htmlStr, 'text/html', 'third argument');
+                anchor = parsedDocument.querySelector('a');
 
-            strictEqual(nativeMethods.anchorHrefGetter.call(anchor), proxyUrl);
+                strictEqual(nativeMethods.anchorHrefGetter.call(anchor), proxyUrl);
+            }
+            else {
+                throws(function () {
+                    domParser.parseFromString(htmlStr, 'text/html', 'third argument');
+                }, TypeError);
+            }
         });
 
         test('parseFromString result Document should not contain self-removing scripts (GH-1619)', function () {
@@ -524,19 +531,17 @@ test('document.createDocumentFragment must be overriden (B237717)', function () 
     notEqual(clone.firstChild.getAttribute, nativeMethods.getAttribute);
 });
 
-if (!browserUtils.isIE || browserUtils.version > 9) {
-    test('Range.createContextualFragment must be overriden (GH-535)', function () {
-        var tagString = '<a href="http://some.domain.com/index.html"></a>';
-        var range     = document.createRange();
-        var container = document.createElement('div');
+test('Range.createContextualFragment must be overriden (GH-535)', function () {
+    var tagString = '<a href="http://some.domain.com/index.html"></a>';
+    var range     = document.createRange();
+    var container = document.createElement('div');
 
-        document.body.appendChild(container);
+    document.body.appendChild(container);
 
-        range.selectNode(container);
+    range.selectNode(container);
 
-        var fragment = range.createContextualFragment(tagString);
-        var anchor   = fragment.childNodes[0];
+    var fragment = range.createContextualFragment(tagString);
+    var anchor   = fragment.childNodes[0];
 
-        strictEqual(nativeMethods.anchorHrefGetter.call(anchor), urlUtils.getProxyUrl('http://some.domain.com/index.html'));
-    });
-}
+    strictEqual(nativeMethods.anchorHrefGetter.call(anchor), urlUtils.getProxyUrl('http://some.domain.com/index.html'));
+});


### PR DESCRIPTION
## Purpose
Chrome 88 throws `TypeError` in the case of three `domParser` arguments:
```js
var domParser = new DOMParser();

domParser.parseFromString('<a href="/path">Anchor</a>', 'text/html', 'third argument');
```

## References
https://developer.mozilla.org/en-US/docs/Web/API/DOMParser#domxrefdomparser.parsefromstring_1:
> Parameters
This method has 2 parameters (both required):
**string**
The DOMString to be parsed. It must contain either HTML, xml, xhtml+xml, or svg document.
**mimeType**
A DOMString. This string determines a class of the method's return value. The possible values are the following:
...
