### PR TITLE
RequestFilterRule improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "20.1.0",
+  "version": "20.2.0",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/request-pipeline/request-hooks/request-filter-rule/index.ts
+++ b/src/request-pipeline/request-hooks/request-filter-rule/index.ts
@@ -15,7 +15,7 @@ const MATCH_ANY_REQUEST_REG_EX = /.*/;
 // NOTE: RequestFilterRule is a data transfer object
 // It should contain only initialization and creation logic
 export default class RequestFilterRule {
-    public readonly options: RequestFilterRuleInit;
+    public options: RequestFilterRuleInit;
     public id: string;
 
     constructor (options: RequestFilterRuleInit) {
@@ -53,10 +53,23 @@ export default class RequestFilterRule {
         return id;
     }
 
-    private static _ensureRule (rule: RequestFilterRuleInit | RequestFilterRule) {
-        return rule instanceof RequestFilterRule ?
-            rule :
-            new RequestFilterRule(rule);
+    static _isRequestFilterRuleLike (rule: unknown): boolean {
+        return !!rule['id'] && !!rule['options'];
+    }
+
+    static _ensureRule (rule: RequestFilterRuleInit | RequestFilterRule) {
+        if (rule instanceof RequestFilterRule)
+            return rule;
+
+        else if (RequestFilterRule._isRequestFilterRuleLike(rule)) {
+            const id         = rule['id'];
+            const options    = rule['options'];
+            const newOptions = Object.assign({}, { id }, options);
+
+            return new RequestFilterRule(newOptions);
+        }
+
+        return new RequestFilterRule(rule);
     }
 
     static get ANY (): RequestFilterRule {

--- a/src/request-pipeline/request-hooks/request-filter-rule/index.ts
+++ b/src/request-pipeline/request-hooks/request-filter-rule/index.ts
@@ -57,7 +57,7 @@ export default class RequestFilterRule {
         return !!rule['id'] && !!rule['options'];
     }
 
-    static _ensureRule (rule: RequestFilterRuleInit | RequestFilterRule) {
+    private static _ensureRule (rule: RequestFilterRuleInit | RequestFilterRule) {
         if (rule instanceof RequestFilterRule)
             return rule;
 

--- a/test/server/request-hook-test.js
+++ b/test/server/request-hook-test.js
@@ -203,12 +203,21 @@ describe('RequestFilterRule', () => {
         const rule2    = new RequestFilterRule(ruleInit);
         const rule3    = { id: '1', url: ruleInit };
 
+        const ruleLikeObject = {
+            id:      '1',
+            options: {
+                url:    'http://dummy.com',
+                method: void 0,
+                isAjax: void 0
+            }
+        };
+
         expect(RequestFilterRule.from()).eql([]);
         expect(RequestFilterRule.from(rule1)).eql([rule1]);
 
-        const rules = RequestFilterRule.from([rule1, rule2, rule3, ruleInit]);
+        const rules = RequestFilterRule.from([rule1, rule2, rule3, ruleInit, ruleLikeObject]);
 
-        expect(rules.length).eql(4);
+        expect(rules.length).eql(5);
 
         rules.forEach(rule => {
             expect(rule).to.be.an.instanceOf(RequestFilterRule);

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -119,6 +119,9 @@ declare module 'testcafe-hammerhead' {
 
         /** Creates RequestFilterRule instances from RequestFilterRule initializers **/
         static from (rules?: RequestFilterRuleInit | RequestFilterRuleInit[]): RequestFilterRule[];
+
+        /** Unique identified of the RequestFilterRule instance **/
+        id: string;
     }
 
     /** The StateSnapshot class is used to create page state snapshot **/

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -120,7 +120,7 @@ declare module 'testcafe-hammerhead' {
         /** Creates RequestFilterRule instances from RequestFilterRule initializers **/
         static from (rules?: RequestFilterRuleInit | RequestFilterRuleInit[]): RequestFilterRule[];
 
-        /** Unique identified of the RequestFilterRule instance **/
+        /** Unique identifier of the RequestFilterRule instance **/
         id: string;
     }
 


### PR DESCRIPTION
Changes:
* the `RequestFilterRule.from` method can create a `RequestFilterRule` instance from request filter rule like object
* add `RequestFilterRule.id` property to TypeScript definitions.
