### PR TITLE
should not open new window if link has the `download` attribute (closes #6132)

### DIFF
--- a/src/client/sandbox/child-window/index.ts
+++ b/src/client/sandbox/child-window/index.ts
@@ -28,9 +28,10 @@ export default class ChildWindowSandbox extends SandboxBase {
     }
 
     private static _shouldOpenInNewWindowOnElementAction (el: HTMLLinkElement | HTMLAreaElement | HTMLFormElement, defaultTarget: string): boolean {
-        const target = this._calculateTargetForElement(el);
+        const target               = this._calculateTargetForElement(el);
+        const hasDownloadAttribute = nativeMethods.getAttribute.call(el, 'download');
 
-        return this._shouldOpenInNewWindow(target, defaultTarget);
+        return hasDownloadAttribute ? false : this._shouldOpenInNewWindow(target, defaultTarget);
     }
 
     private static _shouldOpenInNewWindow (target: string, defaultTarget: string): boolean {

--- a/src/client/sandbox/child-window/index.ts
+++ b/src/client/sandbox/child-window/index.ts
@@ -28,10 +28,14 @@ export default class ChildWindowSandbox extends SandboxBase {
     }
 
     private static _shouldOpenInNewWindowOnElementAction (el: HTMLLinkElement | HTMLAreaElement | HTMLFormElement, defaultTarget: string): boolean {
-        const target               = this._calculateTargetForElement(el);
         const hasDownloadAttribute = nativeMethods.getAttribute.call(el, 'download');
 
-        return hasDownloadAttribute ? false : this._shouldOpenInNewWindow(target, defaultTarget);
+        if (hasDownloadAttribute)
+            return false;
+
+        const target = this._calculateTargetForElement(el);
+
+        return this._shouldOpenInNewWindow(target, defaultTarget);
     }
 
     private static _shouldOpenInNewWindow (target: string, defaultTarget: string): boolean {

--- a/test/client/fixtures/sandbox/child-window-test.js
+++ b/test/client/fixtures/sandbox/child-window-test.js
@@ -20,6 +20,15 @@ test('_shouldOpenInNewWindow', function () {
     window.name = '';
 });
 
+test('should not open new window if link has the `download` attribute', function () {
+    var link = document.createElement('a');
+
+    link.setAttribute('download', 'download');
+    link.setAttribute('target', '_blank');
+
+    notOk(ChildWindowSandbox._shouldOpenInNewWindowOnElementAction(link, defaultTarget.linkOrArea));
+});
+
 test('window.open', function () {
     settings.get().allowMultipleWindows = true;
 


### PR DESCRIPTION
The click on a link with the `download` attribute, should not lead to new window opening (even when link has the target=blank attribute)