### PR TITLE
fix: don't raise the blur after focus on a not focusable element

### DIFF
--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -560,12 +560,16 @@ export function getTabIndex (el: HTMLElement): number | null {
     return isNaN(tabIndex) ? null : tabIndex;
 }
 
+export function isElementDisabled (el: HTMLElement): boolean {
+    return matches(el, ':disabled');
+}
+
 export function isElementFocusable (el: HTMLElement): boolean {
     if (!el)
         return false;
 
     const tabIndex              = getTabIndex(el);
-    const isDisabledElement     = matches(el, ':disabled');
+    const isDisabledElement     = isElementDisabled(el);
     const isInvisibleElement    = getStyle(el, 'visibility') === 'hidden';
     const isNotDisplayedElement = getStyle(el, 'display') === 'none';
     const isHiddenElement       = isWebKit ? isHidden(el) && !isOptionElement(el) : isHidden(el);

--- a/test/client/fixtures/sandbox/event/focus-blur-change-test.js
+++ b/test/client/fixtures/sandbox/event/focus-blur-change-test.js
@@ -1470,8 +1470,8 @@ asyncTest('an active input should not be blurred after a call of the focus on a 
     document.body.appendChild(activeInput);
     document.body.appendChild(notFocusableDiv);
 
-    var isActiveInputFocused     = false;
-    var isActiveInputBlurred     = false;
+    var isActiveInputFocused = false;
+    var isActiveInputBlurred = false;
 
     activeInput.onfocus = function () {
         isActiveInputFocused = true;

--- a/test/client/fixtures/sandbox/event/focus-blur-change-test.js
+++ b/test/client/fixtures/sandbox/event/focus-blur-change-test.js
@@ -1461,3 +1461,33 @@ asyncTest('Should not change active element after source element was focused on 
         });
 });
 
+asyncTest('an active input should not be blurred after a call of the focus on a not focusable element', function () {
+    var activeInput     = document.createElement('input');
+    var notFocusableDiv = document.createElement('div');
+
+    activeInput.className = notFocusableDiv.className = TEST_ELEMENT_CLASS;
+
+    document.body.appendChild(activeInput);
+    document.body.appendChild(notFocusableDiv);
+
+    var isActiveInputFocused     = false;
+    var isActiveInputBlurred     = false;
+
+    activeInput.onfocus = function () {
+        isActiveInputFocused = true;
+    };
+
+    activeInput.onblur = function () {
+        isActiveInputBlurred = true;
+    };
+
+    focusBlur.focus(activeInput, function () {
+        ok(isActiveInputFocused);
+
+        focusBlur.focus(notFocusableDiv, function () {
+            ok(!isActiveInputBlurred);
+
+            startNext();
+        });
+    });
+});


### PR DESCRIPTION
## Purpose
We shouldn't raise the blur event on an active element after the focus method was called on a not focusable element.

## Approach
- add check that if an element is not focusable, then the consecutive blur event is not needed when the `focus` method was called on this element
- add more strict types

## References
https://github.com/DevExpress/testcafe/pull/6236

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
