### PR TITLE
Fix `hammerhead.js throwing Uncaught DOMException: Failed to construct 'Worker' error on recaptcha call`

### DIFF
--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -530,8 +530,10 @@ export default class WindowSandbox extends SandboxBase {
 
                 let scriptURL = args[0];
 
-                if (typeof scriptURL === 'string')
-                    scriptURL = getProxyUrl(scriptURL, { resourceType: stringifyResourceType({ isScript: true }) });
+                if (typeof scriptURL !== 'string')
+                    scriptURL = String(scriptURL);
+
+                scriptURL = getProxyUrl(scriptURL, { resourceType: stringifyResourceType({ isScript: true }) });
 
                 const worker = arguments.length === 1
                     ? new nativeMethods.Worker(scriptURL)

--- a/test/client/fixtures/worker-test.js
+++ b/test/client/fixtures/worker-test.js
@@ -22,7 +22,7 @@ test('throwing errors (GH-1132)', function () {
     }, TypeError);
 });
 
-test('checking parameters (GH-1132)', function () {
+test('checking parameters (GH-1132, GH-2512)', function () {
     var savedNativeWorker = nativeMethods.Worker;
     var workerOptions     = { name: 'test' };
     var resourceType      = urlUtils.stringifyResourceType({ isScript: true });
@@ -31,16 +31,22 @@ test('checking parameters (GH-1132)', function () {
         strictEqual(arguments.length, 1);
         strictEqual(scriptURL, urlUtils.getProxyUrl('/test', { resourceType: resourceType }));
     };
-    // eslint-disable-next-line no-new
+    /* eslint-disable no-new */
     new Worker('/test');
+    // NOTE: GH-2512
+    new Worker({
+        toString: function () {
+            return '/test';
+        }
+    });
 
     nativeMethods.Worker = function (scriptURL, options) {
         strictEqual(arguments.length, 2);
         strictEqual(scriptURL, urlUtils.getProxyUrl('/test', { resourceType: resourceType }));
         strictEqual(options, workerOptions);
     };
-    // eslint-disable-next-line no-new
     new Worker('/test', workerOptions);
+    /* eslint-enable no-new */
 
     nativeMethods.Worker = savedNativeWorker;
 });


### PR DESCRIPTION
## Purpose
Fix the case of `Worker` created from an URL object (reCAPTCHA, [Trusted Types](https://web.dev/trusted-types/))

## Approach
The URL parameter was converted to `string` before proxying.

## References
https://github.com/w3c/webappsec-trusted-types

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
