### PR TITLE
prevent duplicated pointer events (closes #5891)

### DIFF
--- a/src/client/sandbox/event/hover.ts
+++ b/src/client/sandbox/event/hover.ts
@@ -72,7 +72,7 @@ export default class HoverSandbox extends SandboxBase {
         const target               = nativeMethods.eventTargetGetter.call(e);
         const { clientX, clientY } = e;
         const hoverIsDisabled      = browserUtils.isIE &&
-            positionUtils.shouldIgnoreMouseEventInsideIframe(target, clientX, clientY);
+            positionUtils.shouldIgnoreEventInsideIframe(target, clientX, clientY);
 
         if (!hoverIsDisabled)
             this._hover(target);

--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -3,6 +3,7 @@ import nativeMethods from '../native-methods';
 import * as browserUtils from '../../utils/browser';
 import * as domUtils from '../../utils/dom';
 import * as eventUtils from '../../utils/event';
+import { isTouchDevice } from '../../utils/feature-detection';
 import { getOffsetPosition, offsetToClientCoords, shouldIgnoreMouseEventInsideIframe } from '../../utils/position';
 import { getBordersWidth } from '../../utils/style';
 import { HammerheadStorageEventInit } from '../../../typings/client';
@@ -623,7 +624,7 @@ export default class EventSimulator {
             }
         }
 
-        if (eventUtils.hasPointerEvents)
+        if (eventUtils.hasPointerEvents && !isTouchDevice)
             this._dispatchPointerEvent(el, args);
 
         return this._dispatchMouseEvent(el, args, userOptions);

--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -520,7 +520,7 @@ export default class EventSimulator {
             };
         }
 
