### PR TITLE
refactor(client): make sharedUtils accessible

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,6 +13,11 @@ import * as typeUtils from './utils/types';
 import * as positionUtils from './utils/position';
 import * as styleUtils from './utils/style';
 import trim from '../utils/string-trim';
+import * as sharedCookieUtils from '../utils/cookie';
+import * as sharedUrlUtils from '../utils/url';
+import * as sharedHeadersUtils from '../utils/headers';
+import * as sharedStackProcessingUtils from '../utils/stack-processing';
+import sharedSelfRemovingScripts from '../utils/self-removing-scripts';
 import * as urlUtils from './utils/url';
 import * as featureDetection from './utils/feature-detection';
 import * as htmlUtils from './utils/html';
@@ -51,6 +56,8 @@ class Hammerhead {
     storages: any;
     eventSandbox: Dictionary<any>;
     utils: Dictionary<any>;
+    sharedUtils: Dictionary<any>;
+    settings: typeof settings;
 
     constructor () {
         this.win                 = null;
@@ -136,6 +143,16 @@ class Hammerhead {
             featureDetection: featureDetection,
             destLocation:     destLocationUtils
         };
+
+        this.sharedUtils = {
+            cookie:              sharedCookieUtils,
+            url:                 sharedUrlUtils,
+            headers:             sharedHeadersUtils,
+            stackProcessing:     sharedStackProcessingUtils,
+            selfRemovingScripts: sharedSelfRemovingScripts
+        };
+
+        this.settings = settings;
     }
 
     _getEventOwner (evtName: string) {

--- a/test/client/data/cookie-sandbox/cross-domain-iframe.html
+++ b/test/client/data/cookie-sandbox/cross-domain-iframe.html
@@ -9,7 +9,7 @@
         hammerhead.start({ crossDomainProxyPort: 2000, cookie: '', sessionId: 'sessionId' });
 
         var INSTRUCTION   = hammerhead.get('../processing/script/instruction');
-        var settings      = hammerhead.get('./settings');
+        var settings      = hammerhead.settings;
         var nativeMethods = hammerhead.nativeMethods;
 
         window.addEventListener('message', function (e) {

--- a/test/client/data/cross-domain/set-cross-domain-location.html
+++ b/test/client/data/cross-domain/set-cross-domain-location.html
@@ -11,7 +11,7 @@
     hammerhead.start({ crossDomainProxyPort: 2001 });
 
     var INSTRUCTION = hammerhead.get('../processing/script/instruction');
-    var urlUtils    = hammerhead.get('./utils/url');
+    var urlUtils    = hammerhead.utils.url;
     var getLocation = window[INSTRUCTION.getLocation];
 
     var storedParseProxyUrl = urlUtils.parseProxyUrl;

--- a/test/client/data/same-domain/service-message-from-removed-iframe.html
+++ b/test/client/data/same-domain/service-message-from-removed-iframe.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./settings').set({ CROSS_DOMAIN_PROXY_PORT: 2000 });
+    hammerhead.settings.set({ CROSS_DOMAIN_PROXY_PORT: 2000 });
     hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
     hammerhead.start({
         'sessionId': 'sessionId'

--- a/test/client/fixtures/force-proxy-src-for-image-test.js
+++ b/test/client/fixtures/force-proxy-src-for-image-test.js
@@ -1,11 +1,11 @@
 var nativeMethods = hammerhead.nativeMethods;
 var listeners     = hammerhead.sandbox.event.listeners;
 
-var urlUtils = hammerhead.get('./utils/url');
+var urlUtils = hammerhead.utils.url;
 
 QUnit.testStart(function () {
     var domProcessor = hammerhead.get('./dom-processor');
-    var settings     = hammerhead.get('./settings');
+    var settings     = hammerhead.settings;
 
     domProcessor.forceProxySrcForImage   = true;
     settings.get().forceProxySrcForImage = true;

--- a/test/client/fixtures/page-navigation-watch-test.js
+++ b/test/client/fixtures/page-navigation-watch-test.js
@@ -1,5 +1,5 @@
-var urlUtils = hammerhead.get('./utils/url');
-var settings = hammerhead.get('./settings');
+var urlUtils = hammerhead.utils.url;
+var settings = hammerhead.settings;
 
 var storageSandbox      = hammerhead.sandbox.storageSandbox;
 var Promise             = hammerhead.Promise;

--- a/test/client/fixtures/sandbox/child-window-test.js
+++ b/test/client/fixtures/sandbox/child-window-test.js
@@ -1,6 +1,6 @@
 var ChildWindowSandbox = hammerhead.get('./sandbox/child-window');
 var defaultTarget      = hammerhead.get('./sandbox/child-window/default-target');
-var settings           = hammerhead.get('./settings');
+var settings           = hammerhead.settings;
 
 var windowSandbox = hammerhead.sandbox.node.win;
 var nativeMethods = hammerhead.nativeMethods;

--- a/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/getters-test.js
@@ -1,4 +1,4 @@
-var urlUtils       = hammerhead.get('./utils/url');
+var urlUtils       = hammerhead.utils.url;
 var destLocation   = hammerhead.utils.destLocation;
 var DomProcessor   = hammerhead.get('../processing/dom');
 var urlResolver    = hammerhead.get('./utils/url-resolver');

--- a/test/client/fixtures/sandbox/code-instrumentation/location-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/location-test.js
@@ -2,11 +2,11 @@ var INSTRUCTION             = hammerhead.get('../processing/script/instruction')
 var CodeInstrumentation     = hammerhead.get('./sandbox/code-instrumentation');
 var LocationInstrumentation = hammerhead.get('./sandbox/code-instrumentation/location');
 var LocationWrapper         = hammerhead.get('./sandbox/code-instrumentation/location/wrapper');
-var urlUtils                = hammerhead.get('./utils/url');
-var sharedUrlUtils          = hammerhead.get('../utils/url');
+var urlUtils                = hammerhead.utils.url;
+var sharedUrlUtils          = hammerhead.sharedUtils.url;
 var destLocation            = hammerhead.utils.destLocation;
 var urlResolver             = hammerhead.get('./utils/url-resolver');
-var extend                  = hammerhead.get('./utils/extend');
+var extend                  = hammerhead.utils.extend;
 
 var Promise       = hammerhead.Promise;
 var nativeMethods = hammerhead.nativeMethods;

--- a/test/client/fixtures/sandbox/code-instrumentation/process-script-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/process-script-test.js
@@ -1,4 +1,4 @@
-var urlUtils      = hammerhead.get('./utils/url');
+var urlUtils      = hammerhead.utils.url;
 var processScript = hammerhead.get('../processing/script').processScript;
 var scriptHeader  = hammerhead.get('../processing/script/header');
 

--- a/test/client/fixtures/sandbox/code-instrumentation/setters-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/setters-test.js
@@ -1,4 +1,4 @@
-var urlUtils          = hammerhead.get('./utils/url');
+var urlUtils          = hammerhead.utils.url;
 var processScript     = hammerhead.get('../processing/script').processScript;
 
 var Promise               = hammerhead.Promise;

--- a/test/client/fixtures/sandbox/code-instrumentation/type-verification-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/type-verification-test.js
@@ -1,4 +1,4 @@
-var urlUtils = hammerhead.get('./utils/url');
+var urlUtils = hammerhead.utils.url;
 
 test('is window instance', function () {
     var savedGetProxyUrl = urlUtils.getProxyUrl;

--- a/test/client/fixtures/sandbox/cookie-test.js
+++ b/test/client/fixtures/sandbox/cookie-test.js
@@ -1,8 +1,8 @@
 // NOTE: You should clear a browser's cookie if tests are fail,
 // because document.cookie can contains cookie from another sites which was run through playground
-var sharedCookieUtils = hammerhead.get('../utils/cookie');
-var settings          = hammerhead.get('./settings');
-var urlUtils          = hammerhead.get('./utils/url');
+var sharedCookieUtils = hammerhead.sharedUtils.cookie;
+var settings          = hammerhead.settings;
+var urlUtils          = hammerhead.utils.url;
 var destLocation      = hammerhead.utils.destLocation;
 
 var nativeMethods = hammerhead.nativeMethods;
@@ -283,8 +283,8 @@ test('same-domain frames', function () {
             function checkCookies (expectedCookies) {
                 strictEqual(nativeMethods.documentCookieGetter.call(document), '');
                 strictEqual(settings.get().cookie, expectedCookies);
-                strictEqual(iframe.contentWindow['%hammerhead%'].get('./settings').get().cookie, expectedCookies);
-                strictEqual(embeddedIframe.contentWindow['%hammerhead%'].get('./settings').get().cookie, expectedCookies);
+                strictEqual(iframe.contentWindow['%hammerhead%'].settings.get().cookie, expectedCookies);
+                strictEqual(embeddedIframe.contentWindow['%hammerhead%'].settings.get().cookie, expectedCookies);
             }
 
             checkCookies('');
@@ -348,7 +348,7 @@ test('cross-domain frames', function () {
             nativeMethods.documentCookieSetter.call(document, 's|sessionId|test|example.com|%2F||1fckm5lnl=123;path=/');
 
             strictEqual(settings.get().cookie, '');
-            strictEqual(iframes[1].contentWindow['%hammerhead%'].get('./settings').get().cookie, '');
+            strictEqual(iframes[1].contentWindow['%hammerhead%'].settings.get().cookie, '');
 
             return Promise.all([
                 checkCrossDomainIframeCookie(iframes[0], ''),
@@ -361,7 +361,7 @@ test('cross-domain frames', function () {
             expectedCookies = 'cafe=321; test=123';
 
             strictEqual(settings.get().cookie, expectedCookies);
-            strictEqual(iframes[1].contentWindow['%hammerhead%'].get('./settings').get().cookie, expectedCookies);
+            strictEqual(iframes[1].contentWindow['%hammerhead%'].settings.get().cookie, expectedCookies);
 
             return window.QUnitGlobals.wait(realCookieIsEmpty, 5000);
         })
@@ -379,7 +379,7 @@ test('cross-domain frames', function () {
         })
         .then(function () {
             strictEqual(settings.get().cookie, 'test=123; set=cookie');
-            strictEqual(iframes[1].contentWindow['%hammerhead%'].get('./settings').get().cookie, 'test=123; set=cookie');
+            strictEqual(iframes[1].contentWindow['%hammerhead%'].settings.get().cookie, 'test=123; set=cookie');
 
             return Promise.all([
                 checkCrossDomainIframeCookie(iframes[0], 'test=123; set=cookie'),

--- a/test/client/fixtures/sandbox/fetch-test.js
+++ b/test/client/fixtures/sandbox/fetch-test.js
@@ -1,5 +1,5 @@
-var urlUtils      = hammerhead.get('./utils/url');
-var headersUtils  = hammerhead.get('../utils/headers');
+var urlUtils      = hammerhead.utils.url;
+var headersUtils  = hammerhead.sharedUtils.headers;
 var nativeMethods = hammerhead.nativeMethods;
 var browserUtils  = hammerhead.utils.browser;
 var Promise       = hammerhead.Promise;

--- a/test/client/fixtures/sandbox/iframe-flag-test.js
+++ b/test/client/fixtures/sandbox/iframe-flag-test.js
@@ -1,5 +1,5 @@
-var urlUtils = hammerhead.get('./utils/url');
-var settings = hammerhead.get('./settings');
+var urlUtils = hammerhead.utils.url;
+var settings = hammerhead.settings;
 
 var nativeMethods = hammerhead.nativeMethods;
 var browserUtils  = hammerhead.utils.browser;

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -1,7 +1,7 @@
-var settings     = hammerhead.get('./settings');
+var settings     = hammerhead.settings;
 var overriding   = hammerhead.get('./utils/overriding');
 var DomProcessor = hammerhead.get('../processing/dom');
-var htmlUtils    = hammerhead.get('./utils/html');
+var htmlUtils    = hammerhead.utils.html;
 
 var iframeSandbox = hammerhead.sandbox.iframe;
 var cookieSandbox = hammerhead.sandbox.cookie;
@@ -258,7 +258,7 @@ test('quotes in the cookies are not escaped when a task script for an iframe is 
 
     return createTestIframe()
         .then(function (iframe) {
-            strictEqual(iframe.contentWindow['%hammerhead%'].get('./settings').get().cookie, cookie);
+            strictEqual(iframe.contentWindow['%hammerhead%'].settings.get().cookie, cookie);
         });
 });
 

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -1,10 +1,10 @@
 var INTERNAL_PROPS   = hammerhead.get('../processing/dom/internal-properties');
 var DomProcessor     = hammerhead.get('../processing/dom');
 var domProcessor     = hammerhead.get('./dom-processor');
-var settings         = hammerhead.get('./settings');
-var urlUtils         = hammerhead.get('./utils/url');
+var settings         = hammerhead.settings;
+var urlUtils         = hammerhead.utils.url;
 var destLocation     = hammerhead.utils.destLocation;
-var featureDetection = hammerhead.get('./utils/feature-detection');
+var featureDetection = hammerhead.utils.featureDetection;
 var processScript    = hammerhead.get('../processing/script').processScript;
 
 var elementEditingWatcher = hammerhead.sandbox.event.elementEditingWatcher;

--- a/test/client/fixtures/sandbox/node/classes-test.js
+++ b/test/client/fixtures/sandbox/node/classes-test.js
@@ -1,6 +1,6 @@
 var DomProcessor    = hammerhead.get('../processing/dom');
 var destLocation    = hammerhead.utils.destLocation;
-var urlUtils        = hammerhead.get('./utils/url');
+var urlUtils        = hammerhead.utils.url;
 var FileListWrapper = hammerhead.get('./sandbox/upload/file-list-wrapper');
 var INTERNAL_ATTRS  = hammerhead.get('../processing/dom/internal-attributes');
 var Promise         = hammerhead.Promise;

--- a/test/client/fixtures/sandbox/node/document-test.js
+++ b/test/client/fixtures/sandbox/node/document-test.js
@@ -1,10 +1,10 @@
 var processScript           = hammerhead.get('../processing/script').processScript;
 var SHADOW_UI_CLASSNAME     = hammerhead.get('../shadow-ui/class-name');
 var INTERNAL_PROPS          = hammerhead.get('../processing/dom/internal-properties');
-var urlUtils                = hammerhead.get('./utils/url');
+var urlUtils                = hammerhead.utils.url;
 var destLocation            = hammerhead.utils.destLocation;
 var overriding              = hammerhead.get('./utils/overriding');
-var settings                = hammerhead.get('./settings');
+var settings                = hammerhead.settings;
 
 var browserUtils  = hammerhead.utils.browser;
 var nativeMethods = hammerhead.nativeMethods;

--- a/test/client/fixtures/sandbox/node/document-write-test.js
+++ b/test/client/fixtures/sandbox/node/document-write-test.js
@@ -1,5 +1,5 @@
-var urlUtils                = hammerhead.get('./utils/url');
-var htmlUtils               = hammerhead.get('../client/utils/html');
+var urlUtils                = hammerhead.utils.url;
+var htmlUtils               = hammerhead.utils.html;
 var styleProcessor          = hammerhead.get('../processing/style');
 var scriptProcessingHeaders = hammerhead.get('../processing/script/header');
 

--- a/test/client/fixtures/sandbox/node/dom-processor-test.js
+++ b/test/client/fixtures/sandbox/node/dom-processor-test.js
@@ -1,12 +1,12 @@
 var INTERNAL_ATTRS = hammerhead.get('../processing/dom/internal-attributes');
-var htmlUtils      = hammerhead.get('./utils/html');
+var htmlUtils      = hammerhead.utils.html;
 var DomProcessor   = hammerhead.get('../processing/dom');
 var domProcessor   = hammerhead.get('./dom-processor');
 var processScript  = hammerhead.get('../processing/script').processScript;
 var styleProcessor = hammerhead.get('../processing/style');
-var settings       = hammerhead.get('./settings');
-var urlUtils       = hammerhead.get('./utils/url');
-var sharedUrlUtils = hammerhead.get('../utils/url');
+var settings       = hammerhead.settings;
+var urlUtils       = hammerhead.utils.url;
+var sharedUrlUtils = hammerhead.sharedUtils.url;
 var destLocation   = hammerhead.utils.destLocation;
 var eventSimulator = hammerhead.sandbox.event.eventSimulator;
 

--- a/test/client/fixtures/sandbox/node/dom-test.js
+++ b/test/client/fixtures/sandbox/node/dom-test.js
@@ -1,4 +1,4 @@
-var urlUtils = hammerhead.get('./utils/url');
+var urlUtils = hammerhead.utils.url;
 
 var nativeMethods  = hammerhead.nativeMethods;
 var nodeMutation   = hammerhead.sandbox.node.mutation;

--- a/test/client/fixtures/sandbox/node/methods-test.js
+++ b/test/client/fixtures/sandbox/node/methods-test.js
@@ -1,6 +1,6 @@
 var INTERNAL_PROPS      = hammerhead.get('../processing/dom/internal-properties');
 var DomProcessor        = hammerhead.get('../processing/dom');
-var urlUtils            = hammerhead.get('./utils/url');
+var urlUtils            = hammerhead.utils.url;
 var SHADOW_UI_CLASSNAME = hammerhead.get('../shadow-ui/class-name');
 
 var browserUtils  = hammerhead.utils.browser;

--- a/test/client/fixtures/sandbox/node/text-properties-test.js
+++ b/test/client/fixtures/sandbox/node/text-properties-test.js
@@ -1,9 +1,9 @@
 var INTERNAL_PROPS          = hammerhead.get('../processing/dom/internal-properties');
-var processHtml             = hammerhead.get('../client/utils/html').processHtml;
+var processHtml             = hammerhead.utils.html.processHtml;
 var scriptProcessingHeaders = hammerhead.get('../processing/script/header');
 var styleProcessor          = hammerhead.get('../processing/style');
 var scriptProcessor         = hammerhead.get('../processing/script');
-var urlUtils                = hammerhead.get('./utils/url');
+var urlUtils                = hammerhead.utils.url;
 var DomProcessor            = hammerhead.get('../processing/dom');
 
 var nativeMethods = hammerhead.nativeMethods;

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -1,4 +1,4 @@
-var urlUtils     = hammerhead.get('./utils/url');
+var urlUtils     = hammerhead.utils.url;
 var destLocation = hammerhead.utils.destLocation;
 var INSTRUCTION  = hammerhead.get('../processing/script/instruction');
 var XhrSandbox   = hammerhead.get('./sandbox/xhr');

--- a/test/client/fixtures/sandbox/storages-test.js
+++ b/test/client/fixtures/sandbox/storages-test.js
@@ -1,5 +1,5 @@
 var StorageWrapper = hammerhead.get('./sandbox/storages/wrapper');
-var settings       = hammerhead.get('./settings');
+var settings       = hammerhead.settings;
 
 var storageSandbox = hammerhead.sandbox.storageSandbox;
 var Promise        = hammerhead.Promise;

--- a/test/client/fixtures/sandbox/style-test.js
+++ b/test/client/fixtures/sandbox/style-test.js
@@ -1,4 +1,4 @@
-var urlUtils      = hammerhead.get('./utils/url');
+var urlUtils      = hammerhead.utils.url;
 var nativeMethods = hammerhead.nativeMethods;
 var StyleSandbox  = hammerhead.get('./sandbox/style');
 var styleSandbox  = hammerhead.sandbox.style;

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -4,7 +4,7 @@ var hiddenInfo        = hammerhead.get('./sandbox/upload/hidden-info');
 var UploadSandbox     = hammerhead.get('./sandbox/upload');
 var listeningContext  = hammerhead.get('./sandbox/event/listening-context');
 var INTERNAL_PROPS    = hammerhead.get('../processing/dom/internal-properties');
-var settings          = hammerhead.get('./settings');
+var settings          = hammerhead.settings;
 
 var Promise        = hammerhead.Promise;
 var transport      = hammerhead.transport;

--- a/test/client/fixtures/sandbox/xhr-test.js
+++ b/test/client/fixtures/sandbox/xhr-test.js
@@ -1,8 +1,8 @@
 var XhrSandbox     = hammerhead.get('./sandbox/xhr');
 var destLocation   = hammerhead.utils.destLocation;
-var urlUtils       = hammerhead.get('./utils/url');
-var sharedUrlUtils = hammerhead.get('../utils/url');
-var headersUtils   = hammerhead.get('../utils/headers');
+var urlUtils       = hammerhead.utils.url;
+var sharedUrlUtils = hammerhead.sharedUtils.url;
+var headersUtils   = hammerhead.sharedUtils.headers;
 
 var nativeMethods = hammerhead.nativeMethods;
 var xhrSandbox    = hammerhead.sandbox.xhr;

--- a/test/client/fixtures/target-attr-test.js
+++ b/test/client/fixtures/target-attr-test.js
@@ -1,5 +1,5 @@
 var DomProcessor = hammerhead.get('../processing/dom');
-var urlUtils     = hammerhead.get('./utils/url');
+var urlUtils     = hammerhead.utils.url;
 
 var nativeMethods  = hammerhead.nativeMethods;
 var eventSimulator = hammerhead.sandbox.event.eventSimulator;

--- a/test/client/fixtures/transport-test.js
+++ b/test/client/fixtures/transport-test.js
@@ -1,4 +1,4 @@
-var settings     = hammerhead.get('./settings');
+var settings     = hammerhead.settings;
 var listeningCtx = hammerhead.get('../client/sandbox/event/listening-context');
 
 var Promise       = hammerhead.Promise;

--- a/test/client/fixtures/utils/extend-test.js
+++ b/test/client/fixtures/utils/extend-test.js
@@ -1,4 +1,4 @@
-var extend = hammerhead.get('./utils/extend');
+var extend = hammerhead.utils.extend;
 
 test('simple two objects', function () {
     var obj1 = {

--- a/test/client/fixtures/utils/html-test.js
+++ b/test/client/fixtures/utils/html-test.js
@@ -1,12 +1,12 @@
 ﻿var INTERNAL_ATTRS = hammerhead.get('../processing/dom/internal-attributes');
 var DomProcessor   = hammerhead.get('../processing/dom');
 var domProcessor   = hammerhead.get('./dom-processor');
-var htmlUtils      = hammerhead.get('./utils/html');
+var htmlUtils      = hammerhead.utils.html;
 var processScript  = hammerhead.get('../processing/script').processScript;
-var urlUtils       = hammerhead.get('./utils/url');
+var urlUtils       = hammerhead.utils.url;
 var urlResolver    = hammerhead.get('./utils/url-resolver');
 
-var SELF_REMOVING_SCRIPTS = hammerhead.get('../utils/self-removing-scripts');
+var SELF_REMOVING_SCRIPTS = hammerhead.sharedUtils.selfRemovingScripts;
 
 var nativeMethods = hammerhead.nativeMethods;
 var shadowUI      = hammerhead.sandbox.shadowUI;

--- a/test/client/fixtures/utils/replace-proxied-urls-in-stack-test.js
+++ b/test/client/fixtures/utils/replace-proxied-urls-in-stack-test.js
@@ -1,5 +1,5 @@
-var stackProcessing = hammerhead.get('../utils/stack-processing');
-var urlUtils        = hammerhead.get('./utils/url');
+var stackProcessing = hammerhead.sharedUtils.stackProcessing;
+var urlUtils        = hammerhead.utils.url;
 
 var urls = [
     '/fixtures/utils/replace-proxied-urls-in-stack-test.js',

--- a/test/client/fixtures/utils/url-test.js
+++ b/test/client/fixtures/utils/url-test.js
@@ -1,6 +1,6 @@
-var settings       = hammerhead.get('./settings');
-var urlUtils       = hammerhead.get('./utils/url');
-var sharedUrlUtils = hammerhead.get('../utils/url');
+var settings       = hammerhead.settings;
+var urlUtils       = hammerhead.utils.url;
+var sharedUrlUtils = hammerhead.sharedUtils.url;
 var destLocation   = hammerhead.utils.destLocation;
 
 var browserUtils  = hammerhead.utils.browser;

--- a/test/client/fixtures/worker-test.js
+++ b/test/client/fixtures/worker-test.js
@@ -1,4 +1,4 @@
-var urlUtils = hammerhead.get('./utils/url');
+var urlUtils = hammerhead.utils.url;
 
 var nativeMethods = hammerhead.nativeMethods;
 var browserUtils  = hammerhead.utils.browser;


### PR DESCRIPTION
## Purpose
As a preparatory step towards migrating from Webmake to Rollup module bundler (#2567), we need to get rid of using the `hammerhead.get` method. It stores a reference to the `require` function and is used for importing internal hammerhead submodules in the client tests. Such functionality cannot be achieved using Rollup, because Rollup doesn't preserve the structure of the exported submodules inside generated bundle.

## Approach
Place submodules which were exposed in the client tests into the `sharedUtils` property of the `Hammerhead` class, also add the `settings` property and use existing `hammerhead.utils` where is appropriate to use them.