### PR TITLE
Cache non-proxied resources (v2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "19.2.3",
+  "version": "19.3.0",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/request-pipeline/context.ts
+++ b/src/request-pipeline/context.ts
@@ -464,7 +464,7 @@ export default class RequestPipelineContext {
 
         this.destResBody = await this._getDestResBody(this.destRes);
 
-        if (this.temporaryCacheEntry)
+        if (this.temporaryCacheEntry && this.destResBody.length < requestCache.MAX_SIZE_FOR_NON_PROCESSED_RESOURCE)
             this._addTemporaryEntryToCache();
 
         this.res.write(this.destResBody);


### PR DESCRIPTION
Cache non-processed resources up to 5 Mb. It allowing to cache fonts, images, gifs, etc.