### PR TITLE
do not open new window if preventDefault was called in later handler (tc #5621)

### DIFF
--- a/src/client/sandbox/child-window/index.ts
+++ b/src/client/sandbox/child-window/index.ts
@@ -93,19 +93,22 @@ export default class ChildWindowSandbox extends SandboxBase {
     }
 
     private _openNewWindowAfterAllEventHandlers (url, e) {
+        const nativeAddEventListener    = nativeMethods.windowAddEventListener || nativeMethods.addEventListener;
+        const nativeRemoveEventListener = nativeMethods.windowRemoveEventListener || nativeMethods.removeEventListener;
+
         let eventBubbledToTop  = false;
         let isDefaultPrevented = false;
 
         const openUrlInNewWindowIfNotPrevented = () => {
             eventBubbledToTop = true;
 
-            nativeMethods.removeEventListener.call(window, 'click', openUrlInNewWindowIfNotPrevented);
+            nativeRemoveEventListener.call(window, 'click', openUrlInNewWindowIfNotPrevented);
 
             if (!isDefaultPrevented)
                 this._openUrlInNewWindow(url);
         };
 
-        nativeMethods.addEventListener.call(window, 'click', openUrlInNewWindowIfNotPrevented);
+        nativeAddEventListener.call(window, 'click', openUrlInNewWindowIfNotPrevented);
 
         // NOTE: additional attempt to open a new window if window.handler was prevented by
         // `stopPropagation` or `stopImmediatePropagation` methods

--- a/src/client/sandbox/event/listeners.ts
+++ b/src/client/sandbox/event/listeners.ts
@@ -40,7 +40,7 @@ export default class Listeners extends EventEmitter {
         this.removeInternalEventBeforeListener   = this.listeningCtx.removeInternalBeforeHandler;
     }
 
-    private static _getNativeAddEventListener (el: any) {
+    static getNativeAddEventListener (el: any) {
         if (isIE11) {
             if (isWindow(el))
                 return nativeMethods.windowAddEventListener;
@@ -51,7 +51,7 @@ export default class Listeners extends EventEmitter {
         return nativeMethods.addEventListener;
     }
 
-    private static _getNativeRemoveEventListener (el) {
+    static getNativeRemoveEventListener (el) {
         if (isIE11) {
             if (isWindow(el))
                 return nativeMethods.windowRemoveEventListener;
@@ -154,7 +154,7 @@ export default class Listeners extends EventEmitter {
                 const el                     = this;
                 const useCapture             = Listeners._getUseCaptureParam(args[2]);
                 const eventCtx               = listeningCtx.getEventCtx(el, eventType);
-                const nativeAddEventListener = Listeners._getNativeAddEventListener(el);
+                const nativeAddEventListener = Listeners.getNativeAddEventListener(el);
 
                 if (!eventCtx || !isValidEventListener(listener))
                     return nativeAddEventListener.apply(el, args);
@@ -183,7 +183,7 @@ export default class Listeners extends EventEmitter {
                 const [eventType, listener]     = args;
                 const el                        = this;
                 const useCapture                = Listeners._getUseCaptureParam(args[2]);
-                const nativeRemoveEventListener = Listeners._getNativeRemoveEventListener(el);
+                const nativeRemoveEventListener = Listeners.getNativeRemoveEventListener(el);
                 const eventCtx                  = listeningCtx.getEventCtx(el, eventType);
 
                 if (!eventCtx || !isValidEventListener(listener))
@@ -203,7 +203,7 @@ export default class Listeners extends EventEmitter {
     }
 
     initElementListening (el: HTMLElement|Window|Document, events: string[] = LISTENED_EVENTS) {
-        const nativeAddEventListener = Listeners._getNativeAddEventListener(el);
+        const nativeAddEventListener = Listeners.getNativeAddEventListener(el);
 
         for (const event of events) {
             if (!this.listeningCtx.getEventCtx(el, event))
@@ -242,7 +242,7 @@ export default class Listeners extends EventEmitter {
     }
 
     restartElementListening (el: HTMLElement) {
-        const nativeAddEventListener = Listeners._getNativeAddEventListener(el);
+        const nativeAddEventListener = Listeners.getNativeAddEventListener(el);
         const elementCtx             = this.listeningCtx.getElementCtx(el);
 
         if (elementCtx) {

--- a/src/client/sandbox/event/unload.ts
+++ b/src/client/sandbox/event/unload.ts
@@ -98,8 +98,8 @@ export default class UnloadSandbox extends SandboxBase {
     }
 
     private _reattachListener (eventProperties: EventProperties) {
-        const nativeAddEventListener    = nativeMethods.windowAddEventListener || nativeMethods.addEventListener;
-        const nativeRemoveEventListener = nativeMethods.windowRemoveEventListener || nativeMethods.removeEventListener;
+        const nativeAddEventListener    = Listeners.getNativeAddEventListener(this.window);
+        const nativeRemoveEventListener = Listeners.getNativeRemoveEventListener(this.window);
 
         // NOTE: reattach the Listener, it'll be the last in the queue.
         nativeRemoveEventListener.call(this.window, eventProperties.nativeEventName, this);
@@ -111,7 +111,7 @@ export default class UnloadSandbox extends SandboxBase {
     }
 
     private _addEventListener (eventProperties: EventProperties) {
-        const nativeAddEventListener = nativeMethods.windowAddEventListener || nativeMethods.addEventListener;
+        const nativeAddEventListener = Listeners.getNativeAddEventListener(window);
 
         nativeAddEventListener.call(window, eventProperties.nativeEventName, this);
 

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -227,8 +227,8 @@ export default class WindowSandbox extends SandboxBase {
     }
 
     _reattachHandler (window: Window, eventName: string): void {
-        const nativeAddEventListener    = nativeMethods.windowAddEventListener || nativeMethods.addEventListener;
-        const nativeRemoveEventListener = nativeMethods.windowRemoveEventListener || nativeMethods.removeEventListener;
+        const nativeAddEventListener    = Listeners.getNativeAddEventListener(window);
+        const nativeRemoveEventListener = Listeners.getNativeRemoveEventListener(window);
 
         nativeRemoveEventListener.call(window, eventName, this);
         nativeAddEventListener.call(window, eventName, this);

--- a/test/client/fixtures/sandbox/child-window-test.js
+++ b/test/client/fixtures/sandbox/child-window-test.js
@@ -200,7 +200,7 @@ test('Should not open in window if the default behavior was prevented in parent 
     nativeMethods.click.call(link);
 
     return delay(10)
-        .then(() => {
+        .then(function () {
             document.body.removeChild(div2);
             strictEqual(windowOpenCounter, 0);
 
@@ -210,7 +210,7 @@ test('Should not open in window if the default behavior was prevented in parent 
 
             return delay(10);
         })
-        .then(() => {
+        .then(function () {
             document.body.removeChild(div3);
             strictEqual(windowOpenCounter, 1);
 


### PR DESCRIPTION
In the https://github.com/DevExpress/testcafe-hammerhead/pull/2582 I handle the case when a link element has click handler with the `preventDefault` call.

Now, I process the case when the `preventDefault` is called in handler which is defined on some parent element (element, body, window) and event is bubbling.
Example:
```HTML
<document>
    <div onclick="e.preventDefault()">
        <a href="example.com" target="_blank">click me</a>
    </div>
</document>
```
and https://github.com/DevExpress/testcafe/issues/5621#issuecomment-784902631

Approach: add the latest window.click handler, where I check if the event was prevented on previous element.
There is a specific case if event propagation was stopped by `stopPropgation/stopImmediatePropagation` methods. In this specific case I added timeout.