### PR TITLE
fix for-of destructuring duplicate declarator issue with Object.ArrayPattern

### DIFF
--- a/src/processing/script/transformers/for-of.ts
+++ b/src/processing/script/transformers/for-of.ts
@@ -25,7 +25,7 @@ import {
 import replaceNode from './replace-node';
 import TempVariables from './temp-variables';
 
-function walkDeclarators (node: BlockStatement, action: Function): void {
+function walkDeclarators (node: BlockStatement, action: (identifier: Identifier) => void): void {
     const declarators = [];
     const identifiers = [];
 
@@ -58,14 +58,14 @@ function replaceDuplicateDeclarators (forOfNode: ForOfStatement) {
     const forOfLeft      = forOfNode.left as VariableDeclaration;
     const nodesToReplace = [];
 
-    const isArrayPatternDeclaration = forOfLeft.declarations.length && forOfLeft.declarations[0].id.type === Syntax.ArrayPattern;
+    const isArrayPatternDeclaration = forOfLeft.declarations[0]?.id.type === Syntax.ArrayPattern;
     const isBlockStatement          = forOfNode.body.type === Syntax.BlockStatement;
 
     if (!isArrayPatternDeclaration || !isBlockStatement)
         return;
 
     const leftDeclaration = forOfLeft.declarations[0].id as ArrayPattern;
-    const leftIdentifiers = leftDeclaration.elements as Array<Identifier>;
+    const leftIdentifiers = leftDeclaration.elements as Identifier[];
 
     walkDeclarators(forOfNode.body as BlockStatement, (node: Identifier) => {
         for (const identifier of leftIdentifiers)

--- a/src/processing/script/transformers/for-of.ts
+++ b/src/processing/script/transformers/for-of.ts
@@ -44,7 +44,7 @@ function findDeclarator (node: BlockStatement, predicate: Function): Node {
 
             if (declarator.id.type === Syntax.ObjectPattern)
                 for (const prop of declarator.id.properties)
-                    identifiers.push(prop.key);
+                    identifiers.push(prop.value);
         }
     }
 

--- a/src/processing/script/transformers/for-of.ts
+++ b/src/processing/script/transformers/for-of.ts
@@ -63,6 +63,9 @@ function replaceDuplicateDeclarators (forOfNode: ForOfStatement) {
     if (!forOfLeft.declarations.length || forOfLeft.declarations[0].id.type !== Syntax.ArrayPattern)
         return;
 
+    if (forOfNode.body.type !== Syntax.BlockStatement)
+        return;
+
     const leftIdentifiers = Object.values(forOfLeft.declarations[0].id.elements || []) as Array<Identifier>;
 
     const duplicateDeclator = findDeclarator(forOfNode.body as BlockStatement, node => {

--- a/test/server/script-processor-test.js
+++ b/test/server/script-processor-test.js
@@ -1191,6 +1191,11 @@ describe('Script processor', () => {
 
                     expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0]; let _hh$temp2 = q, a =_hh$temp2.a; }'
                 },
+                {
+                    src: 'for (let [a] of q) { let { t: a } = q; }',
+
+                    expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0]; let _hh$temp2 = q, a = _hh$temp2.t; }'
+                },
                 // NOTE: we should replace only if body is `BlockStatement`
                 {
                     src: 'for (let [a] of q) if (true) { let a = 1; }',

--- a/test/server/script-processor-test.js
+++ b/test/server/script-processor-test.js
@@ -1191,6 +1191,12 @@ describe('Script processor', () => {
 
                     expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0]; let _hh$temp2 = q, a =_hh$temp2.a; }'
                 },
+                // NOTE: we should replace only if body is `BlockStatement`
+                {
+                    src: 'for (let [a] of q) if (true) { let a = 1; }',
+
+                    expected: 'for (let _hh$temp0 of q) { let a = _hh$temp0[0]; if (true) { let a = 1; }}'
+                },
                 // NOTE: it's ok that we do not replace the `a` variable inside the `console.log` method`
                 // since we expect to get the `Cannot access 'a' before initialization` error message
                 {

--- a/test/server/script-processor-test.js
+++ b/test/server/script-processor-test.js
@@ -1174,12 +1174,12 @@ describe('Script processor', () => {
                 {
                     src: 'for (let [a, b] of q) { let a = 1; let b = 2; }',
 
-                    expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0], b=_hh$temp0[1]; let a = 1; let b = 2;}'
+                    expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0], _hh$temp2=_hh$temp0[1]; let a = 1; let b = 2;}'
                 },
                 {
                     src: 'for (let [a, b] of q) { let a = 1, b = 2; }',
 
-                    expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0], b=_hh$temp0[1]; let a = 1, b = 2;}'
+                    expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0], _hh$temp2=_hh$temp0[1]; let a = 1, b = 2;}'
                 },
                 {
                     src: 'for (let [a] of q) { let [a] = q; }',
@@ -1190,6 +1190,11 @@ describe('Script processor', () => {
                     src: 'for (let [a] of q) { let { a } = q; }',
 
                     expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0]; let _hh$temp2 = q, a =_hh$temp2.a; }'
+                },
+                {
+                    src: 'for (let [a, b] of q) { let { a, b } = q; }',
+
+                    expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0], _hh$temp2 = _hh$temp0[1]; let _hh$temp3 = q, a = _hh$temp3.a, b=_hh$temp3.b; }'
                 },
                 {
                     src: 'for (let [a] of q) { let { t: a } = q; }',

--- a/test/server/script-processor-test.js
+++ b/test/server/script-processor-test.js
@@ -1154,6 +1154,64 @@ describe('Script processor', () => {
             ]);
         });
 
