### PR TITLE
feat: added the tough-cookie API methods, bumped tough-cookie (v4.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "pinkie": "2.0.4",
     "read-file-relative": "^1.2.0",
     "semver": "5.5.0",
-    "tough-cookie": "2.3.3",
+    "tough-cookie": "4.0.0",
     "tunnel-agent": "0.6.0",
     "webauth": "^1.1.0"
   },
@@ -52,7 +52,7 @@
     "@types/node": "^14.0.27",
     "@types/parse5": "2.2.34",
     "@types/semver": "^6.0.0",
-    "@types/tough-cookie": "^2.3.5",
+    "@types/tough-cookie": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "^4.6.1",
     "@typescript-eslint/parser": "^4.6.1",
     "babel-eslint": "^10.1.0",

--- a/src/session/cookies.ts
+++ b/src/session/cookies.ts
@@ -93,6 +93,8 @@ export default class Cookies {
     }
 
     setCookiesByApi (apiCookies) {
+        const cookiesPromises: Promise<void>[] = [];
+
         for (const apiCookie of apiCookies) {
             const cookieToSet = new Cookie(apiCookie);
             const cookieStr   = cookieToSet.toString();
@@ -100,20 +102,22 @@ export default class Cookies {
             if (cookieStr.length > BYTES_PER_COOKIE_LIMIT)
                 break;
 
-            this._putCookiePromisified.call(this._cookieJar.store, cookieToSet);
+            cookiesPromises.push(this._putCookiePromisified.call(this._cookieJar.store, cookieToSet));
         }
+
+        return Promise.all(cookiesPromises);
     }
 
     deleteCookieByApi () {
-        this._removeCookiePromisified.apply(this._cookieJar.store, arguments);
+        return this._removeCookiePromisified.apply(this._cookieJar.store, arguments);
     }
 
     deleteCookiesByApi () {
-        this._removeCookiesPromisified.apply(this._cookieJar.store, arguments);
+        return this._removeCookiesPromisified.apply(this._cookieJar.store, arguments);
     }
 
     deleteAllCookiesByApi () {
-        this._cookieJar.removeAllCookiesSync();
+        return this._cookieJar.removeAllCookiesSync();
     }
 
     setByServer (url: string, cookies) {

--- a/src/session/cookies.ts
+++ b/src/session/cookies.ts
@@ -16,15 +16,17 @@ export default class Cookies {
     private _putCookiePromisified: any;
     private _removeCookiePromisified: any;
     private _removeCookiesPromisified: any;
+    private _removeAllCookiesPromisified: any;
 
     constructor () {
-        this._cookieJar                = new CookieJar();
-        this._findCookiePromisified    = promisify(this._cookieJar.store.findCookie);
-        this._findCookiesPromisified   = promisify(this._cookieJar.store.findCookies);
-        this._getAllCookiesPromisified = promisify(this._cookieJar.store.getAllCookies);
-        this._putCookiePromisified     = promisify(this._cookieJar.store.putCookie);
-        this._removeCookiePromisified  = promisify(this._cookieJar.store.removeCookie);
-        this._removeCookiesPromisified = promisify(this._cookieJar.store.removeCookies);
+        this._cookieJar                   = new CookieJar();
+        this._findCookiePromisified       = promisify(this._cookieJar.store.findCookie);
+        this._findCookiesPromisified      = promisify(this._cookieJar.store.findCookies);
+        this._getAllCookiesPromisified    = promisify(this._cookieJar.store.getAllCookies);
+        this._putCookiePromisified        = promisify(this._cookieJar.store.putCookie);
+        this._removeCookiePromisified     = promisify(this._cookieJar.store.removeCookie);
+        this._removeCookiesPromisified    = promisify(this._cookieJar.store.removeCookies);
+        this._removeAllCookiesPromisified = promisify(this._cookieJar.removeAllCookies);
     }
 
     static _hasLocalhostDomain (cookie): boolean {
@@ -117,7 +119,7 @@ export default class Cookies {
     }
 
     deleteAllCookiesByApi () {
-        return this._cookieJar.removeAllCookiesSync();
+        return this._removeAllCookiesPromisified.call(this._cookieJar);
     }
 
     setByServer (url: string, cookies) {

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -99,6 +99,9 @@ declare module 'testcafe-hammerhead' {
         /** Session's injectable resources **/
         injectable: InjectableResources;
 
+        /** Session's cookie API **/
+        cookies: any;
+
         /** Creates a session instance **/
         protected constructor (uploadRoots: string[], options: Partial<SessionOptions>)
 


### PR DESCRIPTION
## TODO
- [ ] Bump version
- [ ] Session cookie type

## Purpose
Added the `tough-cookie` API methods for using them in TestCafe, bumped `tough-cookie` (v4.0.0)

[testcafe-hammerhead-24.5.9.zip](https://github.com/DevExpress/testcafe-hammerhead/files/7708579/testcafe-hammerhead-24.5.9.zip)

## Pre-Merge TODO
- [ ] ~~Write tests for your proposed changes~~
- [ ] Make sure that existing tests do not fail
