### PR TITLE
Fixed a bug where the Service Worker registration was failed due to the wrong `currentScope` calculation in `postMessage` (closes #2524)

### DIFF
--- a/src/client/utils/url.ts
+++ b/src/client/utils/url.ts
@@ -295,7 +295,10 @@ export function getScope (url: string): string | null {
     if (!parsedUrl)
         return null;
 
-    return parsedUrl.partAfterHost.replace(SCOPE_RE, '/') || '/';
+    // NOTE: Delete query and hash parts. These parts are not related to the scope (GH-2524)
+    const partAfterHostWithoutQueryAndHash = sharedUrlUtils.getPathname(parsedUrl.partAfterHost);
+
+    return partAfterHostWithoutQueryAndHash.replace(SCOPE_RE, '/') || '/';
 }
 
 export function getAjaxProxyUrl (url: string, credentials: Credentials) {

--- a/test/client/fixtures/utils/url-test.js
+++ b/test/client/fixtures/utils/url-test.js
@@ -167,6 +167,11 @@ test('scope', function () {
     strictEqual(urlUtils.getScope('http://example.com/path?z=9'), '/');
     strictEqual(urlUtils.getScope('/path/?z=9'), '/path/');
     strictEqual(urlUtils.getScope('../path/sw.js'), '/path/');
+
+    // GH-2524
+    strictEqual(urlUtils.getScope('http://example.com/path/sw.js?https://some.url/another-path'), '/path/');
+    strictEqual(urlUtils.getScope('/path/sw.js?v=arg=/another-path'), '/path/');
+    strictEqual(urlUtils.getScope('/path/sw.js?'), '/path/');
 });
 
 module('get proxy url');


### PR DESCRIPTION
## Purpose
Service Worker registration error:
```
Registration failed with Error: The path of the provided scope %SCOPE% is not under the max scope allowed %WRONG-SCOPE%. Adjust the scope, move the Service Worker script, or use the Service-Worker-Allowed HTTP header to allow the scope.
```

## Approach
The Service Worker registration is failed due to the wrong `currentScope` calculation in `postMessage`. In this PR I added a step to remove a problematic URL part (query and hash) with the existing `getPathname` method. This part is not related to the scope (`getScope()`) calculating.

## References
https://tools.ietf.org/html/rfc3986#section-3.3:
> The path is terminated by the first question mark ("?") or number sign ("#") character ...

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
