### PR TITLE
refactor(client): make destLocation utils accessible

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -6,6 +6,7 @@ import settings from './settings';
 import Transport from './transport';
 import * as JSON from 'json-hammerhead';
 import * as browserUtils from './utils/browser';
+import * as destLocationUtils from './utils/destination-location';
 import * as domUtils from './utils/dom';
 import * as eventUtils from './utils/event';
 import * as typeUtils from './utils/types';
@@ -132,7 +133,8 @@ class Hammerhead {
             extend:           extend,
             html:             htmlUtils,
             url:              urlUtils,
-            featureDetection: featureDetection
+            featureDetection: featureDetection,
+            destLocation:     destLocationUtils
         };
     }
 

--- a/test/client/before-test.js
+++ b/test/client/before-test.js
@@ -13,7 +13,7 @@
 
     var INTERNAL_PROPS = hammerhead.get('../processing/dom/internal-properties');
     var INSTRUCTION    = hammerhead.get('../processing/script/instruction');
-    var destLocation   = hammerhead.get('./utils/destination-location');
+    var destLocation   = hammerhead.utils.destLocation;
     var iframeSandbox  = hammerhead.sandbox.iframe;
     var cookieSandbox  = hammerhead.sandbox.cookie;
 
@@ -26,7 +26,7 @@
     };
 
     var iframeTaskScriptTemplate = [
-        'window["%hammerhead%"].get("./utils/destination-location").forceLocation("{{{location}}}");',
+        'window["%hammerhead%"].utils.destLocation.forceLocation("{{{location}}}");',
         'window["%hammerhead%"].start({',
         '    referer : {{{referer}}},',
         '    cookie: {{{cookie}}},',
@@ -60,7 +60,7 @@
 
         if (iframe.id.indexOf('test') !== -1) {
             iframe.contentWindow.eval.call(iframe.contentWindow, [
-                'window["%hammerhead%"].get("./utils/destination-location").forceLocation("' + location + '");',
+                'window["%hammerhead%"].utils.destLocation.forceLocation("' + location + '");',
                 'window["%hammerhead%"].start({',
                 '    referer: ' + JSON.stringify(referer) + ',',
                 '    serviceMsgUrl: "' + serviceMsgUrl + '",',

--- a/test/client/data/active-window-tracker/active-window-tracker.html
+++ b/test/client/data/active-window-tracker/active-window-tracker.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     window.activeWindowTracker = hammerhead.sandbox.event.focusBlur._activeWindowTracker;

--- a/test/client/data/code-instrumentation/iframe.html
+++ b/test/client/data/code-instrumentation/iframe.html
@@ -9,11 +9,11 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({
         sessionId:                'sessionId',
         crossDomainProxyPort:     2000,
-        iframeTaskScriptTemplate: 'window["%hammerhead%"].get("./utils/destination-location").forceLocation("http://localhost/sessionId/https://example.com");' +
+        iframeTaskScriptTemplate: 'window["%hammerhead%"].utils.destLocation.forceLocation("http://localhost/sessionId/https://example.com");' +
                                   'window["%hammerhead%"].start({ iframeTaskScriptTemplate: {{{iframeTaskScriptTemplate}}}});'
     });
     hammerhead.sandbox.shadowUI.getRoot();

--- a/test/client/data/console-sandbox/iframe.html
+++ b/test/client/data/console-sandbox/iframe.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({ crossDomainProxyPort: 2000 });
     hammerhead.sandbox.shadowUI.getRoot();
 </script>

--- a/test/client/data/cookie-sandbox/cross-domain-iframe.html
+++ b/test/client/data/cookie-sandbox/cross-domain-iframe.html
@@ -5,7 +5,7 @@
     <script>
         var hammerhead = window['%hammerhead%'];
 
-        hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+        hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
         hammerhead.start({ crossDomainProxyPort: 2000, cookie: '', sessionId: 'sessionId' });
 
         var INSTRUCTION   = hammerhead.get('../processing/script/instruction');

--- a/test/client/data/cookie-sandbox/same-domain-iframe.html
+++ b/test/client/data/cookie-sandbox/same-domain-iframe.html
@@ -6,7 +6,7 @@
         var hammerhead    = window['%hammerhead%'];
         var iframeSandbox = hammerhead.sandbox.iframe;
 
-        hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+        hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
         hammerhead.start({ crossDomainProxyPort: 2001, cookie: '', sessionId: 'sessionId' });
 
         iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, parent.initIframeTestHandler);

--- a/test/client/data/cookie/get-cookie.html
+++ b/test/client/data/cookie/get-cookie.html
@@ -9,7 +9,7 @@
     var hammerhead    = window['%hammerhead%'];
     var INSTRUCTION   = hammerhead.get('../processing/script/instruction');
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://sub.example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://sub.example.com');
     hammerhead.start({ sessionId: 'cookieSession' });
 
     window[INSTRUCTION.callMethod](top, 'postMessage', ['${cookies}', '*']);

--- a/test/client/data/cross-domain/get-ancestor-origin-of-not-loaded-iframe.html
+++ b/test/client/data/cross-domain/get-ancestor-origin-of-not-loaded-iframe.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     var INSTRUCTION   = hammerhead.get('../processing/script/instruction');

--- a/test/client/data/cross-domain/get-ancestor-origin.html
+++ b/test/client/data/cross-domain/get-ancestor-origin.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     var INSTRUCTION = hammerhead.get('../processing/script/instruction');

--- a/test/client/data/cross-domain/get-message.html
+++ b/test/client/data/cross-domain/get-message.html
@@ -11,7 +11,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     var INSTRUCTION    = hammerhead.get('../processing/script/instruction');

--- a/test/client/data/cross-domain/page-with-iframe-with-js-protocol.html
+++ b/test/client/data/cross-domain/page-with-iframe-with-js-protocol.html
@@ -10,14 +10,14 @@
     var hammerhead = window['%hammerhead%'];
     var INTERNAL_PROPS = hammerhead.get('../processing/dom/internal-properties');
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://target_url');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://target_url');
     hammerhead.start({
         cookie:                   "",
         crossDomainProxyPort:     2000,
         serviceMsgUrl:            '/service-msg/"window[\'' + INTERNAL_PROPS.processDomMethodName +
                                   '\'] = function() {}"',
         iframeTaskScriptTemplate: [
-                                      'window["%hammerhead%"].get("./utils/destination-location").forceLocation("http://localhost/sessionId/http://target_url");',
+                                      'window["%hammerhead%"].utils.destLocation.forceLocation("http://localhost/sessionId/http://target_url");',
                                       'window["%hammerhead%"].start({',
                                       '    referer : "",',
                                       '    cookie: "",',

--- a/test/client/data/cross-domain/service-message-with-handlers.html
+++ b/test/client/data/cross-domain/service-message-with-handlers.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     var processScript = hammerhead.get('../processing/script').processScript;

--- a/test/client/data/cross-domain/service-message.html
+++ b/test/client/data/cross-domain/service-message.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     var messageSandbox = hammerhead.sandbox.event.message;

--- a/test/client/data/cross-domain/service-worker-not-available.html
+++ b/test/client/data/cross-domain/service-worker-not-available.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://target_url');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://target_url');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 </script>
 <script>

--- a/test/client/data/cross-domain/set-cross-domain-location.html
+++ b/test/client/data/cross-domain/set-cross-domain-location.html
@@ -8,7 +8,6 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location');
     hammerhead.start({ crossDomainProxyPort: 2001 });
 
     var INSTRUCTION = hammerhead.get('../processing/script/instruction');

--- a/test/client/data/cross-domain/simple-page.html
+++ b/test/client/data/cross-domain/simple-page.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://target_url');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://target_url');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 </script>
 

--- a/test/client/data/cross-domain/target-url.html
+++ b/test/client/data/cross-domain/target-url.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://target_url');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://target_url');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     var INSTRUCTION = hammerhead.get('../processing/script/instruction');

--- a/test/client/data/cross-domain/wait-loading.html
+++ b/test/client/data/cross-domain/wait-loading.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     var INSTRUCTION    = hammerhead.get('../processing/script/instruction');

--- a/test/client/data/dom-processor/iframe-with-nonproceed-on-server-tags.html
+++ b/test/client/data/dom-processor/iframe-with-nonproceed-on-server-tags.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.start({
         crossDomainProxyPort: 2000,
         sessionId:            'sessionId'

--- a/test/client/data/dom-processor/iframe.html
+++ b/test/client/data/dom-processor/iframe.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.start({ crossDomainProxyPort: 2000 });
     hammerhead.shadowUI.getRoot();
 

--- a/test/client/data/event-sandbox/embedded-iframes.html
+++ b/test/client/data/event-sandbox/embedded-iframes.html
@@ -9,7 +9,7 @@
     var hammerhead = window['%hammerhead%'];
     var INTERNAL_PROPS = hammerhead.get('../processing/dom/internal-properties');
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     var iframeSandbox = hammerhead.sandbox.iframe;
@@ -35,7 +35,7 @@
         var iframeHammerhead        = iframeWindow['%hammerhead%'];
         var iframeMessageSandbox    = iframeHammerhead.sandbox.event.message;
 
-        iframeHammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+        iframeHammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
         iframeMessageSandbox.window = iframeWindow;
         iframeMessageSandbox.sendServiceMsg({ embeddedIframesTestPassed: true }, iframeWindow.parent);
     });

--- a/test/client/data/event-sandbox/event-simulator.html
+++ b/test/client/data/event-sandbox/event-simulator.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 </script>
 <form action="./">

--- a/test/client/data/event-sandbox/focus-blur-sandbox.html
+++ b/test/client/data/event-sandbox/focus-blur-sandbox.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     window.focusInput = function () {

--- a/test/client/data/event-sandbox/send-message-when-top-window-is-cross-domain.html
+++ b/test/client/data/event-sandbox/send-message-when-top-window-is-cross-domain.html
@@ -9,7 +9,7 @@
         var hammerhead     = window['%hammerhead%'];
         var INTERNAL_PROPS = hammerhead.get('../processing/dom/internal-properties');
 
-        hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+        hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
         hammerhead.start({ crossDomainProxyPort: 2000 });
 
         var iframeSandbox         = hammerhead.sandbox.iframe;

--- a/test/client/data/iframe/simple-iframe.html
+++ b/test/client/data/iframe/simple-iframe.html
@@ -9,11 +9,11 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost:2000/sessionId/https://example.com/');
+    hammerhead.utils.destLocation.forceLocation('http://localhost:2000/sessionId/https://example.com/');
     hammerhead.start({
         sessionId:                'sessionId',
         crossDomainProxyPort:     2000,
-        iframeTaskScriptTemplate: 'window["%hammerhead%"].get("./utils/destination-location").forceLocation("http://localhost/sessionId/https://example.com");' +
+        iframeTaskScriptTemplate: 'window["%hammerhead%"].utils.destLocation.forceLocation("http://localhost/sessionId/https://example.com");' +
                                   'window["%hammerhead%"].start({ iframeTaskScriptTemplate: {{{iframeTaskScriptTemplate}}}});'
     });
 </script>

--- a/test/client/data/iframe/window-event-listeners.html
+++ b/test/client/data/iframe/window-event-listeners.html
@@ -19,7 +19,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 </script>
 </body>

--- a/test/client/data/import-script/about-blank.html
+++ b/test/client/data/import-script/about-blank.html
@@ -8,7 +8,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost:2000/sessionId/about:blank');
+    hammerhead.utils.destLocation.forceLocation('http://localhost:2000/sessionId/about:blank');
     hammerhead.start({ sessionId: 'sessionId' });
 
     var INSTRUCTION   = hammerhead.get('../processing/script/instruction');

--- a/test/client/data/import-script/eval-dynamic-import.html
+++ b/test/client/data/import-script/eval-dynamic-import.html
@@ -8,7 +8,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost:2000/sessionId/https://example.com/');
+    hammerhead.utils.destLocation.forceLocation('http://localhost:2000/sessionId/https://example.com/');
     hammerhead.start({ sessionId: 'sessionId' });
 
     var INSTRUCTION = hammerhead.get('../processing/script/instruction');

--- a/test/client/data/live-node-list/getBodyByTagName.html
+++ b/test/client/data/live-node-list/getBodyByTagName.html
@@ -11,7 +11,7 @@
 
             const hammerhead = window['%hammerhead%'];
 
-            hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+            hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
             hammerhead.start({ crossDomainProxyPort: 2000 });
 
             window.bodyExistsBeforeAttachingBody = bodyExists();

--- a/test/client/data/live-node-list/getElementsByTagName.html
+++ b/test/client/data/live-node-list/getElementsByTagName.html
@@ -17,7 +17,7 @@
 
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     var DOMMutationTrackerProto = Object.getPrototypeOf(hammerhead.get('./sandbox/node/live-node-list/dom-mutation-tracker'));

--- a/test/client/data/node-sandbox/body-created-event.html
+++ b/test/client/data/node-sandbox/body-created-event.html
@@ -7,7 +7,7 @@
     <script type="text/javascript">
         var hammerhead = window['%hammerhead%'];
 
-        hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+        hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
         hammerhead.start({
             sessionId: 'sessionId'
         });

--- a/test/client/data/node-sandbox/iframe-override-elems-after-write.html
+++ b/test/client/data/node-sandbox/iframe-override-elems-after-write.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.start({
         crossDomainProxyPort:     2000,
         serviceMsgUrl:            '/service-msg/100',

--- a/test/client/data/node-sandbox/iframe-with-doc-write.html
+++ b/test/client/data/node-sandbox/iframe-with-doc-write.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.start({ crossDomainProxyPort: 2000 });
     hammerhead.shadowUI.getRoot();
 </script>

--- a/test/client/data/node-sandbox/iframe-without-document-cleaned-event.html
+++ b/test/client/data/node-sandbox/iframe-without-document-cleaned-event.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.start({ crossDomainProxyPort: 2000 });
     hammerhead.shadowUI.getRoot();
 </script>

--- a/test/client/data/node-sandbox/multiple-write-with-html-and-body-tags.html
+++ b/test/client/data/node-sandbox/multiple-write-with-html-and-body-tags.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.start({ crossDomainProxyPort: 2000, sessionId: 'sessionId' });
     hammerhead.shadowUI.getRoot();
 </script>

--- a/test/client/data/same-domain/form-target-to-iframe.html
+++ b/test/client/data/same-domain/form-target-to-iframe.html
@@ -9,7 +9,7 @@
     <script type="text/javascript">
         var hammerhead = window['%hammerhead%'];
 
-        hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://example.com');
+        hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://example.com');
         hammerhead.start({ sessionId: 'sessionId' });
 
         var iframeSandbox = hammerhead.sandbox.iframe;

--- a/test/client/data/same-domain/resolving-url-after-document-recreation.html
+++ b/test/client/data/same-domain/resolving-url-after-document-recreation.html
@@ -9,7 +9,7 @@
     <script type="text/javascript">
         var hammerhead = window['%hammerhead%'];
 
-        hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://subdomain.example.com');
+        hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://subdomain.example.com');
         hammerhead.start({
             sessionId: 'sessionId',
             CROSS_DOMAIN_PROXY_PORT: 2000

--- a/test/client/data/same-domain/resolving-url-after-writing-base-tag.html
+++ b/test/client/data/same-domain/resolving-url-after-writing-base-tag.html
@@ -7,7 +7,7 @@
     <script type="text/javascript">
         var hammerhead = window['%hammerhead%'];
 
-        hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://subdomain.example.com');
+        hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://subdomain.example.com');
         hammerhead.start({
             sessionId: 'sessionId',
             CROSS_DOMAIN_PROXY_PORT: 2000

--- a/test/client/data/same-domain/service-message-from-removed-iframe.html
+++ b/test/client/data/same-domain/service-message-from-removed-iframe.html
@@ -10,7 +10,7 @@
     var hammerhead = window['%hammerhead%'];
 
     hammerhead.get('./settings').set({ CROSS_DOMAIN_PROXY_PORT: 2000 });
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.start({
         'sessionId': 'sessionId'
     });

--- a/test/client/data/storages/update-storages-on-unload.html
+++ b/test/client/data/storages/update-storages-on-unload.html
@@ -9,7 +9,7 @@
         sessionStorage.clear();
         localStorage.clear();
 
-        hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://origin_iframe_host');
+        hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://origin_iframe_host');
         hammerhead.start({});
 
         window.sessionStorage.setItem('item', 'value');

--- a/test/client/data/unload/iframe-with-reload-button.html
+++ b/test/client/data/unload/iframe-with-reload-button.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     var reload = document.querySelector('#reload');

--- a/test/client/data/unload/iframe.html
+++ b/test/client/data/unload/iframe.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 </script>
 </body>

--- a/test/client/data/upload/iframe.html
+++ b/test/client/data/upload/iframe.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     var processScript = hammerhead.get('../processing/script').processScript;

--- a/test/client/data/window-storage/iframe.html
+++ b/test/client/data/window-storage/iframe.html
@@ -11,7 +11,7 @@ aaa
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.sandbox.storageSandbox.attach = function () {
     };
     hammerhead.sandbox.storageSandbox.dispose = function () {

--- a/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
@@ -1,5 +1,5 @@
 var urlUtils       = hammerhead.get('./utils/url');
-var destLocation   = hammerhead.get('./utils/destination-location');
+var destLocation   = hammerhead.utils.destLocation;
 var DomProcessor   = hammerhead.get('../processing/dom');
 var urlResolver    = hammerhead.get('./utils/url-resolver');
 

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -4,7 +4,7 @@ var LocationInstrumentation = hammerhead.get('./sandbox/code-instrumentation/loc
 var LocationWrapper         = hammerhead.get('./sandbox/code-instrumentation/location/wrapper');
 var urlUtils                = hammerhead.get('./utils/url');
 var sharedUrlUtils          = hammerhead.get('../utils/url');
-var destLocation            = hammerhead.get('./utils/destination-location');
+var destLocation            = hammerhead.utils.destLocation;
 var urlResolver             = hammerhead.get('./utils/url-resolver');
 var extend                  = hammerhead.get('./utils/extend');
 
@@ -161,7 +161,7 @@ test('location object of iframe with empty src should have properties with corre
 
         return window.QUnitGlobals.waitForIframe(nativeIframe)
             .then(function () {
-                iframe.contentWindow['%hammerhead%'].get('./utils/destination-location').forceLocation(null);
+                iframe.contentWindow['%hammerhead%'].utils.destLocation.forceLocation(null);
 
                 strictEqual(
                     eval(processScript('iframe.contentDocument.location.protocol')),

--- a/test/client/fixtures/sandbox/cookie-test.js
+++ b/test/client/fixtures/sandbox/cookie-test.js
@@ -3,7 +3,7 @@
 var sharedCookieUtils = hammerhead.get('../utils/cookie');
 var settings          = hammerhead.get('./settings');
 var urlUtils          = hammerhead.get('./utils/url');
-var destLocation      = hammerhead.get('./utils/destination-location');
+var destLocation      = hammerhead.utils.destLocation;
 
 var nativeMethods = hammerhead.nativeMethods;
 var browserUtils  = hammerhead.utils.browser;

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -3,7 +3,7 @@ var DomProcessor     = hammerhead.get('../processing/dom');
 var domProcessor     = hammerhead.get('./dom-processor');
 var settings         = hammerhead.get('./settings');
 var urlUtils         = hammerhead.get('./utils/url');
-var destLocation     = hammerhead.get('./utils/destination-location');
+var destLocation     = hammerhead.utils.destLocation;
 var featureDetection = hammerhead.get('./utils/feature-detection');
 var processScript    = hammerhead.get('../processing/script').processScript;
 
@@ -1165,7 +1165,7 @@ test('Url resolving in an instance of document.implementation (GH-1673)', functi
 test('The overridden "createHTMLDocument" method should has right context (GH-1722)', function () {
     return createTestIframe()
         .then(function (iframe) {
-            var iframeDestLocation = iframe.contentWindow['%hammerhead%'].get('./utils/destination-location');
+            var iframeDestLocation = iframe.contentWindow['%hammerhead%'].utils.destLocation;
 
             iframeDestLocation.forceLocation(void 0);
 

--- a/test/client/fixtures/sandbox/node/classes-test.js
+++ b/test/client/fixtures/sandbox/node/classes-test.js
@@ -1,5 +1,5 @@
 var DomProcessor    = hammerhead.get('../processing/dom');
-var destLocation    = hammerhead.get('./utils/destination-location');
+var destLocation    = hammerhead.utils.destLocation;
 var urlUtils        = hammerhead.get('./utils/url');
 var FileListWrapper = hammerhead.get('./sandbox/upload/file-list-wrapper');
 var INTERNAL_ATTRS  = hammerhead.get('../processing/dom/internal-attributes');

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -2,7 +2,7 @@ var processScript           = hammerhead.get('../processing/script').processScri
 var SHADOW_UI_CLASSNAME     = hammerhead.get('../shadow-ui/class-name');
 var INTERNAL_PROPS          = hammerhead.get('../processing/dom/internal-properties');
 var urlUtils                = hammerhead.get('./utils/url');
-var destLocation            = hammerhead.get('./utils/destination-location');
+var destLocation            = hammerhead.utils.destLocation;
 var overriding              = hammerhead.get('./utils/overriding');
 var settings                = hammerhead.get('./settings');
 

--- a/test/client/fixtures/sandbox/node/dom-processor-test.js
+++ b/test/client/fixtures/sandbox/node/dom-processor-test.js
@@ -7,7 +7,7 @@ var styleProcessor = hammerhead.get('../processing/style');
 var settings       = hammerhead.get('./settings');
 var urlUtils       = hammerhead.get('./utils/url');
 var sharedUrlUtils = hammerhead.get('../utils/url');
-var destLocation   = hammerhead.get('./utils/destination-location');
+var destLocation   = hammerhead.utils.destLocation;
 var eventSimulator = hammerhead.sandbox.event.eventSimulator;
 
 var nativeMethods  = hammerhead.nativeMethods;

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -1,5 +1,5 @@
 var urlUtils     = hammerhead.get('./utils/url');
-var destLocation = hammerhead.get('./utils/destination-location');
+var destLocation = hammerhead.utils.destLocation;
 var INSTRUCTION  = hammerhead.get('../processing/script/instruction');
 var XhrSandbox   = hammerhead.get('./sandbox/xhr');
 
@@ -414,7 +414,7 @@ if (window.history.replaceState && window.history.pushState) {
                 var baseUrl             = 'http://' + location.host + '/some/path';
 
                 iframeHammerhead.get('./utils/url-resolver').updateBase(baseUrl, iframe.contentDocument);
-                iframeHammerhead.get('./utils/destination-location')
+                iframeHammerhead.utils.destLocation
                     .forceLocation('http://' + iframeLocation.host + '/sessionId/' + baseUrl);
 
                 var testUrl = function (url, fn, nativeFn) {

--- a/test/client/fixtures/sandbox/xhr-test.js
+++ b/test/client/fixtures/sandbox/xhr-test.js
@@ -1,5 +1,5 @@
 var XhrSandbox     = hammerhead.get('./sandbox/xhr');
-var destLocation   = hammerhead.get('./utils/destination-location');
+var destLocation   = hammerhead.utils.destLocation;
 var urlUtils       = hammerhead.get('./utils/url');
 var sharedUrlUtils = hammerhead.get('../utils/url');
 var headersUtils   = hammerhead.get('../utils/headers');

--- a/test/client/fixtures/utils/origin-location-test.js
+++ b/test/client/fixtures/utils/origin-location-test.js
@@ -1,4 +1,4 @@
-var destLocation = hammerhead.get('./utils/destination-location');
+var destLocation = hammerhead.utils.destLocation;
 
 test('sameOriginCheck', function () {
     ok(destLocation.sameOriginCheck('http://proxy/token!uid/http://origin.com:111/index.html', 'http://origin.com:111/index.php'));

--- a/test/client/fixtures/utils/url-test.js
+++ b/test/client/fixtures/utils/url-test.js
@@ -1,7 +1,7 @@
 var settings       = hammerhead.get('./settings');
 var urlUtils       = hammerhead.get('./utils/url');
 var sharedUrlUtils = hammerhead.get('../utils/url');
-var destLocation   = hammerhead.get('./utils/destination-location');
+var destLocation   = hammerhead.utils.destLocation;
 
 var browserUtils  = hammerhead.utils.browser;
 var nativeMethods = hammerhead.nativeMethods;


### PR DESCRIPTION
## Purpose
As a preparatory step towards migrating from Webmake to Rollup module bundler (#2567), we need to get rid of using the `hammerhead.get` method. It stores a reference to the `require` function and is used for importing internal hammerhead submodules in the client tests. Such functionality cannot be achieved using Rollup, because Rollup doesn't preserve the structure of the exported submodules inside generated bundle.

## Approach
Place the `destLocation` submodule into the `utils` property of the `Hammerhead` class and use it in the tests.