-        if (browserUtils.isChrome && TOUCH_TO_POINTER_EVENT_TYPE_MAP[type]) {
+        if (TOUCH_TO_POINTER_EVENT_TYPE_MAP[type]) {
             return {
                 eventType:   TOUCH_TO_POINTER_EVENT_TYPE_MAP[type],
                 pointerType: 'touch'

--- a/src/client/sandbox/event/simulator.ts
+++ b/src/client/sandbox/event/simulator.ts
@@ -4,7 +4,7 @@ import * as browserUtils from '../../utils/browser';
 import * as domUtils from '../../utils/dom';
 import * as eventUtils from '../../utils/event';
 import { isTouchDevice } from '../../utils/feature-detection';
-import { getOffsetPosition, offsetToClientCoords, shouldIgnoreMouseEventInsideIframe } from '../../utils/position';
+import { getOffsetPosition, offsetToClientCoords, shouldIgnoreEventInsideIframe } from '../../utils/position';
 import { getBordersWidth } from '../../utils/style';
 import { HammerheadStorageEventInit } from '../../../typings/client';
 
@@ -33,6 +33,12 @@ const FOCUS_IN_OUT_EVENT_NAME_RE = /^focus(in|out)$/;
 
 // NOTE: initTextEvent method required INPUT_METHOD param in IE
 const DOM_INPUT_METHOD_KEYBOARD = 1;
+
+const MOUSE_EVENTS_TO_FORCE_POINTER_EVENTS = [
+    'mouseover',
+    'mouseenter',
+    'mouseout',
+];
 
 const MOUSE_TO_POINTER_EVENT_TYPE_MAP = {
     mousedown:  'pointerdown',
@@ -101,6 +107,9 @@ export default class EventSimulator {
     }
 
     _dispatchTouchEvent (el, args) {
+        if (shouldIgnoreEventInsideIframe(el, args.clientX, args.clientY))
+            return true;
+
         let ev = nativeMethods.documentCreateEvent.call(document, 'TouchEvent');
 
         // HACK: A test for iOS by using initTouchEvent arguments.
@@ -606,7 +615,7 @@ export default class EventSimulator {
     }
 
     _dispatchMouseRelatedEvents (el, args, userOptions = {}) {
-        if (args.type !== 'mouseover' && args.type !== 'mouseenter' && shouldIgnoreMouseEventInsideIframe(el, args.clientX, args.clientY))
+        if (args.type !== 'mouseover' && args.type !== 'mouseenter' && shouldIgnoreEventInsideIframe(el, args.clientX, args.clientY))
             return true;
 
         // NOTE: In IE, submit doesn't work if a click is simulated for some submit button's children (for example,
@@ -624,7 +633,7 @@ export default class EventSimulator {
             }
         }
 
-        if (eventUtils.hasPointerEvents && !isTouchDevice)
+        if (eventUtils.hasPointerEvents && (!isTouchDevice || MOUSE_EVENTS_TO_FORCE_POINTER_EVENTS.includes(args.type)))
             this._dispatchPointerEvent(el, args);
 
         return this._dispatchMouseEvent(el, args, userOptions);

--- a/src/client/utils/position.ts
+++ b/src/client/utils/position.ts
@@ -226,7 +226,7 @@ export function getElementRectangle (el) {
     return rectangle;
 }
 
-export function shouldIgnoreMouseEventInsideIframe (el, x, y) {
+export function shouldIgnoreEventInsideIframe (el, x, y) {
     if (domUtils.getTagName(el) !== 'iframe')
         return false;
 

--- a/test/client/fixtures/sandbox/event/event-simulator-test.js
+++ b/test/client/fixtures/sandbox/event/event-simulator-test.js
@@ -365,8 +365,23 @@ if (browserUtils.isIE) {
 if (eventUtils.hasPointerEvents) {
     test('pointer down', function () {
         bindMouseEvent('pointerdown', eventUtils.BUTTON.left);
+
+        if (featureDetection.isTouchDevice) {
+            eventSimulator.touchstart(domElement);
+
+            ok(raised);
+
+            raised = false;
+        }
+
         eventSimulator.mousedown(domElement);
-        ok(raised);
+
+        if (featureDetection.isTouchDevice)
+            notOk(raised);
+        else
+            ok(raised);
+
+        raised = false;
     });
 }
 

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -479,19 +479,25 @@ if (featureDetection.isTouchDevice) {
                 for (i = 0; i < simulatorMethods.length; i++)
                     eventSimulator[simulatorMethods[i]](iframe, { clientX: 190, clientY: 70 });
 
+                const pointerdown = eventUtils.hasPointerEvents ? ['pointerdown'] : [];
+                const pointerup = eventUtils.hasPointerEvents ? ['pointerup'] : [];
+                const pointermove = eventUtils.hasPointerEvents ? ['pointermove'] : [];
+                const pointerover = eventUtils.hasPointerEvents ? ['pointerover'] : [];
+                const pointerenter = eventUtils.hasPointerEvents ? ['pointerenter'] : [];
+
                 deepEqual(actualEvents, [
-                    ...(eventUtils.hasPointerEvents ? ['pointerdown'] : []),
+                    ...pointerdown,
                     'touchstart',
-                    ...(eventUtils.hasPointerEvents ? ['pointerup'] : []),
+                    ...pointerup,
                     'touchend',
-                    ...(eventUtils.hasPointerEvents ? ['pointerup'] : []),
+                    ...pointermove,
                     'touchmove',
                     'mousedown',
                     'mouseup',
                     'mousemove',
-                    ...(eventUtils.hasPointerEvents ? ['pointerover'] : []),
+                    ...pointerover,
                     'mouseover',
-                    ...(eventUtils.hasPointerEvents ? ['pointerenter'] : []),
+                    ...pointerenter,
                     'mouseenter',
                     'click',
                     'dblclick',

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -480,18 +480,18 @@ if (featureDetection.isTouchDevice) {
                     eventSimulator[simulatorMethods[i]](iframe, { clientX: 190, clientY: 70 });
 
                 deepEqual(actualEvents, [
-                    'pointerdown',
+                    ...(eventUtils.hasPointerEvents ? ['pointerdown'] : []),
                     'touchstart',
-                    'pointerup',
+                    ...(eventUtils.hasPointerEvents ? ['pointerup'] : []),
                     'touchend',
-                    'pointermove',
+                    ...(eventUtils.hasPointerEvents ? ['pointerup'] : []),
                     'touchmove',
                     'mousedown',
                     'mouseup',
                     'mousemove',
-                    'pointerover',
+                    ...(eventUtils.hasPointerEvents ? ['pointerover'] : []),
                     'mouseover',
-                    'pointerenter',
+                    ...(eventUtils.hasPointerEvents ? ['pointerenter'] : []),
                     'mouseenter',
                     'click',
                     'dblclick',

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -492,9 +492,8 @@ asyncTest('mouse events in iframe', function () {
             }
 
             var getHandler = function (i) {
-                return function (e) {
+                return function () {
                     actualEvents.push(allEvents[i]);
-                    console.log(e.type);
                 };
             };
 

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -427,14 +427,14 @@ if (featureDetection.isTouchDevice) {
                 ];
 
                 var allEvents = [
-                    'touchstart',
-                    'touchend',
-                    'touchmove',
                     'pointerdown',
-                    'mousedown',
+                    'touchstart',
                     'pointerup',
-                    'mouseup',
+                    'touchend',
                     'pointermove',
+                    'touchmove',
+                    'mousedown',
+                    'mouseup',
                     'mousemove',
                     'pointerover',
                     'mouseover',
@@ -479,40 +479,7 @@ if (featureDetection.isTouchDevice) {
                 for (i = 0; i < simulatorMethods.length; i++)
                     eventSimulator[simulatorMethods[i]](iframe, { clientX: 190, clientY: 70 });
 
-                const expectedEvents = [];
-
-                if (eventUtils.hasPointerEvents)
-                    expectedEvents.push('pointerdown');
-
-                expectedEvents.push('touchstart');
-
-                if (eventUtils.hasPointerEvents)
-                    expectedEvents.push('pointerup');
-
-                expectedEvents.push('touchend');
-
-                if (eventUtils.hasPointerEvents)
-                    expectedEvents.push('pointermove');
-
-                expectedEvents.push('touchmove');
-                expectedEvents.push('mousedown');
-                expectedEvents.push('mouseup');
-                expectedEvents.push('mousemove');
-
-                if (eventUtils.hasPointerEvents)
-                    expectedEvents.push('pointerover');
-
-                expectedEvents.push('mouseover');
-
-                if (eventUtils.hasPointerEvents)
-                    expectedEvents.push('pointerenter');
-
-                expectedEvents.push('mouseenter');
-                expectedEvents.push('click');
-                expectedEvents.push('dblclick');
-                expectedEvents.push('contextmenu');
-
-                deepEqual(actualEvents, expectedEvents);
+                deepEqual(actualEvents, allEvents);
 
                 document.body.removeChild(div);
 

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -479,30 +479,40 @@ if (featureDetection.isTouchDevice) {
                 for (i = 0; i < simulatorMethods.length; i++)
                     eventSimulator[simulatorMethods[i]](iframe, { clientX: 190, clientY: 70 });
 
-                const pointerdown = eventUtils.hasPointerEvents ? ['pointerdown'] : [];
-                const pointerup = eventUtils.hasPointerEvents ? ['pointerup'] : [];
-                const pointermove = eventUtils.hasPointerEvents ? ['pointermove'] : [];
-                const pointerover = eventUtils.hasPointerEvents ? ['pointerover'] : [];
-                const pointerenter = eventUtils.hasPointerEvents ? ['pointerenter'] : [];
+                const expectedEvents = [];
 
-                deepEqual(actualEvents, [
-                    ...pointerdown,
-                    'touchstart',
-                    ...pointerup,
-                    'touchend',
-                    ...pointermove,
-                    'touchmove',
-                    'mousedown',
-                    'mouseup',
-                    'mousemove',
-                    ...pointerover,
-                    'mouseover',
-                    ...pointerenter,
-                    'mouseenter',
-                    'click',
-                    'dblclick',
-                    'contextmenu',
-                ]);
+                if (eventUtils.hasPointerEvents)
+                    expectedEvents.push('pointerdown');
+
+                expectedEvents.push('touchstart');
+
+                if (eventUtils.hasPointerEvents)
+                    expectedEvents.push('pointerup');
+
+                expectedEvents.push('touchend');
+
+                if (eventUtils.hasPointerEvents)
+                    expectedEvents.push('pointermove');
+
+                expectedEvents.push('touchmove');
+                expectedEvents.push('mousedown');
+                expectedEvents.push('mouseup');
+                expectedEvents.push('mousemove');
+
+                if (eventUtils.hasPointerEvents)
+                    expectedEvents.push('pointerover');
+
+                expectedEvents.push('mouseover');
+
+                if (eventUtils.hasPointerEvents)
+                    expectedEvents.push('pointerenter');
+
+                expectedEvents.push('mouseenter');
+                expectedEvents.push('click');
+                expectedEvents.push('dblclick');
+                expectedEvents.push('contextmenu');
+
+                deepEqual(actualEvents, expectedEvents);
 
                 document.body.removeChild(div);
 

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -393,187 +393,123 @@ test('event.preventDefault call should change the event.defaultPrevented propert
     eventSimulator.keydown(input);
 });
 
-if (featureDetection.isTouchDevice) {
-    asyncTest('mouse events in iframe (Touch)', function () {
-        return createTestIframe()
-            .then(function (iframe) {
-                iframe.style.width           = '300px';
-                iframe.style.height          = '100px';
-                iframe.style.border          = '5px solid black';
-                iframe.style.padding         = '20px';
-                iframe.style.backgroundColor = 'yellow';
+function testMouseEventsInIFrame (allEvents) {
+    return createTestIframe()
+        .then(function (iframe) {
+            iframe.style.width           = '300px';
+            iframe.style.height          = '100px';
+            iframe.style.border          = '5px solid black';
+            iframe.style.padding         = '20px';
+            iframe.style.backgroundColor = 'yellow';
 
-                var div = document.createElement('div');
+            var div = document.createElement('div');
 
-                div.style.display = 'inline-block';
+            div.style.display = 'inline-block';
 
-                div.appendChild(iframe);
-                document.body.appendChild(div);
+            div.appendChild(iframe);
+            document.body.appendChild(div);
 
-                var actualEvents = [];
+            var actualEvents = [];
 
-                var simulatorMethods = [
-                    'touchstart',
-                    'touchend',
-                    'touchmove',
-                    'mousedown',
-                    'mouseup',
-                    'mousemove',
-                    'mouseover',
-                    'mouseenter',
-                    'click',
-                    'dblclick',
-                    'contextmenu'
-                ];
+            var simulatorMethods = [
+                'touchstart',
+                'touchend',
+                'touchmove',
+                'mousedown',
+                'mouseup',
+                'mousemove',
+                'mouseover',
+                'mouseenter',
+                'click',
+                'dblclick',
+                'contextmenu'
+            ];
 
-                var allEvents = [
-                    'pointerdown',
-                    'touchstart',
-                    'pointerup',
-                    'touchend',
-                    'pointermove',
-                    'touchmove',
-                    'mousedown',
-                    'mouseup',
-                    'mousemove',
-                    'pointerover',
-                    'mouseover',
-                    'pointerenter',
-                    'mouseenter',
-                    'click',
-                    'dblclick',
-                    'contextmenu'
-                ];
+            var eventsInsideFrame = ['pointerover', 'mouseover', 'pointerenter', 'mouseenter'];
 
-                var eventsInsideFrame = ['pointerover', 'mouseover', 'pointerenter', 'mouseenter'];
+            if (!eventUtils.hasPointerEvents) {
+                const pointerRegExp = /pointer(down|up|move|over|enter)/;
 
-                if (!eventUtils.hasPointerEvents) {
-                    const pointerRegExp = /pointer(down|up|move|over|enter)/;
+                allEvents = allEvents.filter(function (eventName) {
+                    return !pointerRegExp.test(eventName);
+                });
 
-                    allEvents = allEvents.filter(function (eventName) {
-                        return !pointerRegExp.test(eventName);
-                    });
+                eventsInsideFrame = eventsInsideFrame.filter(function (eventName) {
+                    return !pointerRegExp.test(eventName);
+                });
+            }
 
-                    eventsInsideFrame = eventsInsideFrame.filter(function (eventName) {
-                        return !pointerRegExp.test(eventName);
-                    });
-                }
-
-                var getHandler = function (i) {
-                    return function (e) {
-                        actualEvents.push(allEvents[i]);
-                        console.log(e.type);
-                    };
+            var getHandler = function (i) {
+                return function (e) {
+                    actualEvents.push(allEvents[i]);
+                    console.log(e.type);
                 };
+            };
 
-                for (var i = 0; i < allEvents.length; i++)
-                    iframe.addEventListener(allEvents[i], getHandler(i));
+            for (var i = 0; i < allEvents.length; i++)
+                iframe.addEventListener(allEvents[i], getHandler(i));
 
-                for (i = 0; i < simulatorMethods.length; i++)
-                    eventSimulator[simulatorMethods[i]](iframe, { clientX: 190, clientY: 130 });
+            for (i = 0; i < simulatorMethods.length; i++)
+                eventSimulator[simulatorMethods[i]](iframe, { clientX: 190, clientY: 130 });
 
-                deepEqual(actualEvents, eventsInsideFrame);
+            deepEqual(actualEvents, eventsInsideFrame);
 
-                actualEvents = [];
+            actualEvents = [];
 
-                for (i = 0; i < simulatorMethods.length; i++)
-                    eventSimulator[simulatorMethods[i]](iframe, { clientX: 190, clientY: 70 });
+            for (i = 0; i < simulatorMethods.length; i++)
+                eventSimulator[simulatorMethods[i]](iframe, { clientX: 190, clientY: 70 });
 
-                deepEqual(actualEvents, allEvents);
+            deepEqual(actualEvents, allEvents);
 
-                document.body.removeChild(div);
+            document.body.removeChild(div);
 
-                start();
-            });
-    });
+            start();
+        });
 }
-else {
-    asyncTest('mouse events in iframe (No touch)', function () {
-        return createTestIframe()
-            .then(function (iframe) {
-                iframe.style.width           = '300px';
-                iframe.style.height          = '100px';
-                iframe.style.border          = '5px solid black';
-                iframe.style.padding         = '20px';
-                iframe.style.backgroundColor = 'yellow';
 
-                var div = document.createElement('div');
+asyncTest('mouse events in iframe', function () {
+    let allEvents = [];
 
-                div.style.display = 'inline-block';
+    if (featureDetection.isTouchDevice) {
+        allEvents = [
+            'pointerdown',
+            'touchstart',
+            'pointerup',
+            'touchend',
+            'pointermove',
+            'touchmove',
+            'mousedown',
+            'mouseup',
+            'mousemove',
+            'pointerover',
+            'mouseover',
+            'pointerenter',
+            'mouseenter',
+            'click',
+            'dblclick',
+            'contextmenu'
+        ];
+    }
+    else {
+        allEvents = [
+            'pointerdown',
+            'mousedown',
+            'pointerup',
+            'mouseup',
+            'pointermove',
+            'mousemove',
+            'pointerover',
+            'mouseover',
+            'pointerenter',
+            'mouseenter',
+            'click',
+            'dblclick',
+            'contextmenu'
+        ];
+    }
 
-                div.appendChild(iframe);
-                document.body.appendChild(div);
-
-                var actualEvents = [];
-
-                var simulatorMethods = [
-                    'mousedown',
-                    'mouseup',
-                    'mousemove',
-                    'mouseover',
-                    'mouseenter',
-                    'click',
-                    'dblclick',
-                    'contextmenu'
-                ];
-
-                var allEvents = [
-                    'pointerdown',
-                    'mousedown',
-                    'pointerup',
-                    'mouseup',
-                    'pointermove',
-                    'mousemove',
-                    'pointerover',
-                    'mouseover',
-                    'pointerenter',
-                    'mouseenter',
-                    'click',
-                    'dblclick',
-                    'contextmenu'
-                ];
-
-                var eventsInsideFrame = ['pointerover', 'mouseover', 'pointerenter', 'mouseenter'];
-
-                if (!eventUtils.hasPointerEvents) {
-                    const pointerRegExp = /pointer(down|up|move|over|enter)/;
-
-                    allEvents = allEvents.filter(function (eventName) {
-                        return !pointerRegExp.test(eventName);
-                    });
-
-                    eventsInsideFrame = eventsInsideFrame.filter(function (eventName) {
-                        return !pointerRegExp.test(eventName);
-                    });
-                }
-
-                var getHandler = function (i) {
-                    return function () {
-                        actualEvents.push(allEvents[i]);
-                    };
-                };
-
-                for (var i = 0; i < allEvents.length; i++)
-                    iframe.addEventListener(allEvents[i], getHandler(i));
-
-                for (i = 0; i < simulatorMethods.length; i++)
-                    eventSimulator[simulatorMethods[i]](iframe, { clientX: 190, clientY: 130 });
-
-                deepEqual(actualEvents, eventsInsideFrame);
-
-                actualEvents = [];
-
-                for (i = 0; i < simulatorMethods.length; i++)
-                    eventSimulator[simulatorMethods[i]](iframe, { clientX: 190, clientY: 70 });
-
-                deepEqual(actualEvents, allEvents);
-
-                document.body.removeChild(div);
-
-                start();
-            });
-    });
-}
+    return testMouseEventsInIFrame(allEvents);
+});
 
 asyncTest('hover style in iframe', function () {
     return createTestIframe()

--- a/test/client/fixtures/sandbox/event/event-test.js
+++ b/test/client/fixtures/sandbox/event/event-test.js
@@ -393,7 +393,73 @@ test('event.preventDefault call should change the event.defaultPrevented propert
     eventSimulator.keydown(input);
 });
 
-function testMouseEventsInIFrame (allEvents) {
+asyncTest('mouse events in iframe', function () {
+    let simulatorMethods = [];
+    let allEvents        = [];
+
+    if (featureDetection.isTouchDevice) {
+        simulatorMethods = [
+            'touchstart',
+            'touchend',
+            'touchmove',
+            'mousedown',
+            'mouseup',
+            'mousemove',
+            'mouseover',
+            'mouseenter',
+            'click',
+            'dblclick',
+            'contextmenu'
+        ];
+
+        allEvents = [
+            'pointerdown',
+            'touchstart',
+            'pointerup',
+            'touchend',
+            'pointermove',
+            'touchmove',
+            'mousedown',
+            'mouseup',
+            'mousemove',
+            'pointerover',
+            'mouseover',
+            'pointerenter',
+            'mouseenter',
+            'click',
+            'dblclick',
+            'contextmenu'
+        ];
+    }
+    else {
+        simulatorMethods = [
+            'mousedown',
+            'mouseup',
+            'mousemove',
+            'mouseover',
+            'mouseenter',
+            'click',
+            'dblclick',
+            'contextmenu'
+        ];
+
+        allEvents = [
+            'pointerdown',
+            'mousedown',
+            'pointerup',
+            'mouseup',
+            'pointermove',
+            'mousemove',
+            'pointerover',
+            'mouseover',
+            'pointerenter',
+            'mouseenter',
+            'click',
+            'dblclick',
+            'contextmenu'
+        ];
+    }
+
     return createTestIframe()
         .then(function (iframe) {
             iframe.style.width           = '300px';
@@ -410,20 +476,6 @@ function testMouseEventsInIFrame (allEvents) {
             document.body.appendChild(div);
 
             var actualEvents = [];
-
-            var simulatorMethods = [
-                'touchstart',
-                'touchend',
-                'touchmove',
-                'mousedown',
-                'mouseup',
-                'mousemove',
-                'mouseover',
-                'mouseenter',
-                'click',
-                'dblclick',
-                'contextmenu'
-            ];
 
             var eventsInsideFrame = ['pointerover', 'mouseover', 'pointerenter', 'mouseenter'];
 
@@ -465,50 +517,6 @@ function testMouseEventsInIFrame (allEvents) {
 
             start();
         });
-}
-
-asyncTest('mouse events in iframe', function () {
-    let allEvents = [];
-
-    if (featureDetection.isTouchDevice) {
-        allEvents = [
-            'pointerdown',
-            'touchstart',
-            'pointerup',
-            'touchend',
-            'pointermove',
-            'touchmove',
-            'mousedown',
-            'mouseup',
-            'mousemove',
-            'pointerover',
-            'mouseover',
-            'pointerenter',
-            'mouseenter',
-            'click',
-            'dblclick',
-            'contextmenu'
-        ];
-    }
-    else {
-        allEvents = [
-            'pointerdown',
-            'mousedown',
-            'pointerup',
-            'mouseup',
-            'pointermove',
-            'mousemove',
-            'pointerover',
-            'mouseover',
-            'pointerenter',
-            'mouseenter',
-            'click',
-            'dblclick',
-            'contextmenu'
-        ];
-    }
-
-    return testMouseEventsInIFrame(allEvents);
 });
 
 asyncTest('hover style in iframe', function () {

--- a/test/client/fixtures/utils/position-test.js
+++ b/test/client/fixtures/utils/position-test.js
@@ -40,7 +40,7 @@ test('`getOffsetPosition` with `roundFn` arg', function () {
     strictEqual(elementInPoint, child);
 });
 
-asyncTest('`shouldIgnoreMouseEventInsideIframe`', function () {
+asyncTest('`shouldIgnoreEventInsideIframe`', function () {
     return createTestIframe().then(function (iframe) {
         var testDiv = document.querySelector(TEST_DIV_SELECTOR);
 
@@ -60,30 +60,30 @@ asyncTest('`shouldIgnoreMouseEventInsideIframe`', function () {
         rect.right  = rect.left + rect.width;
         rect.bottom = rect.top + rect.height;
 
-        notOk(positionUtils.shouldIgnoreMouseEventInsideIframe(iframe, rect.left, rect.top));
-        notOk(positionUtils.shouldIgnoreMouseEventInsideIframe(iframe, rect.left, rect.bottom));
-        notOk(positionUtils.shouldIgnoreMouseEventInsideIframe(iframe, rect.right, rect.top));
-        notOk(positionUtils.shouldIgnoreMouseEventInsideIframe(iframe, rect.right, rect.bottom));
+        notOk(positionUtils.shouldIgnoreEventInsideIframe(iframe, rect.left, rect.top));
+        notOk(positionUtils.shouldIgnoreEventInsideIframe(iframe, rect.left, rect.bottom));
+        notOk(positionUtils.shouldIgnoreEventInsideIframe(iframe, rect.right, rect.top));
+        notOk(positionUtils.shouldIgnoreEventInsideIframe(iframe, rect.right, rect.bottom));
 
         rect.left += borderWidth + paddingWidth;
         rect.right -= borderWidth + paddingWidth;
         rect.top += borderWidth + paddingWidth;
         rect.bottom -= borderWidth + paddingWidth;
 
-        ok(positionUtils.shouldIgnoreMouseEventInsideIframe(iframe, rect.left, rect.top));
-        ok(positionUtils.shouldIgnoreMouseEventInsideIframe(iframe, rect.left, rect.bottom));
-        ok(positionUtils.shouldIgnoreMouseEventInsideIframe(iframe, rect.right, rect.top));
-        ok(positionUtils.shouldIgnoreMouseEventInsideIframe(iframe, rect.right, rect.bottom));
+        ok(positionUtils.shouldIgnoreEventInsideIframe(iframe, rect.left, rect.top));
+        ok(positionUtils.shouldIgnoreEventInsideIframe(iframe, rect.left, rect.bottom));
+        ok(positionUtils.shouldIgnoreEventInsideIframe(iframe, rect.right, rect.top));
+        ok(positionUtils.shouldIgnoreEventInsideIframe(iframe, rect.right, rect.bottom));
 
         rect.left -= 1;
         rect.right += 1;
         rect.top -= 1;
         rect.bottom += 1;
 
-        notOk(positionUtils.shouldIgnoreMouseEventInsideIframe(iframe, rect.left, rect.top));
-        notOk(positionUtils.shouldIgnoreMouseEventInsideIframe(iframe, rect.left, rect.bottom));
-        notOk(positionUtils.shouldIgnoreMouseEventInsideIframe(iframe, rect.right, rect.top));
-        notOk(positionUtils.shouldIgnoreMouseEventInsideIframe(iframe, rect.right, rect.bottom));
+        notOk(positionUtils.shouldIgnoreEventInsideIframe(iframe, rect.left, rect.top));
+        notOk(positionUtils.shouldIgnoreEventInsideIframe(iframe, rect.left, rect.bottom));
+        notOk(positionUtils.shouldIgnoreEventInsideIframe(iframe, rect.right, rect.top));
+        notOk(positionUtils.shouldIgnoreEventInsideIframe(iframe, rect.right, rect.bottom));
 
         start();
     });


### PR DESCRIPTION
Now, the `dispathPointerEvents` method is called twice: in `dispatchTouchEvents` and in `dispatchMouseEvents`.
We need call it once:
if we are testing on touch device we call `dispatchPointerEvents` in the `touch` method. In we are testing on desktop device we call `dispatchPointerEvents` in the `mouse` method, since we do not have touch events at desktop