### PR TITLE
fix pointer events

### DIFF
--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -5,6 +5,7 @@ import * as domUtils from '../../utils/dom';
 import * as eventUtils from '../../utils/event';
 import { getOffsetPosition, offsetToClientCoords, shouldIgnoreMouseEventInsideIframe } from '../../utils/position';
 import { getBordersWidth } from '../../utils/style';
+import { isTouchDevice } from '../../utils/feature-detection';
 
 const TOUCH_EVENT_RADIUS = 25;
 const TOUCH_EVENT_FORCE  = 0.5;
@@ -622,7 +623,9 @@ export default class EventSimulator {
             }
         }
 
-        if (eventUtils.hasPointerEvents)
+        // NOTE: In the case of touch devices we have already dispatched pointer events in _dispatchTouchEvent
+        // (TC-GH-5891)
+        if (eventUtils.hasPointerEvents && !isTouchDevice)
             this._dispatchPointerEvent(el, args);
 
         return this._dispatchMouseEvent(el, args, userOptions);


### PR DESCRIPTION
## Purpose
`pointerdown` and `pointerup` events are called twice in the case of touch devices: https://github.com/DevExpress/testcafe/issues/5891.

## Approach
Unnecessary pointer events call (`_dispatchMouseRelatedEvents`) is removed in the case of touch devices.

## References
Test: https://github.com/DevExpress/testcafe/pull/5900


[testcafe-hammerhead-19.2.1-fix-pointer-events.zip](https://github.com/DevExpress/testcafe-hammerhead/files/5886590/testcafe-hammerhead-19.2.1-fix-pointer-events.zip)