+        it('destructuring and duplicate declaration', () => {
+            testProcessing([
+                {
+                    src: 'for (let [a] of q) { let a = 1; }',
+
+                    expected: 'for (let_hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0]; let a = 1;}'
+                },
+                {
+                    src: 'for (let [a, b] of q) { let a = 1; }',
+
+                    expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0], b =_hh$temp0[1]; let a = 1;}'
+                },
+                {
+                    src: 'for (let [b, a] of q) { let a = 1; }',
+
+                    expected: 'for (let _hh$temp0 of q) { let b = _hh$temp0[0], _hh$temp1 = _hh$temp0[1]; let a = 1;}'
+                },
+                {
+                    src: 'for (let [a, b] of q) { let a = 1; let b = 2; }',
+
+                    expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0], b=_hh$temp0[1]; let a = 1; let b = 2;}'
+                },
+                {
+                    src: 'for (let [a, b] of q) { let a = 1, b = 2; }',
+
+                    expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0], b=_hh$temp0[1]; let a = 1, b = 2;}'
+                },
+                {
+                    src: 'for (let [a] of q) { let [a] = q; }',
+
+                    expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0]; let _hh$temp2 = q, a =_hh$temp2[0]; }'
+                },
+                {
+                    src: 'for (let [a] of q) { let { a } = q; }',
+
+                    expected: 'for (let _hh$temp0 of q) { let _hh$temp1 = _hh$temp0[0]; let _hh$temp2 = q, a =_hh$temp2.a; }'
+                },
+                // NOTE: it's ok that we do not replace the `a` variable inside the `console.log` method`
+                // since we expect to get the `Cannot access 'a' before initialization` error message
+                {
+                    src: 'for (let [b, a] of q) { console.log(a); let a = 1; }',
+
+                    expected: 'for (let _hh$temp0 of q) { let b = _hh$temp0[0], _hh$temp1 = _hh$temp0[1]; console.log(a); let a = 1;}'
+                },
+                // NOTE: we should not rename the `for-of left` var if it is redeclared in the deeper statement
+                {
+                    src: 'for (let [a] of q) { if (true) { let a = 1; } }',
+
+                    expected: 'for (let _hh$temp0 of q) { let a = _hh$temp0[0]; if (true) { let a = 1; }}'
+                },
+                {
+                    src: 'for (let [a] of q) { for (let a = 1; a < 5; a++) {} }',
+
+                    expected: 'for (let _hh$temp0 of q) { let a = _hh$temp0[0]; for (let a = 1; a < 5; a++) { } }'
+                }
+            ]);
+        });
+
         it('duplicate destructuring', () => {
             testProcessing([
                 {


### PR DESCRIPTION
Approach:
If the `for-of statement` has the `ArrayPattern` declaration in the left block, then I try to find the similar variable declaration inside the `for-of` body. If the similar declaration is found this means that we cannot use the previosly declared variable, so we need to rename it.