### PR TITLE
Should not opened in window if the default behavior was prevented inside the event handler (for #5910 in TestCafe)

### DIFF
--- a/src/client/page-navigation-watch.ts
+++ b/src/client/page-navigation-watch.ts
@@ -37,7 +37,7 @@ export default class PageNavigationWatch extends EventEmiter {
 
         // NOTE: fires when the form is submitted by clicking the submit button
         eventSandbox.listeners.initElementListening(window, ['submit']);
-        eventSandbox.listeners.addInternalEventListener(window, ['submit'], (e: Event) => {
+        eventSandbox.listeners.addInternalEventBeforeListener(window, ['submit'], (e: Event) => {
             let prevented = false;
 
             if (!isFormElement(e.target as HTMLElement))
@@ -80,7 +80,7 @@ export default class PageNavigationWatch extends EventEmiter {
 
     _linkWatch (eventSandbox: EventSandbox): void {
         eventSandbox.listeners.initElementListening(window, ['click']);
-        eventSandbox.listeners.addInternalEventListener(window, ['click'], (e: Event) => {
+        eventSandbox.listeners.addInternalEventBeforeListener(window, ['click'], (e: Event) => {
             const link = isAnchorElement(e.target) ? e.target : closest(e.target, 'a');
 
             if (link && !isShadowUIElement(link)) {

--- a/src/client/sandbox/child-window/index.ts
+++ b/src/client/sandbox/child-window/index.ts
@@ -71,7 +71,7 @@ export default class ChildWindowSandbox extends SandboxBase {
             return;
 
         this._listeners.initElementListening(el, ['click']);
-        this._listeners.addPostHandler(el, ['click'], e => {
+        this._listeners.addInternalEventAfterListener(el, ['click'], e => {
             if (e.defaultPrevented)
                 return;
 
@@ -104,7 +104,7 @@ export default class ChildWindowSandbox extends SandboxBase {
             return;
 
         this._listeners.initElementListening(window, ['submit']);
-        this._listeners.addInternalEventListener(window, ['submit'], e => {
+        this._listeners.addInternalEventBeforeListener(window, ['submit'], e => {
             if (!domUtils.isFormElement(e.target))
                 return;
 

--- a/src/client/sandbox/child-window/index.ts
+++ b/src/client/sandbox/child-window/index.ts
@@ -71,16 +71,19 @@ export default class ChildWindowSandbox extends SandboxBase {
             return;
 
         this._listeners.initElementListening(el, ['click']);
-        this._listeners.addInternalEventListener(el, ['click'], (_e, _dispatched, preventEvent) => {
+        this._listeners.addPostHandler(el, ['click'], e => {
+            if (e.defaultPrevented)
+                return;
+
             if (!ChildWindowSandbox._shouldOpenInNewWindowOnElementAction(el, DefaultTarget.linkOrArea))
                 return;
 
             // TODO: need to check that specified 'area' are clickable (initiated new page opening)
             const url = nativeMethods.anchorHrefGetter.call(el);
 
-            this._openUrlInNewWindow(url);
+            e.preventDefault();
 
-            preventEvent(true);
+            this._openUrlInNewWindow(url);
         });
     }
 

--- a/src/client/sandbox/event/focus-blur.ts
+++ b/src/client/sandbox/event/focus-blur.ts
@@ -169,9 +169,9 @@ export default class FocusBlurSandbox extends SandboxBase {
                     stopEventPropagation();
                 };
 
-                this._listeners.addInternalEventListener(window, ['focus'], preventFocus);
+                this._listeners.addInternalEventBeforeListener(window, ['focus'], preventFocus);
                 this._eventSimulator['focus'](el, relatedTarget);
-                this._listeners.removeInternalEventListener(window, ['focus'], preventFocus);
+                this._listeners.removeInternalEventBeforeListener(window, ['focus'], preventFocus);
             }
 
             callback();
@@ -246,7 +246,7 @@ export default class FocusBlurSandbox extends SandboxBase {
         this._activeWindowTracker.attach(window);
         this._topWindow = domUtils.isCrossDomainWindows(window, window.top) ? window : window.top;
 
-        this._listeners.addInternalEventListener(window, ['focus', 'blur'], () => {
+        this._listeners.addInternalEventBeforeListener(window, ['focus', 'blur'], () => {
             const activeElement = domUtils.getActiveElement(this.document);
 
             this._onChangeActiveElement(activeElement);
@@ -407,12 +407,12 @@ export default class FocusBlurSandbox extends SandboxBase {
             };
 
             if (PREVENT_FOCUS_ON_CHANGE)
-                this._listeners.addInternalEventListener(window, ['focus'], focusOnChangeHandler);
+                this._listeners.addInternalEventBeforeListener(window, ['focus'], focusOnChangeHandler);
 
             this._elementEditingWatcher.processElementChanging(el);
 
             if (PREVENT_FOCUS_ON_CHANGE)
-                this._listeners.removeInternalEventListener(window, ['focus'], focusOnChangeHandler);
+                this._listeners.removeInternalEventBeforeListener(window, ['focus'], focusOnChangeHandler);
 
             this._elementEditingWatcher.stopWatching(el);
         }

--- a/src/client/sandbox/event/hover.ts
+++ b/src/client/sandbox/event/hover.ts
@@ -85,7 +85,7 @@ export default class HoverSandbox extends SandboxBase {
     attach (window: Window & typeof globalThis) {
         super.attach(window);
 
-        this._listeners.addInternalEventListener(window, ['mouseover', 'touchstart'], e => this._onHover(e));
+        this._listeners.addInternalEventBeforeListener(window, ['mouseover', 'touchstart'], e => this._onHover(e));
     }
 
     dispose () {

--- a/src/client/sandbox/event/index.ts
+++ b/src/client/sandbox/event/index.ts
@@ -163,7 +163,7 @@ export default class EventSandbox extends SandboxBase {
         // 'Click' is a complex emulated action that uses 'dispatchEvent' method internally.
         // Another browsers open the native browser dialog in this case.
         // This is why, we are forced to prevent the browser's open file dialog.
-        this.listeners.addInternalEventListener(window, ['click'], (e: Event, dispatched: boolean) => {
+        this.listeners.addInternalEventBeforeListener(window, ['click'], (e: Event, dispatched: boolean) => {
             if (dispatched && domUtils.isInputWithNativeDialog(e.target as HTMLInputElement))
                 preventDefault(e, true);
         });
@@ -212,8 +212,8 @@ export default class EventSandbox extends SandboxBase {
 
         this.listeners.initElementListening(document, DOM_EVENTS);
         this.listeners.initElementListening(window, DOM_EVENTS.concat(['load', 'beforeunload', 'pagehide', 'unload', 'message']));
-        this.listeners.addInternalEventListener(window, ['focus'], this._onFocus);
-        this.listeners.addInternalEventListener(window, ['focus', 'blur', 'change', 'focusin', 'focusout'], this._cancelInternalEvents);
+        this.listeners.addInternalEventBeforeListener(window, ['focus'], this._onFocus);
+        this.listeners.addInternalEventBeforeListener(window, ['focus', 'blur', 'change', 'focusin', 'focusout'], this._cancelInternalEvents);
 
         this._preventInputNativeDialogs(window);
 

--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -24,20 +24,20 @@ export default class Listeners extends EventEmitter {
 
     listeningCtx: any;
 
-    addInternalEventListener: Function;
-    addFirstInternalHandler: Function;
-    removeInternalEventListener: Function;
-    addPostHandler: Function;
+    addInternalEventBeforeListener: Function;
+    addFirstInternalEventBeforeListener: Function;
+    addInternalEventAfterListener: Function;
+    removeInternalEventBeforeListener: Function;
 
     constructor () {
         super();
 
         this.listeningCtx = listeningCtx;
 
-        this.addInternalEventListener    = this.listeningCtx.addInternalHandler;
-        this.addFirstInternalHandler     = this.listeningCtx.addFirstInternalHandler;
-        this.removeInternalEventListener = this.listeningCtx.removeInternalHandler;
-        this.addPostHandler              = this.listeningCtx.addPostHandler;
+        this.addInternalEventBeforeListener      = this.listeningCtx.addInternalBeforeHandler;
+        this.addFirstInternalEventBeforeListener = this.listeningCtx.addFirstInternalBeforeHandler;
+        this.addInternalEventAfterListener       = this.listeningCtx.addInternalAfterHandler;
+        this.removeInternalEventBeforeListener   = this.listeningCtx.removeInternalBeforeHandler;
     }
 
     private static _getNativeAddEventListener (el: any) {
@@ -111,7 +111,7 @@ export default class Listeners extends EventEmitter {
             if (!eventCtx)
                 return;
 
-            const internalHandlers = eventCtx.internalHandlers;
+            const internalHandlers = eventCtx.internalBeforeHandlers;
 
             eventCtx.cancelOuterHandlers = false;
 
@@ -173,7 +173,7 @@ export default class Listeners extends EventEmitter {
 
                 const res = nativeAddEventListener.apply(el, args);
 
-                listeningCtx.updatePostHandlers(el, eventType);
+                listeningCtx.updateInternalAfterHandlers(el, eventType);
 
                 listeners.emit(listeners.EVENT_LISTENER_ATTACHED_EVENT, { el, eventType, listener });
 

--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -27,6 +27,7 @@ export default class Listeners extends EventEmitter {
     addInternalEventListener: Function;
     addFirstInternalHandler: Function;
     removeInternalEventListener: Function;
+    addPostHandler: Function;
 
     constructor () {
         super();
@@ -36,6 +37,7 @@ export default class Listeners extends EventEmitter {
         this.addInternalEventListener    = this.listeningCtx.addInternalHandler;
         this.addFirstInternalHandler     = this.listeningCtx.addFirstInternalHandler;
         this.removeInternalEventListener = this.listeningCtx.removeInternalHandler;
+        this.addPostHandler              = this.listeningCtx.addPostHandler;
     }
 
     private static _getNativeAddEventListener (el: any) {
@@ -170,6 +172,8 @@ export default class Listeners extends EventEmitter {
                 listeningCtx.wrapEventListener(eventCtx, listener, wrapper, useCapture);
 
                 const res = nativeAddEventListener.apply(el, args);
+
+                listeningCtx.updatePostHandlers(el, eventType);
 
                 listeners.emit(listeners.EVENT_LISTENER_ATTACHED_EVENT, { el, eventType, listener });
 

--- a/src/client/sandbox/event/listening-context.ts
+++ b/src/client/sandbox/event/listening-context.ts
@@ -26,12 +26,12 @@ export function addListeningElement (el, events) {
     for (let i = 0; i < events.length; i++) {
         if (!elementCtx[events[i]]) {
             elementCtx[events[i]] = {
-                internalHandlers:     [],
-                outerHandlers:        [],
-                outerHandlersWrapper: null,
-                postHandlers:         [],
-                wrappers:             [],
-                cancelOuterHandlers:  false
+                internalBeforeHandlers: [],
+                internalAfterHandlers:  [],
+                outerHandlers:          [],
+                outerHandlersWrapper:   null,
+                wrappers:               [],
+                cancelOuterHandlers:    false
             };
         }
     }
@@ -48,38 +48,38 @@ export function removeListeningElement (el) {
     delete el[ELEMENT_LISTENING_EVENTS_STORAGE_PROP];
 }
 
-export function addPostHandler (el, events, handler) {
+export function addInternalAfterHandler (el, events, handler) {
     const elementCtx = getElementCtx(el);
 
     for (const event of events) {
-        elementCtx[event].postHandlers.unshift(handler);
+        elementCtx[event].internalAfterHandlers.unshift(handler);
         nativeMethods.addEventListener.call(el, event, handler);
     }
 }
 
-export function addFirstInternalHandler (el, events, handler) {
+export function addFirstInternalBeforeHandler (el, events, handler) {
     const elementCtx = getElementCtx(el);
 
     for (const event of events)
-        elementCtx[event].internalHandlers.unshift(handler);
+        elementCtx[event].internalBeforeHandlers.unshift(handler);
 }
 
-export function addInternalHandler (el, events, handler) {
+export function addInternalBeforeHandler (el, events, handler) {
     const elementCtx = getElementCtx(el);
 
     for (const event of events)
-        elementCtx[event].internalHandlers.push(handler);
+        elementCtx[event].internalBeforeHandlers.push(handler);
 }
 
-export function removeInternalHandler (el, events, handler) {
+export function removeInternalBeforeHandler (el, events, handler) {
     const elementCtx = getElementCtx(el);
 
     for (const event of events) {
-        const internalHandlers = elementCtx[event].internalHandlers;
-        const handlerIndex     = internalHandlers.indexOf(handler);
+        const internalBeforeHandlers = elementCtx[event].internalBeforeHandlers;
+        const handlerIndex     = internalBeforeHandlers.indexOf(handler);
 
         if (handlerIndex > -1)
-            internalHandlers.splice(handlerIndex, 1);
+            internalBeforeHandlers.splice(handlerIndex, 1);
     }
 }
 
@@ -112,10 +112,10 @@ export function getWrapper (eventCtx, listener, useCapture) {
     return null;
 }
 
-export function updatePostHandlers (el, eventType) {
+export function updateInternalAfterHandlers (el, eventType) {
     const elementCtx = getElementCtx(el);
 
-    for (const handler of elementCtx[eventType].postHandlers) {
+    for (const handler of elementCtx[eventType].internalAfterHandlers) {
         nativeMethods.removeEventListener.call(el, eventType, handler);
         nativeMethods.addEventListener.call(el, eventType, handler);
     }

--- a/src/client/sandbox/event/listening-context.ts
+++ b/src/client/sandbox/event/listening-context.ts
@@ -29,6 +29,7 @@ export function addListeningElement (el, events) {
                 internalHandlers:     [],
                 outerHandlers:        [],
                 outerHandlersWrapper: null,
+                postHandlers:         [],
                 wrappers:             [],
                 cancelOuterHandlers:  false
             };
@@ -45,6 +46,15 @@ export function addListeningElement (el, events) {
 
 export function removeListeningElement (el) {
     delete el[ELEMENT_LISTENING_EVENTS_STORAGE_PROP];
+}
+
+export function addPostHandler (el, events, handler) {
+    const elementCtx = getElementCtx(el);
+
+    for (const event of events) {
+        elementCtx[event].postHandlers.unshift(handler);
+        nativeMethods.addEventListener.call(el, event, handler);
+    }
 }
 
 export function addFirstInternalHandler (el, events, handler) {
@@ -100,4 +110,13 @@ export function getWrapper (eventCtx, listener, useCapture) {
     }
 
     return null;
+}
+
+export function updatePostHandlers (el, eventType) {
+    const elementCtx = getElementCtx(el);
+
+    for (const handler of elementCtx[eventType].postHandlers) {
+        nativeMethods.removeEventListener.call(el, eventType, handler);
+        nativeMethods.addEventListener.call(el, eventType, handler);
+    }
 }

--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -136,7 +136,7 @@ export default class MessageSandbox extends SandboxBase {
         const onMessageHandler       = (...args) => fastApply(this, '_onMessage', args);
         const onWindowMessageHandler = (...args) => fastApply(this, '_onWindowMessage', args);
 
-        this._listeners.addInternalEventListener(window, ['message'], onMessageHandler);
+        this._listeners.addInternalEventBeforeListener(window, ['message'], onMessageHandler);
         this._listeners.setEventListenerWrapper(window, ['message'], onWindowMessageHandler);
 
         // NOTE: In Google Chrome, iframes whose src contains html code raise the 'load' event twice.

--- a/src/client/sandbox/event/selection.ts
+++ b/src/client/sandbox/event/selection.ts
@@ -116,13 +116,13 @@ export default class Selection {
                     focusRaised = true;
             };
 
-            listeners.addInternalEventListener(document, ['focus'], focusHandler);
+            listeners.addInternalEventBeforeListener(document, ['focus'], focusHandler);
 
             result = nativeMethods.select.call(this);
 
             timersSandbox.setTimeout.call(window, () => {
                 timersSandbox.setTimeout.call(window, () => {
-                    listeners.removeInternalEventListener(document, ['focus'], focusHandler);
+                    listeners.removeInternalEventBeforeListener(document, ['focus'], focusHandler);
 
                     if (!focusRaised)
                         eventSimulator.focus(element);
@@ -168,7 +168,7 @@ export default class Selection {
         };
 
         if (needFocus)
-            this.listeners.addInternalEventListener(document, ['focus'], focusHandler);
+            this.listeners.addInternalEventBeforeListener(document, ['focus'], focusHandler);
 
         // The focus and blur events
         Listeners.beforeDispatchEvent(el);
@@ -194,7 +194,7 @@ export default class Selection {
             if (browserUtils.isIE11) {
                 this.timersSandbox.setTimeout.call(window, () => {
                     this.timersSandbox.setTimeout.call(window, () => {
-                        this.listeners.removeInternalEventListener(document, ['focus'], focusHandler);
+                        this.listeners.removeInternalEventBeforeListener(document, ['focus'], focusHandler);
 
                         if (!focusRaised)
                             this.eventSimulator.focus(el);
@@ -202,7 +202,7 @@ export default class Selection {
                 }, 0);
             }
             else {
-                this.listeners.removeInternalEventListener(document, ['focus'], focusHandler);
+                this.listeners.removeInternalEventBeforeListener(document, ['focus'], focusHandler);
 
                 if (!focusRaised) {
                     // NOTE: In Firefox, raising the dispatchEvent 'focus' doesn’t activate an element.

--- a/src/client/sandbox/event/unload.ts
+++ b/src/client/sandbox/event/unload.ts
@@ -144,7 +144,7 @@ export default class UnloadSandbox extends SandboxBase {
         this._attachEvent(this.beforeUnloadProperties);
         this._attachEvent(this.unloadProperties);
 
-        this._listeners.addInternalEventListener(window, [this.beforeUnloadProperties.nativeEventName], () => this.emit(this.BEFORE_BEFORE_UNLOAD_EVENT));
+        this._listeners.addInternalEventBeforeListener(window, [this.beforeUnloadProperties.nativeEventName], () => this.emit(this.BEFORE_BEFORE_UNLOAD_EVENT));
     }
 
     setOnEvent (eventProperties: EventProperties, window: Window, handler) {

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -923,7 +923,7 @@ export default class ElementSandbox extends SandboxBase {
 
     private _setValidBrowsingContextOnElementClick (window): void {
         this._eventSandbox.listeners.initElementListening(window, ['click']);
-        this._eventSandbox.listeners.addInternalEventListener(window, ['click'], e => {
+        this._eventSandbox.listeners.addInternalEventBeforeListener(window, ['click'], e => {
             let el = e.target;
 
             if (domUtils.isInputElement(el) && el.form)
@@ -964,7 +964,7 @@ export default class ElementSandbox extends SandboxBase {
 
     private _handleImageLoadEventRaising (el: HTMLImageElement): void {
         this._eventSandbox.listeners.initElementListening(el, ['load']);
-        this._eventSandbox.listeners.addInternalEventListener(el, ['load'], (_e, _dispatched, preventEvent, _cancelHandlers, stopEventPropagation) => {
+        this._eventSandbox.listeners.addInternalEventBeforeListener(el, ['load'], (_e, _dispatched, preventEvent, _cancelHandlers, stopEventPropagation) => {
             if (el[INTERNAL_PROPS.cachedImage])
                 el[INTERNAL_PROPS.cachedImage] = false;
 

--- a/src/client/sandbox/storages/index.ts
+++ b/src/client/sandbox/storages/index.ts
@@ -143,7 +143,7 @@ export default class StorageSandbox extends SandboxBase {
             e => this._simulateStorageEventIfNecessary(e, this.sessionStorageWrapper));
 
         this._listeners.initElementListening(window, ['storage']);
-        this._listeners.addInternalEventListener(window, ['storage'], (_e, dispatched, preventEvent) => {
+        this._listeners.addInternalEventBeforeListener(window, ['storage'], (_e, dispatched, preventEvent) => {
             if (!dispatched)
                 preventEvent();
         });

--- a/src/client/sandbox/upload/index.ts
+++ b/src/client/sandbox/upload/index.ts
@@ -39,7 +39,7 @@ export default class UploadSandbox extends SandboxBase {
     attach (window: Window & typeof globalThis) {
         super.attach(window);
 
-        this._listeners.addInternalEventListener(window, ['change'], (e, dispatched) => {
+        this._listeners.addInternalEventBeforeListener(window, ['change'], (e, dispatched) => {
             const input              = e.target;
             const currentInfoManager = UploadSandbox._getCurrentInfoManager(input);
 
@@ -74,7 +74,7 @@ export default class UploadSandbox extends SandboxBase {
             // 'Click' is a complex emulated action that uses 'dispatchEvent' method internally.
             // Another browsers open the native browser dialog in this case.
             // This is why, we are forced to prevent the browser's open file dialog.
-            this._listeners.addInternalEventListener(window, ['click'], (e: Event, dispatched: boolean) => {
+            this._listeners.addInternalEventBeforeListener(window, ['click'], (e: Event, dispatched: boolean) => {
                 if (dispatched && isFileInput(e.target as HTMLInputElement))
                     preventDefault(e, true);
             });

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -306,7 +306,7 @@ test('SVGElement.dispatchEvent should be overriden (GH-614)', function () {
     });
 
     listeners.initElementListening(svg, ['click']);
-    listeners.addFirstInternalHandler(svg, ['click'], function (event, isDispatchedEventFlag) {
+    listeners.addFirstInternalEventBeforeListener(svg, ['click'], function (event, isDispatchedEventFlag) {
         ok(isDispatchedEventFlag);
     });
 
@@ -531,7 +531,7 @@ asyncTest('events should not be called twice (GH-2062)', function () {
         ++eventCallCounter;
     });
 
-    listeners.addInternalEventListener(window, ['keypress'], function () {
+    listeners.addInternalEventBeforeListener(window, ['keypress'], function () {
         ++internalCallCounter;
     });
 
@@ -562,7 +562,7 @@ test('events should be restored after iframe rewriting (GH-1881)', function () {
             contentDocument.write('<!doctype html><html><head></head><body>hello</body></html>');
             contentDocument.close();
 
-            contentWindow['%hammerhead%'].eventSandbox.listeners.addInternalEventListener(contentWindow, ['click'], function () {
+            contentWindow['%hammerhead%'].eventSandbox.listeners.addInternalEventBeforeListener(contentWindow, ['click'], function () {
                 ++internalClickEventCounter;
             });
 
@@ -581,7 +581,7 @@ test('events should be restored after iframe rewriting (GH-1881)', function () {
             contentDocument.close();
 
             if (browserUtils.isIE) {
-                contentWindow['%hammerhead%'].eventSandbox.listeners.addInternalEventListener(contentWindow, ['click'], function () {
+                contentWindow['%hammerhead%'].eventSandbox.listeners.addInternalEventBeforeListener(contentWindow, ['click'], function () {
                     ++internalClickEventCounter;
                 });
             }

--- a/test/client/fixtures/sandbox/event/internal-listeners-test.js
+++ b/test/client/fixtures/sandbox/event/internal-listeners-test.js
@@ -229,6 +229,36 @@ test('add wrapper', function () {
     dispatchEvent(container, event);
 });
 
+module('post handlers');
+
+test('add post handler', function () {
+    var event    = 'click';
+    var actual   = [];
+    var expected = ['click1', 'click2', 'post1', 'post2'];
+
+    listeners.initElementListening(container, [event]);
+
+    container.addEventListener(event, function () {
+        actual.push('click1');
+    });
+
+    listeners.addPostHandler(container, [event], function () {
+        actual.push('post1');
+    });
+
+    container.addEventListener(event, function () {
+        actual.push('click2');
+    });
+
+    listeners.addPostHandler(container, [event], function () {
+        actual.push('post2');
+    });
+
+    dispatchEvent(container, 'click');
+
+    deepEqual(actual, expected);
+});
+
 module('prevent event');
 
 test('preventer added before listener', function () {

--- a/test/client/fixtures/sandbox/event/internal-listeners-test.js
+++ b/test/client/fixtures/sandbox/event/internal-listeners-test.js
@@ -125,7 +125,7 @@ test('initElementListening', function () {
 
     listeners.initElementListening(container, [event]);
 
-    listeners.addInternalEventListener(container, [event], function () {
+    listeners.addInternalEventBeforeListener(container, [event], function () {
     });
 
     function checkHandlerCounters (first, second, third, fourth) {
@@ -173,7 +173,7 @@ test('getEventListeners', function () {
 
     listeners.initElementListening(container, ['click']);
 
-    listeners.addInternalEventListener(container, ['click'], function () {
+    listeners.addInternalEventBeforeListener(container, ['click'], function () {
     });
 
     deepEqual(listeners.getEventListeners(container, 'click'), []);
@@ -196,7 +196,7 @@ test('stop propagation', function () {
     };
 
     listeners.initElementListening(container, [event]);
-    listeners.addInternalEventListener(container, [event], testStopPropagation);
+    listeners.addInternalEventBeforeListener(container, [event], testStopPropagation);
     bindAll(event);
 
     notEqual(domUtils.getActiveElement(), input);
@@ -242,7 +242,7 @@ test('add post handler', function () {
         actual.push('click1');
     });
 
-    listeners.addPostHandler(container, [event], function () {
+    listeners.addInternalEventAfterListener(container, [event], function () {
         actual.push('post1');
     });
 
@@ -250,7 +250,7 @@ test('add post handler', function () {
         actual.push('click2');
     });
 
-    listeners.addPostHandler(container, [event], function () {
+    listeners.addInternalEventAfterListener(container, [event], function () {
         actual.push('post2');
     });
 
@@ -272,7 +272,7 @@ test('preventer added before listener', function () {
     };
 
     listeners.initElementListening(container, [event]);
-    listeners.addInternalEventListener(container, [event], testPreventEvent);
+    listeners.addInternalEventBeforeListener(container, [event], testPreventEvent);
     bindAll(event);
     dispatchEvent(input, event);
 
@@ -283,7 +283,7 @@ test('preventer added before listener', function () {
     ok(!elementBubbleEventRaised);
 
     preventEventRaised = false;
-    listeners.removeInternalEventListener(container, [event], testPreventEvent);
+    listeners.removeInternalEventBeforeListener(container, [event], testPreventEvent);
     dispatchEvent(input, event);
 
     ok(!preventEventRaised);
@@ -305,7 +305,7 @@ test('preventer added after listener', function () {
 
     listeners.initElementListening(container, [event]);
     bindAll(event);
-    listeners.addInternalEventListener(container, [event], testPreventEvent);
+    listeners.addInternalEventBeforeListener(container, [event], testPreventEvent);
     dispatchEvent(input, event);
 
     ok(preventEventRaised);
@@ -336,10 +336,10 @@ test('append several handlers', function () {
     };
 
     listeners.initElementListening(container, [event1, event2]);
-    listeners.addInternalEventListener(container, [event1], handler1);
-    listeners.addInternalEventListener(container, [event1], testPreventEvent);
-    listeners.addInternalEventListener(container, [event1], handler2);
-    listeners.addInternalEventListener(container, [event2], testPreventEvent);
+    listeners.addInternalEventBeforeListener(container, [event1], handler1);
+    listeners.addInternalEventBeforeListener(container, [event1], testPreventEvent);
+    listeners.addInternalEventBeforeListener(container, [event1], handler2);
+    listeners.addInternalEventBeforeListener(container, [event2], testPreventEvent);
 
     bindAll(event1);
     bindAll(event2);
@@ -370,7 +370,7 @@ test('canceller added after listener', function () {
 
     listeners.initElementListening(container, [event]);
     bindAll(event);
-    listeners.addInternalEventListener(container, [event], testCancelHandlers);
+    listeners.addInternalEventBeforeListener(container, [event], testCancelHandlers);
     dispatchEvent(uiElement, event);
 
     ok(cancelHandlersRaised);
@@ -381,7 +381,7 @@ test('canceller added after listener', function () {
     ok(uiElementCaptureEventRaised);
     ok(uiElementBubbleEventRaised);
 
-    listeners.removeInternalEventListener(container, [event], testCancelHandlers);
+    listeners.removeInternalEventBeforeListener(container, [event], testCancelHandlers);
 });
 
 module('regression');
@@ -408,7 +408,7 @@ test('only one of several handlers must be called (document handlers) (T233158)'
 
     listeners.initElementListening(document, [event]);
 
-    listeners.addInternalEventListener(document, [event], function () {
+    listeners.addInternalEventBeforeListener(document, [event], function () {
     });
 
     var $document = $(document);
@@ -469,7 +469,7 @@ test('only one of several handlers must be called (body handlers) (T233158)', fu
 
     listeners.initElementListening(document, [event]);
 
-    listeners.addInternalEventListener(document, [event], function () {
+    listeners.addInternalEventBeforeListener(document, [event], function () {
     });
 
     document.body.addEventListener(event, clickHandler, true);
@@ -502,7 +502,7 @@ test('only one of several handlers must be called (element handlers) (T233158)',
 
     listeners.initElementListening(document, [event]);
 
-    listeners.addInternalEventListener(document, [event], function () {
+    listeners.addInternalEventBeforeListener(document, [event], function () {
     });
 
     container.addEventListener(event, clickHandler, true);
@@ -530,7 +530,7 @@ test('should allow removing a listener inside a listener (testcafe/#3652', funct
     function expendableHandler () {
         expendableHandlerCallCount++;
 
-        listeners.removeInternalEventListener(container, [event], expendableHandler);
+        listeners.removeInternalEventBeforeListener(container, [event], expendableHandler);
     }
 
     function normalEventHandler () {
@@ -539,9 +539,9 @@ test('should allow removing a listener inside a listener (testcafe/#3652', funct
 
     listeners.initElementListening(container, [event]);
 
-    listeners.addInternalEventListener(container, [event], normalEventHandler);
-    listeners.addInternalEventListener(container, [event], expendableHandler);
-    listeners.addInternalEventListener(container, [event], normalEventHandler);
+    listeners.addInternalEventBeforeListener(container, [event], normalEventHandler);
+    listeners.addInternalEventBeforeListener(container, [event], expendableHandler);
+    listeners.addInternalEventBeforeListener(container, [event], normalEventHandler);
 
     dispatchEvent(container, event);
     dispatchEvent(container, event);
@@ -561,7 +561,7 @@ if (browserUtils.isIE) {
 
         listeners.initElementListening(document, [events]);
 
-        listeners.addInternalEventListener(document, [events], function () {
+        listeners.addInternalEventBeforeListener(document, [events], function () {
         });
 
         document.addEventListener('pointerdown', handler, true);

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -421,7 +421,7 @@ if (browserUtils.isWebKit) {
         return createTestIframe({ src: getSameDomainPageUrl('../../data/iframe/window-event-listeners.html') })
             .then(function (iframe) {
                 iframe.contentWindow.performWrite();
-                iframe.contentWindow['%hammerhead%'].eventSandbox.listeners.addInternalEventListener(iframe.contentWindow, ['click'], function () {
+                iframe.contentWindow['%hammerhead%'].eventSandbox.listeners.addInternalEventBeforeListener(iframe.contentWindow, ['click'], function () {
                     ++internalClickEventCounter;
                 });
 

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -470,7 +470,7 @@ asyncTest('get uploaded file error: single file', function () {
     };
 
     uploadSandbox.on(uploadSandbox.END_FILE_UPLOADING_EVENT, eventHandler);
-    listeningContext.getElementCtx(window).change.internalHandlers[1].call(inputMock, { target: inputMock });
+    listeningContext.getElementCtx(window).change.internalBeforeHandlers[1].call(inputMock, { target: inputMock });
 });
 
 asyncTest('get uploaded file error: multi file', function () {
@@ -512,7 +512,7 @@ asyncTest('get uploaded file error: multi file', function () {
     };
 
     uploadSandbox.on(uploadSandbox.END_FILE_UPLOADING_EVENT, eventHandler);
-    listeningContext.getElementCtx(window).change.internalHandlers[1].call(inputMock, { target: inputMock });
+    listeningContext.getElementCtx(window).change.internalBeforeHandlers[1].call(inputMock, { target: inputMock });
 });
 
 module('upload');
@@ -912,7 +912,7 @@ if (window.FileList) {
 
 test('Should not prevent native upload dialog in the record mode (GH-2168)', function () {
     var uploadSand = new UploadSandbox({
-        addInternalEventListener: function (el, events) {
+        addInternalEventBeforeListener: function (el, events) {
             strictEqual(events.indexOf('click'), -1);
         }
     });

--- a/test/client/fixtures/transport-test.js
+++ b/test/client/fixtures/transport-test.js
@@ -236,14 +236,14 @@ test('should send queued messages', function () {
     var storedEventObj  = null;
     var iframeTransport = null;
 
-    msgEventCtx.internalHandlers.unshift(function (e, flag, preventEvent) {
+    msgEventCtx.internalBeforeHandlers.unshift(function (e, flag, preventEvent) {
         var msgData = e.toString() === '[object MessageEvent]' ? nativeMethods.messageEventDataGetter.call(e) : e.data;
 
         if (msgData.message.cmd !== 'hammerhead|command|get-message-port')
             return;
 
         storedEventObj = e;
-        msgEventCtx.internalHandlers.shift();
+        msgEventCtx.internalBeforeHandlers.shift();
         preventEvent();
     });
 
@@ -266,7 +266,7 @@ test('should send queued messages', function () {
             strictEqual(iframeTransport._queue[0].queued, false);
             strictEqual(iframeTransport._queue[0].msg.test, 'me');
 
-            msgEventCtx.internalHandlers[0].call(window, storedEventObj);
+            msgEventCtx.internalBeforeHandlers[0].call(window, storedEventObj);
 
             return msgPromise;
         })


### PR DESCRIPTION
New mechanism of `postHandlers` which will be called after all user handlers are called.
This mechanism allows us to prevent opening of new window in multiple window mode, if the event was prevented inside on the user listeners
