### PR TITLE
fix hover for label with associated control (testcafe gh-5916)

### DIFF
--- a/src/client/sandbox/event/hover.ts
+++ b/src/client/sandbox/event/hover.ts
@@ -22,6 +22,10 @@ export default class HoverSandbox extends SandboxBase {
             // NOTE: Assign a pseudo-class marker to the elements until the joint parent is found.
             if (newHoveredElement !== jointParent) {
                 nativeMethods.setAttribute.call(newHoveredElement, INTERNAL_ATTRS.hoverPseudoClass, '');
+
+                if (newHoveredElement.control)
+                    nativeMethods.setAttribute.call(newHoveredElement.control, INTERNAL_ATTRS.hoverPseudoClass, '');
+
                 newHoveredElement = nativeMethods.nodeParentNodeGetter.call(newHoveredElement);
             }
             else
@@ -39,6 +43,9 @@ export default class HoverSandbox extends SandboxBase {
             let el = this._lastHoveredElement;
 
             while (el && el.tagName && el.contains) {
+                if (el.control)
+                    nativeMethods.removeAttribute.call(el.control, INTERNAL_ATTRS.hoverPseudoClass);
+
                 // NOTE: Check that the current element is a joint parent for the hovered elements.
                 if (!el.contains(newHoveredElement)) {
                     nativeMethods.removeAttribute.call(el, INTERNAL_ATTRS.hoverPseudoClass);

--- a/src/client/sandbox/event/hover.ts
+++ b/src/client/sandbox/event/hover.ts
@@ -23,8 +23,10 @@ export default class HoverSandbox extends SandboxBase {
             if (newHoveredElement !== jointParent) {
                 nativeMethods.setAttribute.call(newHoveredElement, INTERNAL_ATTRS.hoverPseudoClass, '');
 
-                if (newHoveredElement.control)
-                    nativeMethods.setAttribute.call(newHoveredElement.control, INTERNAL_ATTRS.hoverPseudoClass, '');
+                const inputForLabel = newHoveredElement.control || newHoveredElement.htmlFor && document.getElementById(newHoveredElement.htmlFor);
+
+                if (inputForLabel)
+                    nativeMethods.setAttribute.call(inputForLabel, INTERNAL_ATTRS.hoverPseudoClass, '');
 
                 newHoveredElement = nativeMethods.nodeParentNodeGetter.call(newHoveredElement);
             }
@@ -43,8 +45,10 @@ export default class HoverSandbox extends SandboxBase {
             let el = this._lastHoveredElement;
 
             while (el && el.tagName && el.contains) {
-                if (el.control)
-                    nativeMethods.removeAttribute.call(el.control, INTERNAL_ATTRS.hoverPseudoClass);
+                const inputForLabel = el.control || el.htmlFor && document.getElementById(el.htmlFor);
+
+                if (inputForLabel)
+                    nativeMethods.removeAttribute.call(inputForLabel, INTERNAL_ATTRS.hoverPseudoClass);
 
                 // NOTE: Check that the current element is a joint parent for the hovered elements.
                 if (!el.contains(newHoveredElement)) {

--- a/src/client/sandbox/event/hover.ts
+++ b/src/client/sandbox/event/hover.ts
@@ -23,10 +23,10 @@ export default class HoverSandbox extends SandboxBase {
             if (newHoveredElement !== jointParent) {
                 nativeMethods.setAttribute.call(newHoveredElement, INTERNAL_ATTRS.hoverPseudoClass, '');
 
-                const inputForLabel = newHoveredElement.control || newHoveredElement.htmlFor && document.getElementById(newHoveredElement.htmlFor);
+                const associatedElement = domUtils.getAssociatedElement(newHoveredElement);
 
-                if (inputForLabel)
-                    nativeMethods.setAttribute.call(inputForLabel, INTERNAL_ATTRS.hoverPseudoClass, '');
+                if (associatedElement)
+                    nativeMethods.setAttribute.call(associatedElement, INTERNAL_ATTRS.hoverPseudoClass, '');
 
                 newHoveredElement = nativeMethods.nodeParentNodeGetter.call(newHoveredElement);
             }
@@ -45,10 +45,10 @@ export default class HoverSandbox extends SandboxBase {
             let el = this._lastHoveredElement;
 
             while (el && el.tagName && el.contains) {
-                const inputForLabel = el.control || el.htmlFor && document.getElementById(el.htmlFor);
+                const associatedElement = domUtils.getAssociatedElement(el);
 
-                if (inputForLabel)
-                    nativeMethods.removeAttribute.call(inputForLabel, INTERNAL_ATTRS.hoverPseudoClass);
+                if (associatedElement)
+                    nativeMethods.removeAttribute.call(associatedElement, INTERNAL_ATTRS.hoverPseudoClass);
 
                 // NOTE: Check that the current element is a joint parent for the hovered elements.
                 if (!el.contains(newHoveredElement)) {

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -877,3 +877,9 @@ export function isInputWithoutSelectionProperties (el): boolean {
 
     return !hasSelectionProperties;
 }
+
+export function getAssociatedElement (el: HTMLLabelElement): HTMLElement {
+    const doc = findDocument(el);
+
+    return el.control || el.htmlFor && nativeMethods.getElementById.call(doc, el.htmlFor);
+}

--- a/test/client/fixtures/sandbox/event/hover-test.js
+++ b/test/client/fixtures/sandbox/event/hover-test.js
@@ -81,3 +81,72 @@ test('Hovering element which is not in the DOM (GH-345)', function () {
 
     document.body.removeChild(el1);
 });
+
+test('Hovering label with associated control', function () {
+    var style = document.createElement('style');
+    var div   = document.createElement('div');
+
+    style.innerHTML = '.custom-control {' +
+                      '    position: relative;' +
+                      '    padding-left: 40px;' +
+                      '}' +
+                      '.custom-radio .custom-control-label::before {' +
+                      '    background-color: #000;' +
+                      '}' +
+                      '.custom-radio .custom-control-input {' +
+                      '    opacity: 0;' +
+                      '    width: 1px;' +
+                      '    height: 1px;' +
+                      '    position: absolute;' +
+                      '    left: 5px;' +
+                      '    top: 10px;' +
+                      '}' +
+                      '.custom-radio .custom-control-input:hover ~ .custom-control-label::before {' +
+                      '    background-color: rgb(255, 0, 0);' +
+                      '}' +
+                      '.custom-control-label:before {' +
+                      '    background-color: #fff;' +
+                      '    border: 1px solid #adb5bd;' +
+                      '    background-color: #000;' +
+                      '    border-radius: 50%;' +
+                      '    position: absolute;' +
+                      '    top: 0;' +
+                      '    left: 0;' +
+                      '    display: block;' +
+                      '    width: 20px;' +
+                      '    height: 20px;' +
+                      '    content: "";' +
+                      '}';
+
+    div.innerHTML = '<div class="custom-control custom-radio">' +
+                    '    <input type="radio" class="custom-control-input" value="warm" id="radio1">' +
+                    '    <label class="custom-control-label" for="radio1"><span>radio 1</span></label>' +
+                    '</div>' +
+                    '<div class="custom-control custom-radio">' +
+                    '    <input type="radio" class="custom-control-input" value="warm" id="radio2">' +
+                    '    <label class="custom-control-label" for="radio2"><span>radio 2</span></label>' +
+                    '</div>';
+
+
+    document.body.appendChild(style);
+    document.body.appendChild(div);
+
+    var label1 = document.querySelectorAll('label')[0];
+    var label2 = document.querySelectorAll('label')[1];
+
+    strictEqual('rgb(0, 0, 0)', getComputedStyle(label1, ':before').backgroundColor);
+    strictEqual('rgb(0, 0, 0)', getComputedStyle(label2, ':before').backgroundColor);
+
+    hoverElement(label1);
+
+    strictEqual('rgb(255, 0, 0)', getComputedStyle(label1, ':before').backgroundColor);
+    strictEqual('rgb(0, 0, 0)', getComputedStyle(label2, ':before').backgroundColor);
+
+    hoverElement(label2);
+
+    strictEqual('rgb(0, 0, 0)', getComputedStyle(label1, ':before').backgroundColor);
+    strictEqual('rgb(255, 0, 0)', getComputedStyle(label2, ':before').backgroundColor);
+
+    document.body.removeChild(style);
+    document.body.removeChild(div);
+});


### PR DESCRIPTION
The cause of the issue is that if user hovers a label associated with input element (using htmlFor atrtibute) then input:hover style applies as well.

i.e.
```HTML
<label for='inp'>label<label>
<input id='inp'>
<div>test</div>
```
```CSS
input:hover ~ div {
background-color: red;
}
```
If you hover label then div becomes red