### PR TITLE
fixes #2642: instrument sendBeacon via Navigator.prototype

### DIFF
--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -976,7 +976,7 @@ class NativeMethods {
         this.clearInterval       = win.clearInterval || winProto.clearInterval;
 
         this.registerProtocolHandler = win.navigator.registerProtocolHandler;
-        this.sendBeacon              = win.navigator.sendBeacon;
+        this.sendBeacon              = win.Navigator.prototype.sendBeacon;
 
         if (win.XMLHttpRequest) {
             // NOTE: IE11 has no EventTarget so we should save "Event" methods separately

--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -976,7 +976,7 @@ class NativeMethods {
         this.clearInterval       = win.clearInterval || winProto.clearInterval;
 
         this.registerProtocolHandler = win.navigator.registerProtocolHandler;
-        this.sendBeacon              = win.Navigator.prototype.sendBeacon;
+        this.sendBeacon              = win.Navigator && win.Navigator.prototype.sendBeacon;
 
         if (win.XMLHttpRequest) {
             // NOTE: IE11 has no EventTarget so we should save "Event" methods separately

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -785,7 +785,7 @@ export default class WindowSandbox extends SandboxBase {
         }
 
         if (window.navigator.sendBeacon) {
-            overrideFunction(window.navigator, 'sendBeacon', function (this: Navigator) {
+            overrideFunction(window.Navigator.prototype, 'sendBeacon', function (this: Navigator) {
                 if (typeof arguments[0] === 'string')
                     arguments[0] = getProxyUrl(arguments[0]);
 

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -784,7 +784,7 @@ export default class WindowSandbox extends SandboxBase {
             overrideFunction(window.history, 'replaceState', createWrapperForHistoryStateManipulationFn(nativeMethods.historyReplaceState));
         }
 
-        if (window.navigator.sendBeacon) {
+        if (nativeMethods.sendBeacon) {
             overrideFunction(window.Navigator.prototype, 'sendBeacon', function (this: Navigator) {
                 if (typeof arguments[0] === 'string')
                     arguments[0] = getProxyUrl(arguments[0]);

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -624,7 +624,7 @@ if (nativeMethods.windowOriginGetter) {
 
 module('regression');
 
-if (window.navigator.sendBeacon) {
+if (nativeMethods.sendBeacon) {
     test('navigator.sendBeacon must be overriden (GH-1035)', function () {
         var originUrl    = 'http://example.com/index.html';
         var originData   = 'some data';

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -625,7 +625,7 @@ if (nativeMethods.windowOriginGetter) {
 module('regression');
 
 if (window.navigator.sendBeacon) {
-    test('Navigator.sendBeacon must be overriden (GH-1035)', function () {
+    test('navigator.sendBeacon must be overriden (GH-1035)', function () {
         var originUrl    = 'http://example.com/index.html';
         var originData   = 'some data';
         var nativeMethod = nativeMethods.sendBeacon;
@@ -637,6 +637,20 @@ if (window.navigator.sendBeacon) {
         };
 
         window.navigator.sendBeacon(originUrl, originData);
+    });
+
+    test('Navigator.prototype.sendBeacon must be overriden (GH-2642)', function () {
+        var originUrl    = 'http://example.com/index.html';
+        var originData   = 'some data';
+        var nativeMethod = nativeMethods.sendBeacon;
+
+        nativeMethods.sendBeacon = function (url, data) {
+            strictEqual(url, urlUtils.getProxyUrl(originUrl));
+            strictEqual(data, originData);
+            nativeMethods.sendBeacon = nativeMethod;
+        };
+
+        window.Navigator.prototype.sendBeacon.call(originUrl, originData);
     });
 }
 

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -650,7 +650,7 @@ if (window.navigator.sendBeacon) {
             nativeMethods.sendBeacon = nativeMethod;
         };
 
-        window.Navigator.prototype.sendBeacon.call(originUrl, originData);
+        window.Navigator.prototype.sendBeacon.call(window.navigator, originUrl, originData);
     });
 }
 

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -114,8 +114,8 @@ test('wrappers of native functions should return the correct string representati
             'history.replaceState');
     }
 
-    if (window.navigator.sendBeacon)
-        window.checkStringRepresentation(window.navigator.sendBeacon, nativeMethods.sendBeacon);
+    if (nativeMethods.sendBeacon)
+        window.checkStringRepresentation(window.Navigator.prototype.sendBeacon, nativeMethods.sendBeacon, 'Navigator.prototype.sendBeacon');
 
     if (window.navigator.registerProtocolHandler) {
         window.checkStringRepresentation(window.navigator.registerProtocolHandler,


### PR DESCRIPTION
## Purpose
Fixes #2642. Disallow subversion of instrumentation via `Navigator.prototype.sendBeacon.call`.

## Approach
Instrument `sendBeacon` via `Navigator.prototype` instead of the `navigator` singleton instance. I've noticed that there's other instrumentation with similar failures, but I kept this PR minimal, just addressing #2642.

## References
#2642

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [X] Make sure that existing tests do not fail