### PR TITLE
ci: increased the client tests timeout for the latest Microsoft Edge browser

### DIFF
--- a/gulp/saucelabs-settings.js
+++ b/gulp/saucelabs-settings.js
@@ -55,7 +55,7 @@ const SAUCELABS_SETTINGS = {
     tags:      [process.env.TRAVIS_BRANCH || 'master'],
     browsers:  CLIENT_TESTS_BROWSERS,
     name:      'testcafe-hammerhead client tests',
-    timeout:   360
+    timeout:   720
 };
 
 module.exports = SAUCELABS_SETTINGS;


### PR DESCRIPTION
Edge versions check: https://github.com/DevExpress/testcafe-hammerhead/pull/2645.
Also, I see no elapsed time difference for Microsoft Edge 90,91 and Chrome 91 using `testcafe-browser-provider-saucelabs`.