### PR TITLE
feat: added the strictNullChecks rule to tsconfig

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -15,11 +15,12 @@ export const MESSAGE = {
     invalidHeaderCharacter:           'Character with code "{charCode}" in header "{name}" {location} at index {index}'
 };
 
-export function getText (template: string, parameters: Dictionary<string>): string {
+export function getText (template: string, parameters: Partial<Dictionary<string>>): string {
     let errorStr = template;
 
     for (const [parameterName, parameterValue] of Object.entries(parameters))
-        errorStr = errorStr.replace(new RegExp(`{${parameterName}}`, 'g'), parameterValue);
+        if (parameterValue)
+            errorStr = errorStr.replace(new RegExp(`{${parameterName}}`, 'g'), parameterValue);
 
     return errorStr;
 }

--- a/src/processing/dom/base-dom-adapter.ts
+++ b/src/processing/dom/base-dom-adapter.ts
@@ -17,7 +17,7 @@ export default abstract class BaseDomAdapter {
     ];
 
     abstract removeAttr (el: HTMLElement | ASTNode, attr: string): void;
-    abstract getAttr (el: HTMLElement | ASTNode, attr: string): string;
+    abstract getAttr (el: HTMLElement | ASTNode, attr: string): string | null;
     abstract hasAttr (el: HTMLElement | ASTNode, attr: string): boolean;
     abstract isSVGElement (el: HTMLElement | ASTNode): boolean;
     abstract hasEventHandler (el: HTMLElement | ASTNode): boolean;

--- a/src/processing/dom/parse5-dom-adapter.ts
+++ b/src/processing/dom/parse5-dom-adapter.ts
@@ -21,7 +21,7 @@ export default class Parse5DomAdapter extends BaseDomAdapter {
         parse5Utils.removeAttr(el, attr);
     }
 
-    getAttr (el: ASTNode, attr: string): string {
+    getAttr (el: ASTNode, attr: string): string | null {
         return parse5Utils.getAttr(el, attr);
     }
 
@@ -59,11 +59,11 @@ export default class Parse5DomAdapter extends BaseDomAdapter {
     }
 
     getScriptContent (script: ASTNode): string {
-        return script.childNodes.length ? script.childNodes[0].value : '';
+        return script.childNodes?.[0]?.value || '';
     }
 
     getStyleContent (style: ASTNode): string {
-        return style.childNodes.length ? style.childNodes[0].value : '';
+        return style.childNodes?.[0]?.value || '';
     }
 
     setStyleContent (style: ASTNode, content: string): void {

--- a/src/processing/encoding/brotli.ts
+++ b/src/processing/encoding/brotli.ts
@@ -9,17 +9,15 @@ import { promisify } from 'util';
 
 const hasBuiltInBrotliSupport = 'brotliCompress' in zlib;
 
-// @ts-ignore
 const builtInBrotliCompress = hasBuiltInBrotliSupport ? promisify(zlib.brotliCompress) : null;
-// @ts-ignore
 const builtInBrotliDecompress = hasBuiltInBrotliSupport ? promisify(zlib.brotliDecompress): null;
 
 export function brotliCompress(data: zlib.InputType): Promise<Buffer> | Buffer {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return hasBuiltInBrotliSupport ? builtInBrotliCompress(data): Buffer.from(require('brotli').compress(data));
+    return builtInBrotliCompress ? builtInBrotliCompress(data): Buffer.from(require('brotli').compress(data));
 }
 
 export function brotliDecompress(data: zlib.InputType): Promise<Buffer> | Buffer {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return hasBuiltInBrotliSupport ? builtInBrotliDecompress(data): Buffer.from(require('brotli').decompress(data));
+    return builtInBrotliDecompress ? builtInBrotliDecompress(data): Buffer.from(require('brotli').decompress(data));
 }

--- a/src/processing/encoding/charset.ts
+++ b/src/processing/encoding/charset.ts
@@ -76,6 +76,9 @@ export default class Charset {
             const charsetMatch = contentTypeHeader && contentTypeHeader.match(CHARSET_RE);
             const charset      = charsetMatch && charsetMatch[1];
 
+            if (!charset)
+                return false;
+
             return this.set(getEncodingName(charset), CharsetPriority.CONTENT_TYPE);
         }
 
@@ -94,11 +97,11 @@ export default class Charset {
     // Each <meta> descriptor should contain values of the "http-equiv", "content" and "charset" attributes.
     fromMeta (metas) {
         if (this.priority < CharsetPriority.META && metas.length) {
-            let needPragma = null;
-            let charsetStr = null;
+            let needPragma = true;
+            let charsetStr = '';
 
             metas.forEach(attrs => {
-                const shouldParseFromContentAttr = needPragma !== false && attrs.content && attrs.httpEquiv &&
+                const shouldParseFromContentAttr = needPragma && attrs.content && attrs.httpEquiv &&
                                                    attrs.httpEquiv.toLowerCase() === BUILTIN_HEADERS.contentType;
 
                 if (shouldParseFromContentAttr) {

--- a/src/processing/resources/page.ts
+++ b/src/processing/resources/page.ts
@@ -14,9 +14,9 @@ import BaseDomAdapter from '../dom/base-dom-adapter';
 import SERVICE_ROUTES from '../../proxy/service-routes';
 import { stringify as stringifyJSON } from '../../utils/json';
 
-const PARSED_BODY_CREATED_EVENT_SCRIPT                = parse5.parseFragment(SELF_REMOVING_SCRIPTS.onBodyCreated).childNodes[0];
-const PARSED_ORIGIN_FIRST_TITLE_ELEMENT_LOADED_SCRIPT = parse5.parseFragment(SELF_REMOVING_SCRIPTS.onOriginFirstTitleLoaded).childNodes[0];
-const PARSED_INIT_SCRIPT_FOR_IFRAME_TEMPLATE          = parse5.parseFragment(SELF_REMOVING_SCRIPTS.iframeInit).childNodes[0];
+const PARSED_BODY_CREATED_EVENT_SCRIPT                = parse5.parseFragment(SELF_REMOVING_SCRIPTS.onBodyCreated).childNodes![0];
+const PARSED_ORIGIN_FIRST_TITLE_ELEMENT_LOADED_SCRIPT = parse5.parseFragment(SELF_REMOVING_SCRIPTS.onOriginFirstTitleLoaded).childNodes![0];
+const PARSED_INIT_SCRIPT_FOR_IFRAME_TEMPLATE          = parse5.parseFragment(SELF_REMOVING_SCRIPTS.iframeInit).childNodes![0];
 
 interface PageProcessingOptions {
     crossDomainProxyPort: number;
@@ -25,6 +25,12 @@ interface PageProcessingOptions {
     scripts:              string[];
     urlReplacer:          Function;
     isIframeWithImageSrc: boolean;
+}
+
+interface MetaInfo {
+    httpEquiv: string | null;
+    content:   string | null;
+    charset:   string | null;
 }
 
 class PageProcessor extends ResourceProcessorBase {
@@ -41,7 +47,7 @@ class PageProcessor extends ResourceProcessorBase {
             storageKey, stringifyJSON(storages.localStorage),
             storageKey, stringifyJSON(storages.sessionStorage)));
 
-        return parsedDocumentFragment.childNodes[0];
+        return parsedDocumentFragment.childNodes![0];
     }
 
     private static _getPageProcessingOptions (ctx: RequestPipelineContext, urlReplacer: Function): PageProcessingOptions {
@@ -56,7 +62,7 @@ class PageProcessor extends ResourceProcessorBase {
     }
 
     private static _getPageMetas (metaEls, domAdapter: BaseDomAdapter) {
-        const metas = [];
+        const metas = [] as MetaInfo[];
 
         for (let i = 0; i < metaEls.length; i++) {
             metas.push({

--- a/src/processing/script/destructuring.ts
+++ b/src/processing/script/destructuring.ts
@@ -123,7 +123,7 @@ function processArrayPattern (pattern: ArrayPattern, value: Expression, build: N
         else
             value = createMemberExpression(tempIdentifier, createSimpleLiteral(i), true);
 
-        process(elem, value, build, TempVariables.generateName(baseTempName, null, i));
+        process(elem, value, build, TempVariables.generateName(baseTempName, void 0, i));
     }
 }
 

--- a/src/processing/script/index.ts
+++ b/src/processing/script/index.ts
@@ -134,7 +134,7 @@ function isStrictMode (ast: Program): boolean {
 
 function applyChanges (script: string, changes: CodeChange[], isObject: boolean): string {
     const indexOffset = isObject ? -1 : 0;
-    const chunks      = [];
+    const chunks      = [] as string[];
     let index         = 0;
 
     if (!changes.length)

--- a/src/processing/script/node-builder.ts
+++ b/src/processing/script/node-builder.ts
@@ -66,7 +66,9 @@ export function createBinaryExpression (left: Expression, operator: BinaryOperat
     return { type: Syntax.BinaryExpression, left, right, operator };
 }
 
-export function createSequenceExpression (expressions: Expression[]): SequenceExpression {
+export function createSequenceExpression (expressions: (Expression | Pattern)[]): SequenceExpression {
+    //@ts-ignore SequenceExpression can actually
+    // TODO: To write to https://github.com/estree/estree that SequenceExpression must include Pattern
     return { type: Syntax.SequenceExpression, expressions };
 }
 

--- a/src/processing/script/node-builder.ts
+++ b/src/processing/script/node-builder.ts
@@ -78,7 +78,7 @@ function createLogicalExpression (left: Expression, operator: LogicalOperator, r
     return { type: Syntax.LogicalExpression, left, right, operator }
 }
 
-export function createReturnStatement (argument: Expression = null): ReturnStatement {
+export function createReturnStatement (argument: Expression | null = null): ReturnStatement {
     return { type: Syntax.ReturnStatement, argument };
 }
 
@@ -110,7 +110,7 @@ export function createBlockStatement (body: Statement[]): BlockStatement {
     return { type: Syntax.BlockStatement, body };
 }
 
-export function createVariableDeclarator (id: Pattern, init: Expression = null): VariableDeclarator {
+export function createVariableDeclarator (id: Pattern, init: Expression | null = null): VariableDeclarator {
     return { type: Syntax.VariableDeclarator, id, init };
 }
 

--- a/src/processing/script/transform.ts
+++ b/src/processing/script/transform.ts
@@ -96,7 +96,7 @@ function addChangeForTransformedNode (state: State, changes: CodeChange[], repla
     if (hasTransformedAncestor)
         return;
 
-    if (state.newExpressionAncestor) {
+    if (state.newExpressionAncestor && state.newExpressionAncestorParent) {
         replaceNode(state.newExpressionAncestor, state.newExpressionAncestor, state.newExpressionAncestorParent!, state.newExpressionAncestorKey!);
         changes.push(getChange(state.newExpressionAncestor, state.newExpressionAncestorParent.type));
     }
@@ -165,7 +165,7 @@ function transform<T extends Node> (node: Node, changes: CodeChange[], state: St
     else {
         const storedNode = node;
         let transformer  = findTransformer(node, parent);
-        let replacement  = null;
+        let replacement  = null as Node | null;
 
         while (transformer) {
             replacement = transformer.run(replacement || node, parent, key, tempVars);
@@ -182,7 +182,7 @@ function transform<T extends Node> (node: Node, changes: CodeChange[], state: St
             node        = replacement;
         }
 
-        if (nodeTransformed) {
+        if (nodeTransformed && replacement) {
             replaceNode(storedNode, replacement, parent, key);
             addChangeForTransformedNode(state, changes, replacement, parent.type);
         }

--- a/src/processing/script/transformers/assignment-destructuring.ts
+++ b/src/processing/script/transformers/assignment-destructuring.ts
@@ -27,19 +27,21 @@ const transformer: Transformer<AssignmentExpression> = {
 
     run: (node, _parent, _key, tempVars) => {
         const assignments = [] as (AssignmentExpression | Identifier)[];
-        let firstTemp     = void 0;
+        let isFirstTemp   = true;
+        let firstTemp     = null as Identifier | null;
 
         destructuring(node.left, node.right, (pattern, value, isTemp) => {
-            if (firstTemp === void 0) {
+
+            if (isFirstTemp) {
+                isFirstTemp = false;
+
                 if (isTemp)
-                    firstTemp = pattern;
-                else
-                    firstTemp = null;
+                    firstTemp = pattern as Identifier;
             }
 
             assignments.push(createAssignmentExpression(pattern, '=', value));
 
-            if (isTemp)
+            if (isTemp && tempVars)
                 tempVars.append((pattern as Identifier).name);
         });
 

--- a/src/processing/script/transformers/declaration-destructuring.ts
+++ b/src/processing/script/transformers/declaration-destructuring.ts
@@ -28,7 +28,7 @@ const transformer: Transformer<VariableDeclaration> = {
     // @ts-ignore
     condition: (node, parent) => {
         // Skip: for (let { x } in some);
-        if (parent.type === Syntax.ForInStatement)
+        if (parent?.type === Syntax.ForInStatement)
             return false;
 
         for (const declarator of node.declarations) {
@@ -43,6 +43,9 @@ const transformer: Transformer<VariableDeclaration> = {
         const declarations = [] as VariableDeclarator[];
 
         for (const declarator of node.declarations) {
+            if (!declarator.init)
+                continue;
+
             destructuring(declarator.id, declarator.init, (pattern, value) =>
                 declarations.push(createVariableDeclarator(pattern, value)));
         }

--- a/src/processing/script/transformers/temp-variables.ts
+++ b/src/processing/script/transformers/temp-variables.ts
@@ -19,7 +19,7 @@ export default class TempVariables {
             if (key.type === Syntax.Identifier)
                 return baseName + '$' + key.name;
 
-            if (key.type === Syntax.Literal)
+            if (key.type === Syntax.Literal && key.value)
                 return baseName + '$' + key.value.toString().replace(/[^a-zA-Z0-9]/g, '');
         }
 

--- a/src/proxy/router.ts
+++ b/src/proxy/router.ts
@@ -57,7 +57,7 @@ export default abstract class Router {
     }
 
     _prepareParamInfo (tokens: string[], method: string) {
-        const paramNames = [];
+        const paramNames = [] as string[];
         const reParts    = tokens.map(token => {
             const paramMatch = token.match(PARAM_RE);
 
@@ -93,7 +93,7 @@ export default abstract class Router {
     }
 
     _route (req: http.IncomingMessage, res: http.ServerResponse | net.Socket, serverInfo: ServerInfo): boolean {
-        const routerQuery = `${req.method} ${getPathname(req.url)}`;
+        const routerQuery = `${req.method} ${getPathname(req.url || '')}`;
         const route       = this.routes.get(routerQuery);
 
         if (route) {

--- a/src/request-pipeline/cache.ts
+++ b/src/request-pipeline/cache.ts
@@ -12,7 +12,7 @@ const requestsCache = new LRUCache<string, ResponseCacheEntry>({
     length: responseCacheEntry => {
         // NOTE: Length is resource content size.
         // 1 character is 1 bite.
-        return responseCacheEntry.res.getBody().length;
+        return responseCacheEntry.res.getBody()?.length || 0;
     }
 });
 

--- a/src/request-pipeline/destination-request/http2.ts
+++ b/src/request-pipeline/destination-request/http2.ts
@@ -40,10 +40,10 @@ const sessionsCache      = new LRUCache<string, ClientHttp2Session>({
 
 export async function getHttp2Session (requestId: string, origin: string): Promise<ClientHttp2Session | null> {
     if (sessionsCache.has(origin))
-        return sessionsCache.get(origin);
+        return sessionsCache.get(origin) || null;
 
     if (pendingSessions.has(origin))
-        return pendingSessions.get(origin);
+        return pendingSessions.get(origin) || null;
 
     if (unsupportedOrigins.includes(origin))
         return null;

--- a/src/request-pipeline/destination-request/index.ts
+++ b/src/request-pipeline/destination-request/index.ts
@@ -39,7 +39,8 @@ export default class DestinationRequest extends EventEmitter implements Destinat
         super();
 
         this.protocolInterface = this.opts.isHttps ? https : http;
-        this.timeout           = this.opts.isAjax ? opts.requestTimeout.ajax : opts.requestTimeout.page;
+
+        this.timeout = this.opts.isAjax ? opts.requestTimeout.ajax : opts.requestTimeout.page;
 
         if (this.opts.isHttps)
             opts.ignoreSSLAuth();
@@ -195,7 +196,7 @@ export default class DestinationRequest extends EventEmitter implements Destinat
     }
 
     _isTunnelingErr (err): boolean {
-        return this.opts.isHttps && this.opts.proxy && err.message && TUNNELING_SOCKET_ERR_RE.test(err.message);
+        return this.opts.isHttps && err.message && TUNNELING_SOCKET_ERR_RE.test(err.message);
     }
 
     _isSocketHangUpErr (err): boolean {
@@ -225,7 +226,7 @@ export default class DestinationRequest extends EventEmitter implements Destinat
             this._send();
         }
 
-        else if (this._isTunnelingErr(err)) {
+        else if (this.opts.proxy && this._isTunnelingErr(err)) {
             if (TUNNELING_AUTHORIZE_ERR_RE.test(err.message))
                 this._fatalError(MESSAGE.cantAuthorizeToProxy, this.opts.proxy.host);
             else

--- a/src/request-pipeline/header-transforms/index.ts
+++ b/src/request-pipeline/header-transforms/index.ts
@@ -64,7 +64,7 @@ function calculateForcedHeadersCase (headers: OutgoingHttpHeaders, processedHead
     }
 }
 
-function transformOriginHeaders (headers: OutgoingHttpHeaders, processedHeaders: object, headersNames: string[], rawHeaders: string[]): void {
+function transformOriginHeaders (headers: OutgoingHttpHeaders, processedHeaders: object, headersNames: (string | undefined)[], rawHeaders: string[]): void {
     for (let i = 0; i < rawHeaders.length; i += 2) {
         const rawHeaderName           = rawHeaders[i];
         const lowerCasedRawHeaderName = rawHeaderName.toLowerCase();

--- a/src/request-pipeline/http-header-parser.ts
+++ b/src/request-pipeline/http-header-parser.ts
@@ -7,14 +7,14 @@ const HEADER_BODY_INVALID_CHARACTERS    = [ '\n', '\r' ];
 const HEADER_NAME_VALID_CHAR_CODE_RANGE = { min: 33, max: 126 };
 const HEADER_INVALID_CHAR_LOCATIONS     = { name: 'name', body: 'body' };
 
-interface InvalidCharactersRecord extends Dictionary<string> {
+interface InvalidCharactersRecord extends Partial<Dictionary<string>> {
     name:  string;
     body?: string;
     index: string;
 }
 
 export function getFormattedInvalidCharacters (rawHeaders: string): string {
-    let invalidCharList = [];
+    let invalidCharList = [] as InvalidCharactersRecord[];
 
     for (const header of rawHeaders.split(HEADER_LINE_SEPARATOR)) {
         const name = header.slice(0, header.indexOf(HEADER_BODY_SEPARATOR));
@@ -35,14 +35,14 @@ function headerBodyCharIsInvalid (char: string): boolean {
 }
 
 function getInvalidCharacters (name: string, body: string): InvalidCharactersRecord[] {
-    const invalidCharList = [];
+    const invalidCharList = [] as InvalidCharactersRecord[];
 
     for (let i = 0; i < name.length; i++) {
         if (headerNameCharIsInvalid(name[i])) {
             invalidCharList.push({
                 name:     name,
                 location: HEADER_INVALID_CHAR_LOCATIONS.name,
-                charCode: name[i].charCodeAt(0),
+                charCode: '' + name[i].charCodeAt(0),
                 index:    i.toString()
             });
         }
@@ -53,7 +53,7 @@ function getInvalidCharacters (name: string, body: string): InvalidCharactersRec
             invalidCharList.push({
                 name:     name,
                 location: HEADER_INVALID_CHAR_LOCATIONS.body,
-                charCode: body[i].charCodeAt(0),
+                charCode: '' + body[i].charCodeAt(0),
                 index:    i.toString()
             });
         }

--- a/src/request-pipeline/incoming-message-like.ts
+++ b/src/request-pipeline/incoming-message-like.ts
@@ -2,7 +2,7 @@ import { IncomingHttpHeaders, IncomingMessage } from 'http';
 import { Readable } from 'stream';
 
 export interface IncomingMessageLikeInitOptions {
-    headers: { [name: string]: string|string[] };
+    headers: IncomingHttpHeaders;
     trailers: { [key: string]: string | undefined };
     statusCode: number;
     body: object|string|Buffer|null;
@@ -11,7 +11,7 @@ export interface IncomingMessageLikeInitOptions {
 const DEFAULT_STATUS_CODE = 200;
 
 export default class IncomingMessageLike extends Readable {
-    private _body: Buffer;
+    private _body: Buffer | null;
     headers: IncomingHttpHeaders;
     trailers: { [key: string]: string | undefined };
     statusCode: number;
@@ -57,12 +57,12 @@ export default class IncomingMessageLike extends Readable {
         this._body = value;
     }
 
-    getBody (): Buffer {
+    getBody (): Buffer | null {
         return this._body;
     }
 
     static createFrom (res: IncomingMessage): IncomingMessageLike {
-        const { headers, trailers, statusCode } = res;
+        const { headers = {}, trailers, statusCode } = res;
 
         return new IncomingMessageLike({
             headers,

--- a/src/request-pipeline/request-hooks/request-filter-rule/index.ts
+++ b/src/request-pipeline/request-hooks/request-filter-rule/index.ts
@@ -11,7 +11,7 @@ import stringifyRule from './stringify';
 import { RequestFilterRuleObjectInitializer } from './rule-init';
 import isPredicate from '../is-predicate';
 
-const DEFAULT_OPTIONS: RequestFilterRuleObjectInitializer = {
+const DEFAULT_OPTIONS: Partial<RequestFilterRuleObjectInitializer> = {
     url:    void 0,
     method: void 0,
     isAjax: void 0

--- a/src/request-pipeline/request-hooks/response-mock/index.ts
+++ b/src/request-pipeline/request-hooks/response-mock/index.ts
@@ -11,7 +11,7 @@ export default class ResponseMock {
     public readonly body?: ResponseMockBodyInit;
     public readonly statusCode: number;
     public readonly headers: Record<string, string | string[]>;
-    public requestOptions: RequestOptions = null;
+    public requestOptions: RequestOptions;
     public readonly id: string;
     public isPredicate: boolean;
 
@@ -20,16 +20,20 @@ export default class ResponseMock {
 
         this.id          = generateUniqueId();
         this.body        = body;
-        this.statusCode  = statusCode;
-        this.headers     = lowerCaseHeaderNames(headers);
         this.isPredicate = isPredicate(body);
+
+        if (headers)
+            this.headers = lowerCaseHeaderNames(headers);
+
+        if (statusCode)
+            this.statusCode = statusCode;
     }
 
     setRequestOptions (opts: RequestOptions): void {
         this.requestOptions = opts;
     }
 
-    public static from (val: object): ResponseMock {
+    public static from (val: object): ResponseMock | null {
         if (!val)
             return null;
 

--- a/src/request-pipeline/request-hooks/response-mock/lowercase-header-names.ts
+++ b/src/request-pipeline/request-hooks/response-mock/lowercase-header-names.ts
@@ -1,7 +1,6 @@
-export default function (headers?: Record<string, string | string[]>): Record<string, string | string[]> {
-    if (!headers)
-        return headers;
+import { IncomingHttpHeaders } from 'http';
 
+export default function (headers: IncomingHttpHeaders): Record<string, string | string[]> {
     const lowerCaseHeaders = {};
 
     Object.keys(headers).forEach(headerName => {

--- a/src/request-pipeline/request-options.ts
+++ b/src/request-pipeline/request-options.ts
@@ -49,7 +49,7 @@ export default class RequestOptions {
         this.port           = ctx.dest.port;
         this.path           = ctx.dest.partAfterHost;
         this.auth           = ctx.dest.auth;
-        this.method         = ctx.req.method;
+        this.method         = ctx.req.method || '';
         this.credentials    = ctx.session.getAuthCredentials();
         this.body           = ctx.reqBody;
         this.isAjax         = ctx.isAjax;

--- a/src/session/events/info.ts
+++ b/src/session/events/info.ts
@@ -28,7 +28,7 @@ export class ResponseInfo {
     readonly requestId: string;
     readonly statusCode: number;
     readonly sessionId: string;
-    readonly headers: { [name: string]: string|string[] };
+    readonly headers: OutgoingHttpHeaders;
     readonly body: Buffer;
     readonly isSameOriginPolicyFailed: boolean;
 
@@ -36,8 +36,10 @@ export class ResponseInfo {
         this.requestId  = ctx.requestId;
         this.headers    = ctx.destRes.headers;
         this.body       = ctx.nonProcessedDestResBody;
-        this.statusCode = ctx.destRes.statusCode;
         this.sessionId  = ctx.session.id;
+
+        if (ctx.destRes.statusCode)
+            this.statusCode = ctx.destRes.statusCode;
 
         this.isSameOriginPolicyFailed = ctx.isSameOriginPolicyFailed;
     }
@@ -47,7 +49,7 @@ export class PreparedResponseInfo {
     readonly requestId: string;
     readonly statusCode: number;
     readonly sessionId: string;
-    readonly headers?: { [name: string]: string|string[] };
+    readonly headers?: OutgoingHttpHeaders;
     readonly body?: Buffer;
     readonly isSameOriginPolicyFailed: boolean;
 

--- a/src/session/events/response-event.ts
+++ b/src/session/events/response-event.ts
@@ -1,13 +1,14 @@
 import RequestFilterRule from '../../request-pipeline/request-hooks/request-filter-rule';
 import { PreparedResponseInfo } from './info';
 import generateUniqueId from '../../utils/generate-unique-id';
+import { OutgoingHttpHeaders } from 'http';
 
 export default class ResponseEvent {
     public requestFilterRule: RequestFilterRule;
     public readonly requestId: string;
     public readonly statusCode: number;
     public readonly sessionId: string;
-    public readonly headers?: { [name: string]: string|string[] };
+    public readonly headers?: OutgoingHttpHeaders;
     public readonly body?: Buffer;
     public readonly isSameOriginPolicyFailed: boolean;
     public readonly id: string;

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -75,7 +75,7 @@ interface TaskScriptTemplateOpts {
     isFirstPageLoad: boolean;
     referer: string | null;
     cookie: string | null;
-    iframeTaskScriptTemplate: string;
+    iframeTaskScriptTemplate: string | null;
     payloadScript: string;
     allowMultipleWindows: boolean;
     isRecordMode: boolean;
@@ -237,12 +237,12 @@ export default abstract class Session extends EventEmitter {
 
         const { url, bypassRules } = proxySettings;
         const parsedUrl            = parseUrl('http://' + url);
-        let settings               = null;
+        let settings               = null as ExternalProxySettings | null;
 
         if (parsedUrl && parsedUrl.host) {
             settings = {
                 host:     parsedUrl.host,
-                hostname: parsedUrl.hostname
+                hostname: parsedUrl.hostname || ''
             };
 
             if (bypassRules)
@@ -266,7 +266,9 @@ export default abstract class Session extends EventEmitter {
 
         this.cookies.setJar(this.pendingStateSnapshot.cookies);
 
-        ctx.restoringStorages     = this.pendingStateSnapshot.storages;
+        if (this.pendingStateSnapshot.storages)
+            ctx.restoringStorages     = this.pendingStateSnapshot.storages;
+
         this.pendingStateSnapshot = null;
     }
 
@@ -304,7 +306,7 @@ export default abstract class Session extends EventEmitter {
             return void 0;
         }));
 
-        return matchedRules.filter(rule => !!rule);
+        return matchedRules.filter(rule => !!rule) as RequestFilterRule[];
     }
 
     async _patchOnConfigureResponseEvent (eventName: RequestEventNames, event: RequestEvent | ResponseEvent | ConfigureResponseEvent): Promise<void> {

--- a/src/typings/proxy.d.ts
+++ b/src/typings/proxy.d.ts
@@ -27,8 +27,8 @@ interface RouterOptions {
 }
 
 interface RequestTimeout {
-    page?: number;
-    ajax?: number;
+    page: number;
+    ajax: number;
 }
 
 interface ProxyOptions extends RouterOptions {

--- a/src/upload/form-data-entry.ts
+++ b/src/upload/form-data-entry.ts
@@ -23,8 +23,12 @@ export default class FormDataEntry {
     private _setHeader(name: string, value: string, rawHeader?: string) {
         if (!this._headers.has(name))
             this._headers.set(name, { rawName: typeof rawHeader === 'string' ? rawHeader : name, value });
-        else
-            this._headers.get(name).value = value;
+        else {
+            const header = this._headers.get(name);
+
+            if (header)
+                header.value = value;
+        }
     }
 
     private _setContentDisposition (name: string, fileName: string) {
@@ -46,7 +50,7 @@ export default class FormDataEntry {
     }
 
     setRawHeader (rawHeader: string) {
-        const [, rawName = '', value = ''] = rawHeader.match(HEADER_RE);
+        const [, rawName = '', value = ''] = rawHeader.match(HEADER_RE) || [];
         const name                         = rawName.toLowerCase();
 
         this._headers.set(name, { rawName, value });

--- a/src/upload/form-data.ts
+++ b/src/upload/form-data.ts
@@ -25,8 +25,8 @@ export default class FormData {
     }
 
     private _injectFileInfo (fileInfo: FileInputInfo): void {
-        const entries: FormDataEntry[]   = this._getEntriesByName(fileInfo.name);
-        let previousEntry: FormDataEntry = null;
+        const entries     = this._getEntriesByName(fileInfo.name);
+        let previousEntry = null as FormDataEntry | null;
 
         for (let idx = 0; idx < fileInfo.files.length; idx++) {
             let entry = entries[idx];
@@ -86,9 +86,9 @@ export default class FormData {
     }
 
     parseBody (body: Buffer): void {
-        let state                       = ParserState.inPreamble;
-        const lines                     = bufferUtils.createLineIterator(body);
-        let currentEntry: FormDataEntry = null;
+        let state        = ParserState.inPreamble;
+        const lines      = bufferUtils.createLineIterator(body);
+        let currentEntry = null as FormDataEntry | null;
 
         for (const line of lines) {
             if (this._isBoundary(line)) {
@@ -111,7 +111,7 @@ export default class FormData {
 
             else if (state === ParserState.inHeaders) {
                 if (line.length)
-                    currentEntry.setRawHeader(line.toString());
+                    currentEntry?.setRawHeader(line.toString());
                 else
                     state = ParserState.inBody;
             }
@@ -119,7 +119,7 @@ export default class FormData {
             else if (state === ParserState.inEpilogue)
                 bufferUtils.appendLine(this._epilogue, line);
 
-            else if (state === ParserState.inBody)
+            else if (state === ParserState.inBody && currentEntry)
                 bufferUtils.appendLine(currentEntry.body, line);
         }
     }

--- a/src/upload/storage.ts
+++ b/src/upload/storage.ts
@@ -20,6 +20,20 @@ interface ResolvePathError {
     resolvedPaths: string[];
 }
 
+interface ResolvePathResult extends Partial<ResolvePathError> {
+    data?: string;
+    info?: {
+        [key: string]: unknown
+    };
+    resolvedPath?: string;
+}
+
+interface StoredFiles {
+    err?: string;
+    path: string;
+    file: string;
+}
+
 export default class UploadStorage {
     uploadRoots: string[];
 
@@ -67,7 +81,7 @@ export default class UploadStorage {
     }
 
     async store (fileNames: string[], data: string[]) {
-        const storedFiles    = [];
+        const storedFiles    = [] as StoredFiles[];
         const mainUploadRoot = this.uploadRoots[0];
         const err            = await UploadStorage.ensureUploadsRoot(mainUploadRoot);
 
@@ -94,13 +108,13 @@ export default class UploadStorage {
         return storedFiles;
     }
 
-    async _resolvePath (filePath: string, result: ResolvePathError[]): Promise<string | null> {
-        let resolvedPath = null;
+    async _resolvePath (filePath: string, result: Partial<ResolvePathError>[]): Promise<string | null> {
+        let resolvedPath = null as string | null;
 
         if (path.isAbsolute(filePath))
             resolvedPath = filePath;
         else {
-            const nonExistingPaths = [];
+            const nonExistingPaths = [] as string[];
 
             for (const uploadRoot of this.uploadRoots) {
                 resolvedPath = path.resolve(uploadRoot, filePath);
@@ -124,10 +138,10 @@ export default class UploadStorage {
     }
 
     async get (filePathList: string[]) {
-        const result = [];
+        const result = [] as ResolvePathResult[];
 
         for (const filePath of filePathList) {
-            const resolvedPath: string | null = await this._resolvePath(filePath, result);
+            const resolvedPath = await this._resolvePath(filePath, result) as string | null;
 
             if (resolvedPath === null)
                 continue;

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -27,8 +27,8 @@ function isSameCookies (cookie1: CookieRecord, cookie2: CookieRecord): boolean {
 }
 
 function sortByOutdatedAndActual (parsedCookies: CookieRecord[]): ParsedClientSyncCookie {
-    const outdated = [];
-    const actual   = [];
+    const outdated = [] as CookieRecord[];
+    const actual   = [] as CookieRecord[];
 
     for (let current = 0; current < parsedCookies.length; current++) {
         let other = current + 1;
@@ -73,7 +73,7 @@ function formatSyncCookieKey (cookie: CookieRecord): string {
 
 export function parseClientSyncCookieStr (cookieStr: string): ParsedClientSyncCookie {
     const cookies       = cookieStr ? cookieStr.split(';') : '';
-    const parsedCookies = [];
+    const parsedCookies = [] as CookieRecord[];
 
     for (const cookie of cookies) {
         const parsedCookie = parseSyncCookie(trim(cookie));
@@ -97,9 +97,9 @@ export function formatSyncCookie (cookie: CookieRecord): string {
     return `${formatSyncCookieKey(cookie)}=${cookie.value};path=/`;
 }
 
-export function parseSyncCookie (cookieStr: string): CookieRecord {
-    const [, key, value] = KEY_VALUE_REGEX.exec(cookieStr);
-    const parsedKey: any = key !== void 0 && value !== void 0 && key.split('|');
+export function parseSyncCookie (cookieStr: string): CookieRecord | null {
+    const [, key, value] = KEY_VALUE_REGEX.exec(cookieStr) || [];
+    const parsedKey      = key !== void 0 && value !== void 0 && key.split('|') as any;
 
     if (parsedKey && parsedKey.length !== CLIENT_COOKIE_SYNC_KEY_FRAGMENT_COUNT)
         return null;
@@ -133,8 +133,8 @@ export function changeSyncType (parsedCookie: CookieRecord, flags): void {
 
     const newSyncTypeStr = stringifySyncType(parsedCookie);
 
-    parsedCookie.syncKey   = parsedCookie.syncKey.replace(SYNCHRONIZATION_TYPE_RE, newSyncTypeStr);
-    parsedCookie.cookieStr = parsedCookie.cookieStr.replace(SYNCHRONIZATION_TYPE_RE, newSyncTypeStr);
+    parsedCookie.syncKey   = parsedCookie.syncKey?.replace(SYNCHRONIZATION_TYPE_RE, newSyncTypeStr);
+    parsedCookie.cookieStr = parsedCookie.cookieStr?.replace(SYNCHRONIZATION_TYPE_RE, newSyncTypeStr);
 }
 
 export function isOutdatedSyncCookie (currentCookie: CookieRecord, newCookie: CookieRecord): boolean {

--- a/src/utils/parse5.ts
+++ b/src/utils/parse5.ts
@@ -43,19 +43,19 @@ export function createElement (tagName: string, attrs: ASTAttribute[]): ASTNode 
         nodeName:   tagName,
         tagName:    tagName,
         attrs:      attrs,
-        childNodes: []
+        childNodes: [] as ASTNode[],
     } as ASTNode;
 }
 
 export function unshiftElement (el: ASTNode, parent: ASTNode): void {
     el.namespaceURI = parent.namespaceURI;
     el.parentNode   = parent;
-    parent.childNodes.unshift(el);
+    parent.childNodes?.unshift(el);
 }
 
 export function insertBeforeFirstScript (el: ASTNode, parent: ASTNode): void {
     const firstScriptIndex = findNodeIndex(parent, node => node.tagName === 'script');
-    const insertIndex      = firstScriptIndex !== -1 ? firstScriptIndex : parent.childNodes.length;
+    const insertIndex      = firstScriptIndex !== -1 ? firstScriptIndex : parent.childNodes?.length || 0;
 
     appendNode(el, parent, insertIndex);
 }
@@ -67,7 +67,10 @@ export function findNodeIndex (parent: ASTNode, predicate: (value: ASTNode, inde
 }
 
 export function findNextNonTextNode (parent: ASTNode, startIndex: number): ASTNode | null {
-    let currentNode = null;
+    if (!parent.childNodes)
+        return null;
+
+    let currentNode: ASTNode;
 
     while (currentNode = parent.childNodes[startIndex]){
         if (currentNode.nodeName !== '#text')
@@ -83,11 +86,15 @@ export function appendNode (node: ASTNode, parent: ASTNode, index: number): void
     node.namespaceURI = parent.namespaceURI;
     node.parentNode   = parent;
 
-    parent.childNodes.splice(index, 0, node);
+    parent.childNodes?.splice(index, 0, node);
 }
 
 export function removeNode (node: ASTNode): void {
     const parent  = node.parentNode;
+
+    if (!parent || !parent.childNodes)
+        return
+
     const elIndex = parent.childNodes.indexOf(node);
 
     parent.childNodes.splice(elIndex, 1);

--- a/src/utils/promisify-stream.ts
+++ b/src/utils/promisify-stream.ts
@@ -9,9 +9,10 @@ export default function (s: Readable, contentLength?: string): Promise<Buffer> {
         let currentLength  = 0;
         const chunks       = [] as Buffer[];
         const finalLength  = typeof contentLength === 'string' ? parseInt(contentLength) : null;
-        const http2session = finalLength === null && ('session' in s) && (s as ClientHttp2Stream).session || null;
-        let timeout        = null;
+        const http2session = finalLength === null && ('session' in s) &&
+                             (s as ClientHttp2Stream).session || null;
         let isResolved     = false;
+        let timeout: NodeJS.Timeout;
 
         s.on('data', (chunk: Buffer) => {
             chunks.push(chunk);

--- a/src/utils/stack-processing.ts
+++ b/src/utils/stack-processing.ts
@@ -55,7 +55,7 @@ export function getFirstDestUrl (stack: string | null | void): string | null {
             if (!stackFrameRegExp.test(stackFrame))
                 continue;
 
-            let destSource = null;
+            let destSource = null as string | null;
 
             stackFrame.replace(stackFrameRegExp, (str: string, source: string) => {
                 source     = source.replace(ROW_COLUMN_NUMBER_REG_EX, '');

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -243,7 +243,7 @@ export function parseProxyUrl (proxyUrl: string): ParsedProxyUrl | null {
     if (!isSpecialPage(destUrlWithoutHash) && !SUPPORTED_PROTOCOL_RE.test(destUrl))
         return null;
 
-    let destResourceInfo = null;
+    let destResourceInfo : ParsedUrl;
 
     if (isSpecialPage(destUrlWithoutHash))
         destResourceInfo = SPECIAL_PAGE_DEST_RESOURCE_INFO;
@@ -259,8 +259,8 @@ export function parseProxyUrl (proxyUrl: string): ParsedProxyUrl | null {
         partAfterHost: parsedUrl.partAfterHost,
 
         proxy: {
-            hostname: parsedUrl.hostname,
-            port:     parsedUrl.port
+            hostname: parsedUrl.hostname || '',
+            port:     parsedUrl.port || ''
         },
 
         sessionId:    parsedDesc.sessionId,
@@ -361,7 +361,7 @@ export function resolveUrlAsDest (url: string, getProxyUrlMeth: Function): strin
 export function formatUrl (parsedUrl: ParsedUrl): string {
     // NOTE: the URL is relative.
     if (parsedUrl.protocol !== 'file:' && !parsedUrl.host && (!parsedUrl.hostname || !parsedUrl.port))
-        return parsedUrl.partAfterHost;
+        return parsedUrl.partAfterHost || '';
 
     let url = parsedUrl.protocol || '';
 
@@ -451,7 +451,7 @@ export function ensureOriginTrailingSlash (url: string): string {
     // then browser adds the trailing slash itself.
     const parsedUrl = parseUrl(url);
 
-    if (!parsedUrl.partAfterHost && HTTP_RE.test(parsedUrl.protocol))
+    if (!parsedUrl.partAfterHost && parsedUrl.protocol && HTTP_RE.test(parsedUrl.protocol))
         return url + '/';
 
     return url;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "noImplicitReturns": true,
     "strictFunctionTypes": true,
     "noImplicitThis": true,
-    "outDir": "lib"
+    "outDir": "lib",
+    "strictNullChecks": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
## Purpose
Synchronize typescript options with testcafe for monorepo migration.

## Approach
Added the strictNullChecks rule to tsconfig, fixed errors.

## References
Part of https://github.com/DevExpress/testcafe/issues/5666

## Pre-Merge TODO
- [x] Make sure that existing tests do not fail