### PR TITLE
Compiler service related changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "21.0.0",
+  "version": "22.1.0",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "22.1.0",
+  "version": "23.0.0",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/request-pipeline/request-hooks/request-filter-rule/index.ts
+++ b/src/request-pipeline/request-hooks/request-filter-rule/index.ts
@@ -82,7 +82,14 @@ export default class RequestFilterRule {
             instance.options.url === MATCH_ANY_REQUEST_REG_EX);
     }
 
-    static from (rules?: RequestFilterRuleInit | RequestFilterRuleInit[]): RequestFilterRule[] {
+    static from (rule?: RequestFilterRuleInit): RequestFilterRule | null {
+        if (!rule)
+            return null;
+
+        return this._ensureRule(rule);
+    }
+
+    static fromArray (rules?: RequestFilterRuleInit[]): RequestFilterRule[] {
         if (!rules)
             return [];
 

--- a/src/session/events/configure-response-event.ts
+++ b/src/session/events/configure-response-event.ts
@@ -5,7 +5,7 @@ import ConfigureResponseEventOptions from './configure-response-event-options';
 export default class ConfigureResponseEvent {
     private readonly _requestContext: RequestPipelineContext;
     readonly _requestFilterRule: RequestFilterRule;
-    readonly opts: ConfigureResponseEventOptions;
+    public opts: ConfigureResponseEventOptions;
 
     constructor (requestContext: RequestPipelineContext, requestFilterRule: RequestFilterRule, opts: ConfigureResponseEventOptions) {
         this._requestContext    = requestContext;

--- a/test/server/request-hook-test.js
+++ b/test/server/request-hook-test.js
@@ -213,7 +213,7 @@ describe('RequestFilterRule', () => {
         expect(RequestFilterRule.isANY(new RequestFilterRule('https://example.com'))).to.be.false;
     });
 
-    it('.from', () => {
+    it('.from, .fromArray', () => {
         const ruleInit = 'https://example.com';
         const rule1    = new RequestFilterRule(ruleInit);
         const rule2    = new RequestFilterRule(ruleInit);
@@ -228,10 +228,10 @@ describe('RequestFilterRule', () => {
             }
         };
 
-        expect(RequestFilterRule.from()).eql([]);
-        expect(RequestFilterRule.from(rule1)).eql([rule1]);
+        expect(RequestFilterRule.fromArray()).eql([]);
+        expect(RequestFilterRule.fromArray(rule1)).eql([rule1]);
 
-        const rules = RequestFilterRule.from([rule1, rule2, rule3, ruleInit, ruleLikeObject]);
+        const rules = RequestFilterRule.fromArray([rule1, rule2, rule3, ruleInit, ruleLikeObject]);
 
         expect(rules.length).eql(5);
 
@@ -241,6 +241,13 @@ describe('RequestFilterRule', () => {
 
         expect(rules[2].id).eql(rule3.id);
         expect(rules[1].id).eql(rule2.id);
+
+        expect(RequestFilterRule.from()).eql(null);
+
+        const rule = RequestFilterRule.from(rule3);
+
+        expect(rule.id).eql('1');
+        expect(rule).be.instanceOf(RequestFilterRule);
     });
 });
 

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -83,6 +83,9 @@ declare module 'testcafe-hammerhead' {
 
         /** Set RequestMock for the specified RequestFilterRule **/
         setMock (requestFilterRule: RequestFilterRule, mock: ResponseMock): Promise<void>;
+
+        /** Set ConfigureResponseEvent options which are applied during the request pipeline execution**/
+        setConfigureResponseEventOptions (rule: RequestFilterRule, opts: ConfigureResponseEventOptions): Promise<void>;
     }
 
     /** The Proxy class is used to create a web-proxy **/
@@ -120,8 +123,11 @@ declare module 'testcafe-hammerhead' {
         /** Check whether the specified RequestFilterRule instance accepts any request **/
         static isANY (instance: any): boolean;
 
+        /** Creates a RequestFilterRule instance from the RequestFilterRule initializer **/
+        static from (rule?: RequestFilterRuleInit): RequestFilterRule;
+
         /** Creates RequestFilterRule instances from RequestFilterRule initializers **/
-        static from (rules?: RequestFilterRuleInit | RequestFilterRuleInit[]): RequestFilterRule[];
+        static fromArray (rules?: RequestFilterRuleInit | RequestFilterRuleInit[]): RequestFilterRule[];
 
         /** Unique identifier of the RequestFilterRule instance **/
         id: string;
@@ -149,6 +155,9 @@ declare module 'testcafe-hammerhead' {
     export class ConfigureResponseEvent {
         /** The options to configure ResponseEvent **/
         opts: ConfigureResponseEventOptions;
+
+        /** RequestFilterRule associated with event **/
+        _requestFilterRule: RequestFilterRule;
     }
 
     /** The RequestInfo class contains information about query request **/


### PR DESCRIPTION
Changes:
* split  the `RequestFilterRule.from` method to `RequestFilterRule.from`, `RequestFilterRule.fromArray` methods
* `allow using the specified `ConfigureResponseEventOptions` (`session.setConfigureResponseEventOptions` method)