### PR TITLE
feat: added handling non-HTML pages [closes DevExpress/testcafe#1471]

### DIFF
--- a/src/utils/content-type.ts
+++ b/src/utils/content-type.ts
@@ -30,10 +30,20 @@ const SCRIPT_MIMES = [
     'text/x-javascript'
 ];
 
+const TEXT_PAGE_MIMES = [
+    'text/plain',
+];
+
 export function isPage (header: string): boolean {
     header = header.toLowerCase();
 
     return PAGE_MIMES.some(mime => header.includes(mime));
+}
+
+export function isTextPage (contentTypeHeader: string): boolean {
+    contentTypeHeader = contentTypeHeader.toLowerCase();
+
+    return (TEXT_PAGE_MIMES.some(mime => contentTypeHeader.includes(mime)) || !contentTypeHeader);
 }
 
 export function isCSSResource (contentTypeHeader: string, acceptHeader: string) {

--- a/test/server/content-type-test.js
+++ b/test/server/content-type-test.js
@@ -56,3 +56,8 @@ it('Should detect page', () => {
     expect(contentTypeUtils.isPage('application/xml')).to.be.true;
     expect(contentTypeUtils.isPage('application/x-ms-application')).to.be.true;
 });
+
+it('Should detect text page', () => {
+    expect(contentTypeUtils.isTextPage('')).to.be.true;
+    expect(contentTypeUtils.isTextPage('text/plain')).to.be.true;
+});


### PR DESCRIPTION
[closes DevExpress/testcafe#1471]
## Purpose
Test hangs with non-HTML tested pages (pdf, plain text, etc.)

## Approach
1. Plane text page converts to HTML text page
2. Other non-HTML pages are downloaded

## References
https://github.com/DevExpress/testcafe/issues/1471

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
