### PR TITLE
refactor: improve types to avoid issues with tsc

### DIFF
--- a/src/client/sandbox/cookie/window-sync.ts
+++ b/src/client/sandbox/cookie/window-sync.ts
@@ -165,12 +165,12 @@ export default class WindowSync {
         }
 
         if (syncMessages.length) {
-            let syncMessagesPromise = Promise.all(syncMessages);
+            const syncMessagesPromise = Promise.all(syncMessages);
 
             if (this._win === topOpenerWindow)
-                syncMessagesPromise = syncMessagesPromise.then(() => this._removeSyncCookie(cookies));
+                return syncMessagesPromise.then(() => this._removeSyncCookie(cookies));
 
-            return syncMessagesPromise;
+            return syncMessagesPromise.then();
         }
         else {
             this._removeSyncCookie(cookies);

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -9,7 +9,7 @@ import styleProcessor from '../../../processing/style';
 import * as urlUtils from '../../utils/url';
 import * as domUtils from '../../utils/dom';
 import * as hiddenInfo from '../upload/hidden-info';
-import * as urlResolver from '../../utils/url-resolver';
+import urlResolver from '../../utils/url-resolver';
 import { sameOriginCheck, get as getDestLocation } from '../../utils/destination-location';
 import { isValidEventListener, stopPropagation } from '../../utils/event';
 import { processHtml, isInternalHtmlParserElement } from '../../utils/html';
@@ -189,7 +189,6 @@ export default class ElementSandbox extends SandboxBase {
 
                     if (ElementSandbox._isHrefAttrForBaseElement(el, attr) &&
                         domUtils.isElementInDocument(el, currentDocument))
-                        // @ts-ignore
                         urlResolver.updateBase(value, currentDocument);
 
                     args[valueIndex] = isIframe && isCrossDomainUrl
@@ -411,7 +410,6 @@ export default class ElementSandbox extends SandboxBase {
         }
 
         if (ElementSandbox._isHrefAttrForBaseElement(el, formatedAttr))
-            // @ts-ignore
             urlResolver.updateBase(getDestLocation(), this.document);
 
         if (formatedAttr !== 'autocomplete')
@@ -799,7 +797,6 @@ export default class ElementSandbox extends SandboxBase {
             const storedHrefAttrValue = el.getAttribute(storedHrefAttrName);
 
             if (storedHrefAttrValue !== null)
-                // @ts-ignore
                 urlResolver.updateBase(storedHrefAttrValue, this.document);
         }
     }
@@ -812,7 +809,6 @@ export default class ElementSandbox extends SandboxBase {
             const firstBaseEl    = nativeMethods.querySelector.call(this.document, 'base');
             const storedHrefAttr = firstBaseEl && firstBaseEl.getAttribute(DomProcessor.getStoredAttrName('href'));
 
-            // @ts-ignore
             urlResolver.updateBase(storedHrefAttr || getDestLocation(), this.document);
         }
 
@@ -988,7 +984,6 @@ export default class ElementSandbox extends SandboxBase {
         const storedUrlAttr = nativeMethods.getAttribute.call(el, DomProcessor.getStoredAttrName('href'));
 
         if (storedUrlAttr !== null)
-        // @ts-ignore
             urlResolver.updateBase(storedUrlAttr, el.ownerDocument || this.document);
     }
 

--- a/src/client/utils/destination-location.ts
+++ b/src/client/utils/destination-location.ts
@@ -1,6 +1,6 @@
 import * as sharedUrlUtils from '../../utils/url';
 import * as domUtils from './dom';
-import * as urlResolver from './url-resolver';
+import urlResolver from './url-resolver';
 import settings from '../settings';
 import nativeMethods from '../sandbox/native-methods';
 import globalContextInfo from './global-context-info';
@@ -54,7 +54,6 @@ export function resolveUrl (url: string, doc?: Document): string {
             return url;
     }
     else {
-        // @ts-ignore
         return urlResolver.resolve(preProcessedUrl, doc || document);
     }
 }
