### PR TITLE
Allow to using async function for request filter rule predicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "19.3.0",
+  "version": "19.3.1",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/processing/resources/index.ts
+++ b/src/processing/resources/index.ts
@@ -48,8 +48,6 @@ export async function process (ctx: RequestPipelineContext): Promise<Buffer> {
 
     const decoded = await decodeContent(destResBody, encoding, charset);
 
-    await ctx.prepareInjectableUserScripts();
-
     for (const processor of RESOURCE_PROCESSORS) {
         if (!processor.shouldProcessResource(ctx))
             continue;

--- a/src/processing/resources/index.ts
+++ b/src/processing/resources/index.ts
@@ -43,12 +43,12 @@ function getResourceUrlReplacer (ctx: RequestPipelineContext): Function {
 }
 
 export async function process (ctx: RequestPipelineContext): Promise<Buffer> {
-    const body        = ctx.destResBody;
-    const contentInfo = ctx.contentInfo;
-    const encoding    = contentInfo.encoding;
-    const charset     = contentInfo.charset;
+    const { destResBody: body, contentInfo } = ctx;
+    const { encoding, charset }              = contentInfo;
 
     const decoded = await decodeContent(body, encoding, charset);
+
+    await ctx.prepareInjectableUserScripts();
 
     for (const processor of RESOURCE_PROCESSORS) {
         if (processor.shouldProcessResource(ctx)) {

--- a/src/request-pipeline/request-hooks/request-filter-rule.ts
+++ b/src/request-pipeline/request-hooks/request-filter-rule.ts
@@ -79,8 +79,8 @@ export default class RequestFilterRule {
                this._matchIsAjax(this.options.isAjax, requestInfo.isAjax);
     }
 
-    _matchUsingFunctionOptions (requestInfo: RequestInfo) {
-        return !!this.options.call(this, requestInfo);
+    async _matchUsingFunctionOptions (requestInfo: RequestInfo): Promise<boolean> {
+        return !!await this.options.call(this, requestInfo);
     }
 
     _stringifyObjectOptions () {
@@ -101,9 +101,9 @@ export default class RequestFilterRule {
         return `{ ${msg} }`;
     }
 
-    match (requestInfo: RequestInfo): boolean {
+    async match (requestInfo: RequestInfo): Promise<boolean> {
         if (typeof this.options === 'function')
-            return this._matchUsingFunctionOptions(requestInfo);
+            return await this._matchUsingFunctionOptions(requestInfo);
 
         return this._matchUsingObjectOptions(requestInfo);
     }

--- a/src/request-pipeline/stages.ts
+++ b/src/request-pipeline/stages.ts
@@ -64,7 +64,8 @@ export default [
         if (ctx.session.hasRequestEventListeners()) {
             const requestInfo = new RequestInfo(ctx);
 
-            ctx.requestFilterRules = ctx.session.getRequestFilterRules(requestInfo);
+            ctx.requestFilterRules = await ctx.session.getRequestFilterRules(requestInfo);
+
             await ctx.forEachRequestFilterRule(async rule => {
                 await callOnRequestEventCallback(ctx, rule, requestInfo);
                 ctx.setupMockIfNecessary(rule);

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -266,10 +266,16 @@ export default abstract class Session extends EventEmitter {
     }
 
     async getRequestFilterRules (requestInfo: RequestInfo): Promise<RequestFilterRule[]> {
-        const rulesArray       = Array.from(this.requestEventListeners.keys());
-        const matchRuleResults = await Promise.all(rulesArray.map(rule => rule.match(requestInfo)));
+        const rulesArray = Array.from(this.requestEventListeners.keys());
 
-        return rulesArray.filter((_, index) => matchRuleResults[index]);
+        const matchedRules = await Promise.all(rulesArray.map(async rule => {
+            if (await rule.match(requestInfo))
+                return rule;
+
+            return void 0;
+        }));
+
+        return matchedRules.filter(rule => !!rule);
     }
 
     async callRequestEventCallback (eventName: RequestEventNames, requestFilterRule: RequestFilterRule, eventData: RequestEvent | ResponseEvent | ConfigureResponseEvent) {

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -265,10 +265,11 @@ export default abstract class Session extends EventEmitter {
         this.requestEventListeners.clear();
     }
 
-    getRequestFilterRules (requestInfo: RequestInfo): RequestFilterRule[] {
-        const rulesArray: RequestFilterRule[] = Array.from(this.requestEventListeners.keys());
+    async getRequestFilterRules (requestInfo: RequestInfo): Promise<RequestFilterRule[]> {
+        const rulesArray  = Array.from(this.requestEventListeners.keys());
+        const matchingRules = await Promise.all(rulesArray.map(rule => rule.match(requestInfo)));
 
-        return rulesArray.filter(rule => rule.match(requestInfo));
+        return rulesArray.filter((_, index) => matchingRules[index]);
     }
 
     async callRequestEventCallback (eventName: RequestEventNames, requestFilterRule: RequestFilterRule, eventData: RequestEvent | ResponseEvent | ConfigureResponseEvent) {

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -266,10 +266,10 @@ export default abstract class Session extends EventEmitter {
     }
 
     async getRequestFilterRules (requestInfo: RequestInfo): Promise<RequestFilterRule[]> {
-        const rulesArray  = Array.from(this.requestEventListeners.keys());
-        const matchingRules = await Promise.all(rulesArray.map(rule => rule.match(requestInfo)));
+        const rulesArray       = Array.from(this.requestEventListeners.keys());
+        const matchRuleResults = await Promise.all(rulesArray.map(rule => rule.match(requestInfo)));
 
-        return rulesArray.filter((_, index) => matchingRules[index]);
+        return rulesArray.filter((_, index) => matchRuleResults[index]);
     }
 
     async callRequestEventCallback (eventName: RequestEventNames, requestFilterRule: RequestFilterRule, eventData: RequestEvent | ResponseEvent | ConfigureResponseEvent) {

--- a/test/server/request-hook-test.js
+++ b/test/server/request-hook-test.js
@@ -189,7 +189,7 @@ describe('RequestFilterRule', () => {
         expect(hook.toString()).eql('{ <predicate> }');
     });
 
-    it('Match', () => {
+    it('Match', async () => {
         const requestInfo = {
             url:     'http://example.com/',
             method:  'post',
@@ -200,46 +200,55 @@ describe('RequestFilterRule', () => {
             }
         };
 
-        expect(new RequestFilterRule('http://example.com').match(requestInfo)).to.be.true;
-        expect(new RequestFilterRule('http://example.com/').match(requestInfo)).to.be.true;
-        expect(new RequestFilterRule('http://example.com/index').match(requestInfo)).to.be.false;
-        expect(new RequestFilterRule('https://example.com').match(requestInfo)).to.be.false;
-        expect(new RequestFilterRule(/example.com/).match(requestInfo)).to.be.true;
-        expect(new RequestFilterRule(/example1.com/).match(requestInfo)).to.be.false;
-        expect(new RequestFilterRule({ url: 'http://example.com', method: 'Post' }).match(requestInfo)).to.be.true;
-        expect(new RequestFilterRule({ url: 123, method: 'Post' }).match(requestInfo)).to.be.false;
-        expect(new RequestFilterRule({ method: 'get' }).match(requestInfo)).to.be.false;
-        expect(new RequestFilterRule({ method: 1 }).match(requestInfo)).to.be.false;
-        expect(new RequestFilterRule({
+        expect(await new RequestFilterRule('http://example.com').match(requestInfo)).to.be.true;
+        expect(await new RequestFilterRule('http://example.com/').match(requestInfo)).to.be.true;
+        expect(await new RequestFilterRule('http://example.com/index').match(requestInfo)).to.be.false;
+        expect(await new RequestFilterRule('https://example.com').match(requestInfo)).to.be.false;
+        expect(await new RequestFilterRule(/example.com/).match(requestInfo)).to.be.true;
+        expect(await new RequestFilterRule(/example1.com/).match(requestInfo)).to.be.false;
+        expect(await new RequestFilterRule({ url: 'http://example.com', method: 'Post' }).match(requestInfo)).to.be.true;
+        expect(await new RequestFilterRule({ url: 123, method: 'Post' }).match(requestInfo)).to.be.false;
+        expect(await new RequestFilterRule({ method: 'get' }).match(requestInfo)).to.be.false;
+        expect(await new RequestFilterRule({ method: 1 }).match(requestInfo)).to.be.false;
+        expect(await new RequestFilterRule({
             url:    'http://example.com',
             method: 'Post',
             isAjax: false
         }).match(requestInfo)).to.be.false;
-        expect(new RequestFilterRule({
+        expect(await new RequestFilterRule({
             url:    'http://example.com',
             method: 'Post',
             isAjax: true
         }).match(requestInfo)).to.be.true;
-        expect(new RequestFilterRule({
+        expect(await new RequestFilterRule({
             url:    'http://example.com',
             method: 'Post',
             isAjax: 'test'
         }).match(requestInfo)).to.be.false;
-        expect(new RequestFilterRule(() => {}).match(requestInfo)).to.be.false;
-        expect(new RequestFilterRule(request => request.url === 'wrong_url').match(requestInfo)).to.be.false;
-        expect(new RequestFilterRule(request => {
+        expect(await new RequestFilterRule(() => {}).match(requestInfo)).to.be.false;
+        expect(await new RequestFilterRule(request => request.url === 'wrong_url').match(requestInfo)).to.be.false;
+        expect(await new RequestFilterRule(request => {
             return request.url === 'http://example.com/' &&
                    request.method === 'post' &&
                    request.isAjax &&
                    request.body === '{ test: true }' &&
                    request.headers['content-type'] === 'application/json';
         }).match(requestInfo)).to.be.true;
+        expect(await new RequestFilterRule(async request => {
+            const resultPromise = new Promise(resolve => {
+                setTimeout(() => {
+                    resolve(request.url === 'http://example.com/');
+                }, 100);
+            });
+
+            return resultPromise;
+        }).match(requestInfo)).to.be.true;
     });
 
-    it('Match all', () => {
-        expect(RequestFilterRule.ANY.match({ url: 'https://example.com' })).to.be.true;
-        expect(RequestFilterRule.ANY.match({ url: 'https://example.com/index.html' })).to.be.true;
-        expect(RequestFilterRule.ANY.match({ url: 'file://user/bin/data' })).to.be.true;
+    it('Match all', async () => {
+        expect(await RequestFilterRule.ANY.match({ url: 'https://example.com' })).to.be.true;
+        expect(await RequestFilterRule.ANY.match({ url: 'https://example.com/index.html' })).to.be.true;
+        expect(await RequestFilterRule.ANY.match({ url: 'file://user/bin/data' })).to.be.true;
     });
 
     it('isANY', () => {


### PR DESCRIPTION
Part of https://github.com/DevExpress/testcafe/issues/5924

https://devexpress.github.io/testcafe/documentation/reference/test-api/requesthook/constructor.html#filter-with-a-predicate