### PR TITLE
fix: fixed processing of styles in Safari 15, which led to freezes and inability to run tests

### DIFF
--- a/gulp/saucelabs-settings.js
+++ b/gulp/saucelabs-settings.js
@@ -27,6 +27,11 @@ const CLIENT_TESTS_BROWSERS = [
         version:     'latest'
     },
     {
+        browserName: 'safari',
+        platform:    'macOS 11.00',
+        version:     'latest'
+    },
+    {
         browserName:     'Safari',
         deviceName:      'iPhone 7 Plus Simulator',
         platformVersion: '11.3',
@@ -40,11 +45,11 @@ const CLIENT_TESTS_BROWSERS = [
     },
     {
         browserName: 'chrome',
-        platform:    'OS X 10.11'
+        platform:    'macOS 10.15'
     },
     {
         browserName: 'firefox',
-        platform:    'OS X 10.11'
+        platform:    'macOS 10.15'
     }
 ];
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "24.5.2",
+  "version": "24.5.3",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"


### PR DESCRIPTION
## Purpose
Closes https://github.com/DevExpress/testcafe/issues/6546

## Approach
Fixed the Safari 15 style overriding.

## Additional changes
Added the Big Sur test case, updated the macOS version for the Chrome and Firefox test cases. [10.11 is unsupported as of December 2019](https://en.wikipedia.org/wiki/OS_X_El_Capitan).

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
