### PR TITLE
fix: missing case for download attribute (closes DevExpress/testcafe#6132)

### DIFF
--- a/src/client/sandbox/child-window/index.ts
+++ b/src/client/sandbox/child-window/index.ts
@@ -28,7 +28,7 @@ export default class ChildWindowSandbox extends SandboxBase {
     }
 
     private static _shouldOpenInNewWindowOnElementAction (el: HTMLLinkElement | HTMLAreaElement | HTMLFormElement, defaultTarget: string): boolean {
-        const hasDownloadAttribute = nativeMethods.getAttribute.call(el, 'download');
+        const hasDownloadAttribute = typeof nativeMethods.getAttribute.call(el, 'download') === 'string';
 
         if (hasDownloadAttribute)
             return false;

--- a/test/client/fixtures/sandbox/child-window-test.js
+++ b/test/client/fixtures/sandbox/child-window-test.js
@@ -25,8 +25,13 @@ test('should not open new window if link has the `download` attribute', function
 
     link.setAttribute('download', 'download');
     link.setAttribute('target', '_blank');
-
     notOk(ChildWindowSandbox._shouldOpenInNewWindowOnElementAction(link, defaultTarget.linkOrArea));
+
+    link.setAttribute('download', '');
+    notOk(ChildWindowSandbox._shouldOpenInNewWindowOnElementAction(link, defaultTarget.linkOrArea));
+
+    link.removeAttribute('download');
+    ok(ChildWindowSandbox._shouldOpenInNewWindowOnElementAction(link, defaultTarget.linkOrArea));
 });
 
 test('window.open', function () {


### PR DESCRIPTION
[closes DevExpress/testcafe#6132]
need to consider the case when download attribute has empty value:
```HTML
<a href='' download>download</a>
```