### PR TITLE
fix: ready to init event in iframe with srcdoc

### DIFF
--- a/src/client/sandbox/iframe.ts
+++ b/src/client/sandbox/iframe.ts
@@ -3,7 +3,13 @@ import SandboxBase from './base';
 import settings from '../settings';
 import nativeMethods from '../sandbox/native-methods';
 import DomProcessor from '../../processing/dom';
-import { isShadowUIElement, isIframeWithoutSrc, isIframeElement, isFrameElement } from '../utils/dom';
+import {
+    isShadowUIElement,
+    isIframeWithoutSrc,
+    isIframeElement,
+    isFrameElement,
+    isIframeWithSrcdoc,
+} from '../utils/dom';
 import { isFirefox, isWebKit, isIE } from '../utils/browser';
 import NodeMutation from './node/mutation';
 import CookieSandbox from './cookie';
@@ -151,6 +157,10 @@ export default class IframeSandbox extends SandboxBase {
 
     processIframe (el: HTMLIFrameElement | HTMLFrameElement): void {
         if (isShadowUIElement(el))
+            return;
+
+        // NOTE: the ready to init event will be raised by the self removing script
+        if (isIframeWithSrcdoc(el))
             return;
 
         if (isIframeElement(el) && nativeMethods.contentWindowGetter.call(el) ||

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -145,6 +145,29 @@ if (nativeMethods.iframeSrcdocGetter) {
         strictEqual(iframe.getAttribute('srcdoc'), html);
         strictEqual(nativeMethods.getAttribute.call(iframe, 'srcdoc'), htmlUtils.processHtml(html, { isPage: true }).replace(/(sessionId)/, '$1!i'));
     });
+
+    asyncTest('ready to init event should be raised after the document was initialized', function () {
+        var iframeLoadingEventRaised = false;
+
+        var handler = function (iframe) {
+            iframeLoadingEventRaised = true;
+
+            strictEqual(iframe.contentDocument.location.href, 'about:srcdoc');
+        };
+
+        iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, handler);
+
+        var $iframe = $('<iframe srcdoc="<h1>simple markup</h1>">').appendTo('body');
+
+        $iframe[0].addEventListener('load', function () {
+            ok(iframeLoadingEventRaised);
+
+            iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, handler);
+            $iframe.remove();
+
+            start();
+        });
+    });
 }
 
 test('should not call the contentWindow getter while cloning iframe/frame from XMLDocument (GH-2554)', function () {

--- a/test/client/fixtures/sandbox/iframe-test.js
+++ b/test/client/fixtures/sandbox/iframe-test.js
@@ -146,7 +146,7 @@ if (nativeMethods.iframeSrcdocGetter) {
         strictEqual(nativeMethods.getAttribute.call(iframe, 'srcdoc'), htmlUtils.processHtml(html, { isPage: true }).replace(/(sessionId)/, '$1!i'));
     });
 
-    asyncTest('ready to init event should be raised after the document was initialized', function () {
+    test('ready to init event should be raised after the document was initialized', function () {
         var iframeLoadingEventRaised = false;
 
         var handler = function (iframe) {
@@ -157,16 +157,25 @@ if (nativeMethods.iframeSrcdocGetter) {
 
         iframeSandbox.on(iframeSandbox.RUN_TASK_SCRIPT_EVENT, handler);
 
-        var $iframe = $('<iframe srcdoc="<h1>simple markup</h1>">').appendTo('body');
+        var iframe = document.createElement('iframe');
 
-        $iframe[0].addEventListener('load', function () {
-            ok(iframeLoadingEventRaised);
+        iframe.setAttribute('srcdoc', '<h1>simple markup</h1>');
+        iframe.id = 'test' + Date.now();
 
-            iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, handler);
-            $iframe.remove();
+        document.body.appendChild(iframe);
 
-            start();
-        });
+        return window.QUnitGlobals.wait(function () {
+            return true;
+        })
+            .then(function () {
+                return window.QUnitGlobals.waitForIframe(iframe);
+            })
+            .then(function () {
+                ok(iframeLoadingEventRaised);
+
+                iframeSandbox.off(iframeSandbox.RUN_TASK_SCRIPT_EVENT, handler);
+                document.body.removeChild(iframe);
+            });
     });
 }
 


### PR DESCRIPTION
## Purpose
The ready to init event raised too early in the iframes with the srcdoc attribute. Because of that, TestCafe scripts can't properly initiate themselves. ([init](https://github.com/DevExpress/testcafe/blob/faec4a93682d51a6f51909514b437236899b08c1/src/client/core/page-unload-barrier.js#L82) method of the pageUnloadBarrier gets the 'unload' event of the 'about:blank' document and can't properly work further).

## Approach
Don't raise the ready to init event after processing an iframe. Instead, this event will be raised later by self removing script of the iframe with the srcdoc attribute.

## References
Functional test in testcafe - https://github.com/DevExpress/testcafe/pull/6142

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