@@ -76,7 +75,6 @@ export function withHash (hash: string): string {
 }
 
 function parseLocationThroughAnchor (url: string) {
-    // @ts-ignore
     const resolver = urlResolver.getResolverElement(document);
 
     // eslint-disable-next-line no-restricted-properties

--- a/src/client/utils/html.ts
+++ b/src/client/utils/html.ts
@@ -8,7 +8,7 @@ import styleProcessor from '../../processing/style';
 import { find, getTagName, isScriptElement } from './dom';
 import { convertToProxyUrl, parseProxyUrl } from './url';
 import { isIE, isMSEdge } from './browser';
-import * as urlResolver from './url-resolver';
+import urlResolver from './url-resolver';
 import INTERNAL_PROPS from '../../processing/dom/internal-properties';
 import { URL_ATTRS, ATTRS_WITH_SPECIAL_PROXYING_LOGIC } from '../../processing/dom/attributes';
 import SELF_REMOVING_SCRIPTS from '../../utils/self-removing-scripts';
@@ -264,7 +264,6 @@ export function processHtml (html, options: ProcessHTMLOptions = {}) {
         const htmlElements  = [];
         let children        = [];
         let length          = 0;
-        // @ts-ignore
         const storedBaseUrl = urlResolver.getBaseUrl(document);
 
         if (prepareDom)
@@ -278,7 +277,6 @@ export function processHtml (html, options: ProcessHTMLOptions = {}) {
         const base = nativeMethods.elementQuerySelector.call(container, 'base');
 
         if (base)
-            // @ts-ignore
             urlResolver.updateBase(nativeMethods.getAttribute.call(base, 'href'), document);
 
         for (let i = 0; i < length; i++) {
@@ -318,7 +316,6 @@ export function processHtml (html, options: ProcessHTMLOptions = {}) {
                 nativeMethods.insertAdjacentHTML.call(container, InsertPosition.afterBegin, SELF_REMOVING_SCRIPTS.iframeInit);
         }
 
-        // @ts-ignore
         urlResolver.updateBase(storedBaseUrl, document);
 
         return true;

--- a/src/client/utils/url.ts
+++ b/src/client/utils/url.ts
@@ -1,7 +1,7 @@
 import INTERNAL_PROPS from '../../processing/dom/internal-properties';
 import * as sharedUrlUtils from '../../utils/url';
 import * as destLocation from './destination-location';
-import * as urlResolver from './url-resolver';
+import urlResolver from './url-resolver';
 import settings from '../settings';
 import { ResourceType } from '../../typings/url';
 import globalContextInfo from './global-context-info';
@@ -232,7 +232,6 @@ export function changeDestUrlPart (proxyUrl: string, nativePropSetter, value, re
     if (parsed) {
         const sessionId = parsed.sessionId;
         const proxy     = parsed.proxy;
-        // @ts-ignore
         const destUrl   = urlResolver.changeUrlPart(parsed.destUrl, nativePropSetter, value, document);
 
         return getProxyUrl(destUrl, {

--- a/src/request-pipeline/destination-request/windows-domain.ts
+++ b/src/request-pipeline/destination-request/windows-domain.ts
@@ -5,9 +5,9 @@ let cached: WindowCredentials | null = null;
 
 async function queryOSForCredential (cmd: string): Promise<string> {
     try {
-        const credential: string = await exec(cmd);
+        const { stdout } = await exec(cmd);
 
-        return credential.replace(/\s/g, '');
+        return stdout.replace(/\s/g, '');
     }
     catch (err) {
         return '';

--- a/src/typings/pinkie.d.ts
+++ b/src/typings/pinkie.d.ts
@@ -1,0 +1,3 @@
+declare module 'pinkie' {
+    export = Promise;
+}


### PR DESCRIPTION
## Purpose
I faced some issues with the types when working on #2567.

## Approach
* add type for the `pinkie` module (before that, this was `any` and so there was no type-checking)
* use default import for the `urlResolver` utility (there are no named exports in the module, only default one)
* fix little bug originated because there is no type-checking of the server scripts (only transpiling via babel)