### PR TITLE
feat: added synchronization the tough-cookie with the client

### DIFF
--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -162,11 +162,11 @@ export default class Proxy extends Router {
                 const syncCookies       = session.cookies.syncCookies;
                 const parsedSyncCookies = [] as string[];
 
-                while (syncCookies.length) {
+                while (true) {
                     const syncCookie = syncCookies.pop();
 
                     if (!syncCookie)
-                        continue;
+                        break;
 
                     const cookieRecord = {
                         ...syncCookie,

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -159,7 +159,7 @@ export default class Proxy extends Router {
 
                 logger.serviceMsg.onMessage(msg, result);
 
-                const syncCookies       = session.cookies.getSyncCookies();
+                const syncCookies       = session.cookies.syncCookies;
                 const parsedSyncCookies = [] as string[];
 
                 while (syncCookies.length) {

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -22,6 +22,7 @@ import BUILTIN_HEADERS from '../request-pipeline/builtin-header-names';
 import logger from '../utils/logger';
 import errToString from '../utils/err-to-string';
 import { parse as parseJSON } from '../utils/json';
+import { formatSyncCookie } from '../utils/cookie';
 
 const SESSION_IS_NOT_OPENED_ERR = 'Session is not opened in proxy';
 
@@ -157,6 +158,32 @@ export default class Proxy extends Router {
                 const result = await session.handleServiceMessage(msg, serverInfo);
 
                 logger.serviceMsg.onMessage(msg, result);
+
+                const syncCookies       = session.cookies.getSyncCookies();
+                const parsedSyncCookies = [] as string[];
+
+                while (syncCookies.length) {
+                    const syncCookie = syncCookies.pop();
+
+                    if (!syncCookie)
+                        continue;
+
+                    const cookieRecord = {
+                        ...syncCookie,
+                        sid:          msg.sessionId,
+                        isServerSync: true,
+                        domain:       syncCookie.domain || '',
+                        path:         syncCookie.path || '',
+                        lastAccessed: new Date(),
+                        syncKey:      ''
+                    };
+
+                    const parsedSyncCookie = formatSyncCookie(cookieRecord);
+
+                    parsedSyncCookies.push(parsedSyncCookie);
+                }
+
+                res.setHeader('Set-Cookie', parsedSyncCookies);
 
                 respondWithJSON(res, result, false);
             }

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -22,7 +22,6 @@ import BUILTIN_HEADERS from '../request-pipeline/builtin-header-names';
 import logger from '../utils/logger';
 import errToString from '../utils/err-to-string';
 import { parse as parseJSON } from '../utils/json';
-import { formatSyncCookie } from '../utils/cookie';
 
 const SESSION_IS_NOT_OPENED_ERR = 'Session is not opened in proxy';
 
@@ -159,31 +158,7 @@ export default class Proxy extends Router {
 
                 logger.serviceMsg.onMessage(msg, result);
 
-                const syncCookies       = session.cookies.syncCookies;
-                const parsedSyncCookies = [] as string[];
-
-                while (true) {
-                    const syncCookie = syncCookies.pop();
-
-                    if (!syncCookie)
-                        break;
-
-                    const cookieRecord = {
-                        ...syncCookie,
-                        sid:          msg.sessionId,
-                        isServerSync: true,
-                        domain:       syncCookie.domain || '',
-                        path:         syncCookie.path || '',
-                        lastAccessed: new Date(),
-                        syncKey:      ''
-                    };
-
-                    const parsedSyncCookie = formatSyncCookie(cookieRecord);
-
-                    parsedSyncCookies.push(parsedSyncCookie);
-                }
-
-                res.setHeader('Set-Cookie', parsedSyncCookies);
+                res.setHeader('Set-Cookie', session.syncCookies);
 
                 respondWithJSON(res, result, false);
             }

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -158,7 +158,7 @@ export default class Proxy extends Router {
 
                 logger.serviceMsg.onMessage(msg, result);
 
-                res.setHeader(BUILTIN_HEADERS.setCookie, session.syncCookies);
+                res.setHeader(BUILTIN_HEADERS.setCookie, session.takePendingSyncCookies());
 
                 respondWithJSON(res, result, false);
             }

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -158,7 +158,7 @@ export default class Proxy extends Router {
 
                 logger.serviceMsg.onMessage(msg, result);
 
-                res.setHeader('Set-Cookie', session.syncCookies);
+                res.setHeader(BUILTIN_HEADERS.setCookie, session.syncCookies);
 
                 respondWithJSON(res, result, false);
             }

--- a/src/session/cookies.ts
+++ b/src/session/cookies.ts
@@ -32,8 +32,8 @@ export default class Cookies {
     private readonly _getAllCookiesSync: any;
     private readonly _putCookieSync: any;
     private readonly _removeCookieSync: any;
-    private readonly _removeCookiesSync: any;
     private readonly _removeAllCookiesSync: any;
+    private readonly _syncCookie: Cookie[];
 
     constructor () {
         this._cookieJar            = new CookieJar();
@@ -42,8 +42,8 @@ export default class Cookies {
         this._getAllCookiesSync    = this._syncWrap('getAllCookies');
         this._putCookieSync        = this._syncWrap('putCookie');
         this._removeCookieSync     = this._syncWrap('removeCookie');
-        this._removeCookiesSync    = this._syncWrap('removeCookies');
         this._removeAllCookiesSync = this._syncWrap('removeAllCookies');
+        this._syncCookie           = [];
     }
 
     _syncWrap(method: string) {
@@ -157,29 +157,25 @@ export default class Cookies {
         return cookies.filter(cookie => filterKeys.every(key => cookie[key] === filters[key]));
     }
 
-    private _getCookiesByApi (cookie: Cookie.Properties, urls?: Url[]): Cookie[] {
+    private _getCookiesByApi (cookie: Cookie.Properties, urls?: Url[], strict = false): Cookie[] {
         const { key, domain, path, ...filters } = cookie;
 
         const currentUrls = domain && path ? castArray({ domain, path }) : urls;
         let receivedCookies: Cookie[];
 
-        if (currentUrls && currentUrls.length)
+        if (currentUrls?.[0] && (!strict || key))
             receivedCookies = flattenDeep(this._findCookiesByApi(currentUrls, key));
         else {
             receivedCookies = flattenDeep(this._getAllCookiesSync());
 
-            Object.assign(filters, cookie);
+            if (currentUrls?.[0])
+                Object.assign(filters, currentUrls[0]);
+
+            if (key)
+                Object.assign(filters, { key });
         }
 
         return Object.keys(filters).length ? this._filterCookies(receivedCookies, filters) : receivedCookies;
-    }
-
-    private _deleteCookiesByApi (urls: Url[], key?: string): void[] {
-        return urls.map(({ domain, path }) => {
-            return key
-                   ? this._removeCookieSync(domain, path, key)
-                   : this._removeCookiesSync(domain, path);
-        });
     }
 
     getCookies (externalCookies?: ExternalCookies[], urls: string[] = []): Partial<ExternalCookies>[] {
@@ -222,12 +218,18 @@ export default class Cookies {
                 break;
 
             this._putCookieSync(cookieToSet);
+
+            this._syncCookie.push(cookieToSet);
         }
     }
 
     deleteCookies (externalCookies?: ExternalCookies[], urls: string[] = []): void {
-        if (!externalCookies || !externalCookies.length)
+        if (!externalCookies || !externalCookies.length) {
+            const deletedCookies = this._getAllCookiesSync();
+
+            this._syncCookie.push(...deletedCookies);
             return this._removeAllCookiesSync();
+        }
 
         const parsedUrls = urls.map(url => {
             const { hostname, pathname } = new URL(url);
@@ -238,21 +240,21 @@ export default class Cookies {
         const cookies = this._convertToCookieProperties(externalCookies);
 
         for (const cookie of cookies) {
-            const { key, domain, path, ...filters } = cookie;
+            const deletedCookies = this._getCookiesByApi(cookie, parsedUrls, true);
 
-            const currentUrls  = domain && path ? castArray({ domain, path }) : parsedUrls;
+            for (const deletedCookie of deletedCookies) {
+                if (deletedCookie.domain && deletedCookie.path && deletedCookie.key) {
+                     this._removeCookieSync(deletedCookie.domain, deletedCookie.path, deletedCookie.key);
 
-            if (currentUrls.length && !Object.keys(filters).length)
-                this._deleteCookiesByApi(currentUrls, key);
-            else {
-                const deletedCookies = this._getCookiesByApi(cookie, parsedUrls);
-
-                for (const deletedCookie of deletedCookies) {
-                    if (deletedCookie.domain && deletedCookie.path && deletedCookie.key)
-                        this._removeCookieSync(deletedCookie.domain, deletedCookie.path, deletedCookie.key);
+                    deletedCookie.expires = new Date(0);
+                    this._syncCookie.push(deletedCookie);
                 }
             }
         }
+    }
+
+    getSyncCookies () {
+        return this._syncCookie;
     }
 
     setByServer (url: string, cookies) {

--- a/src/session/cookies.ts
+++ b/src/session/cookies.ts
@@ -33,7 +33,7 @@ export default class Cookies {
     private readonly _putCookieSync: any;
     private readonly _removeCookieSync: any;
     private readonly _removeAllCookiesSync: any;
-    private readonly _syncCookies: Cookie[];
+    public syncCookies: Cookie[];
 
     constructor () {
         this._cookieJar            = new CookieJar();
@@ -43,7 +43,7 @@ export default class Cookies {
         this._putCookieSync        = this._syncWrap('putCookie');
         this._removeCookieSync     = this._syncWrap('removeCookie');
         this._removeAllCookiesSync = this._syncWrap('removeAllCookies');
-        this._syncCookies          = [];
+        this.syncCookies           = [];
     }
 
     _syncWrap(method: string) {
@@ -219,7 +219,7 @@ export default class Cookies {
 
             this._putCookieSync(cookieToSet);
 
-            this._syncCookies.push(cookieToSet);
+            this.syncCookies.push(cookieToSet);
         }
     }
 
@@ -227,7 +227,7 @@ export default class Cookies {
         if (!externalCookies || !externalCookies.length) {
             const deletedCookies = this._getAllCookiesSync();
 
-            this._syncCookies.push(...deletedCookies);
+            this.syncCookies.push(...deletedCookies);
             return this._removeAllCookiesSync();
         }
 
@@ -247,14 +247,10 @@ export default class Cookies {
                      this._removeCookieSync(deletedCookie.domain, deletedCookie.path, deletedCookie.key);
 
                     deletedCookie.expires = new Date(0);
-                    this._syncCookies.push(deletedCookie);
+                    this.syncCookies.push(deletedCookie);
                 }
             }
         }
-    }
-
-    get syncCookies () {
-        return this._syncCookies;
     }
 
     setByServer (url: string, cookies) {

--- a/src/session/cookies.ts
+++ b/src/session/cookies.ts
@@ -33,7 +33,7 @@ export default class Cookies {
     private readonly _putCookieSync: any;
     private readonly _removeCookieSync: any;
     private readonly _removeAllCookiesSync: any;
-    private readonly _syncCookie: Cookie[];
+    private readonly _syncCookies: Cookie[];
 
     constructor () {
         this._cookieJar            = new CookieJar();
@@ -43,7 +43,7 @@ export default class Cookies {
         this._putCookieSync        = this._syncWrap('putCookie');
         this._removeCookieSync     = this._syncWrap('removeCookie');
         this._removeAllCookiesSync = this._syncWrap('removeAllCookies');
-        this._syncCookie           = [];
+        this._syncCookies          = [];
     }
 
     _syncWrap(method: string) {
@@ -219,7 +219,7 @@ export default class Cookies {
 
             this._putCookieSync(cookieToSet);
 
-            this._syncCookie.push(cookieToSet);
+            this._syncCookies.push(cookieToSet);
         }
     }
 
@@ -227,7 +227,7 @@ export default class Cookies {
         if (!externalCookies || !externalCookies.length) {
             const deletedCookies = this._getAllCookiesSync();
 
-            this._syncCookie.push(...deletedCookies);
+            this._syncCookies.push(...deletedCookies);
             return this._removeAllCookiesSync();
         }
 
@@ -247,14 +247,14 @@ export default class Cookies {
                      this._removeCookieSync(deletedCookie.domain, deletedCookie.path, deletedCookie.key);
 
                     deletedCookie.expires = new Date(0);
-                    this._syncCookie.push(deletedCookie);
+                    this._syncCookies.push(deletedCookie);
                 }
             }
         }
     }
 
-    getSyncCookies () {
-        return this._syncCookie;
+    get syncCookies () {
+        return this._syncCookies;
     }
 
     setByServer (url: string, cookies) {

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -28,6 +28,7 @@ import SERVICE_ROUTES from '../proxy/service-routes';
 import DEFAULT_REQUEST_TIMEOUT from '../request-pipeline/destination-request/default-request-timeout';
 import requestIsMatchRule from '../request-pipeline/request-hooks/request-is-match-rule';
 import ConfigureResponseEventOptions from '../session/events/configure-response-event-options';
+import { formatSyncCookie } from '../utils/cookie';
 
 const TASK_TEMPLATE = read('../client/task.js.mustache');
 
@@ -164,6 +165,33 @@ export default abstract class Session extends EventEmitter {
             return await this[msg.cmd](msg, serverInfo);
 
         throw new Error('Malformed service message or message handler is not implemented');
+    }
+
+    get syncCookies () {
+        const parsedSyncCookies = [] as string[];
+
+        while (true) {
+            const syncCookie = this.cookies.syncCookies.pop();
+
+            if (!syncCookie)
+                break;
+
+            const cookieRecord = {
+                ...syncCookie,
+                sid:          this.id,
+                isServerSync: true,
+                domain:       syncCookie.domain || '',
+                path:         syncCookie.path || '',
+                lastAccessed: new Date(),
+                syncKey:      ''
+            };
+
+            const parsedSyncCookie = formatSyncCookie(cookieRecord);
+
+            parsedSyncCookies.push(parsedSyncCookie);
+        }
+
+        return parsedSyncCookies;
     }
 
     _fillTaskScriptTemplate ({ serverInfo, isFirstPageLoad, referer, cookie, iframeTaskScriptTemplate, payloadScript, allowMultipleWindows, isRecordMode, windowId }: TaskScriptTemplateOpts): string {

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -167,8 +167,8 @@ export default abstract class Session extends EventEmitter {
         throw new Error('Malformed service message or message handler is not implemented');
     }
 
-    get syncCookies () {
-        const parsedSyncCookies = this.cookies.syncCookies.map(syncCookie => formatSyncCookie({
+    takePendingSyncCookies () {
+        return this.cookies.takePendingSyncCookies().map(syncCookie => formatSyncCookie({
             ...syncCookie,
             sid:          this.id,
             isServerSync: true,
@@ -177,10 +177,6 @@ export default abstract class Session extends EventEmitter {
             lastAccessed: new Date(),
             syncKey:      ''
         }));
-
-        this.cookies.syncCookies = [];
-
-        return parsedSyncCookies;
     }
 
     _fillTaskScriptTemplate ({ serverInfo, isFirstPageLoad, referer, cookie, iframeTaskScriptTemplate, payloadScript, allowMultipleWindows, isRecordMode, windowId }: TaskScriptTemplateOpts): string {

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -168,28 +168,17 @@ export default abstract class Session extends EventEmitter {
     }
 
     get syncCookies () {
-        const parsedSyncCookies = [] as string[];
+        const parsedSyncCookies = this.cookies.syncCookies.map(syncCookie => formatSyncCookie({
+            ...syncCookie,
+            sid:          this.id,
+            isServerSync: true,
+            domain:       syncCookie.domain || '',
+            path:         syncCookie.path || '',
+            lastAccessed: new Date(),
+            syncKey:      ''
+        }));
 
-        while (true) {
-            const syncCookie = this.cookies.syncCookies.pop();
-
-            if (!syncCookie)
-                break;
-
-            const cookieRecord = {
-                ...syncCookie,
-                sid:          this.id,
-                isServerSync: true,
-                domain:       syncCookie.domain || '',
-                path:         syncCookie.path || '',
-                lastAccessed: new Date(),
-                syncKey:      ''
-            };
-
-            const parsedSyncCookie = formatSyncCookie(cookieRecord);
-
-            parsedSyncCookies.push(parsedSyncCookie);
-        }
+        this.cookies.syncCookies = [];
 
         return parsedSyncCookies;
     }

--- a/test/server/cookies-test.js
+++ b/test/server/cookies-test.js
@@ -1,8 +1,7 @@
 const Cookies = require('../../lib/session/cookies');
 const expect  = require('chai').expect;
 
-/*eslint-disable*/
-describe.only('Cookies', () => {
+describe('Cookies', () => {
     const cookieJar = new Cookies();
 
     describe('Get cookies', () => {

--- a/test/server/cookies-test.js
+++ b/test/server/cookies-test.js
@@ -1,7 +1,8 @@
 const Cookies = require('../../lib/session/cookies');
 const expect  = require('chai').expect;
 
-describe('Cookies', () => {
+/*eslint-disable*/
+describe.only('Cookies', () => {
     const cookieJar = new Cookies();
 
     describe('Get cookies', () => {
@@ -605,7 +606,7 @@ describe('Cookies', () => {
     });
 
     describe('Sync cookies', () => {
-        afterEach(() => {
+        beforeEach(() => {
             cookieJar.deleteCookies();
             cookieJar._syncCookies = [];
         });

--- a/test/server/cookies-test.js
+++ b/test/server/cookies-test.js
@@ -18,6 +18,7 @@ describe('Cookies', () => {
 
         afterEach(() => {
             cookieJar.deleteCookies();
+            cookieJar._pendingSyncCookies = [];
         });
 
         it('Should get all cookies', () => {
@@ -383,6 +384,7 @@ describe('Cookies', () => {
     describe('Set cookies', () => {
         afterEach(() => {
             cookieJar.deleteCookies();
+            cookieJar._pendingSyncCookies = [];
         });
 
         it('Should set cookie', () => {
@@ -485,6 +487,7 @@ describe('Cookies', () => {
 
         afterEach(() => {
             cookieJar.deleteCookies();
+            cookieJar._pendingSyncCookies = [];
         });
 
         it('Should delete all cookies', () => {
@@ -605,13 +608,13 @@ describe('Cookies', () => {
     });
 
     describe('Sync cookies', () => {
-        beforeEach(() => {
+        afterEach(() => {
             cookieJar.deleteCookies();
-            cookieJar.syncCookies = [];
+            cookieJar.takePendingSyncCookies();
         });
 
         it('Should add cookie in syncCookies that was set', () => {
-            expect(cookieJar.syncCookies.length).eql(0);
+            expect(cookieJar.takePendingSyncCookies().length).eql(0);
 
             cookieJar.setCookies([{
                 name:   'apiCookie13',
@@ -620,8 +623,10 @@ describe('Cookies', () => {
                 path:   '/',
             }]);
 
-            expect(cookieJar.syncCookies.length).eql(1);
-            expect(cookieJar.syncCookies[0]).include({
+            const pendingSyncCookies = cookieJar.takePendingSyncCookies();
+
+            expect(pendingSyncCookies.length).eql(1);
+            expect(pendingSyncCookies[0]).include({
                 key:     'apiCookie13',
                 value:   'value13',
                 domain:  'some-another-domain.com',
@@ -631,7 +636,7 @@ describe('Cookies', () => {
         });
 
         it('Should add cookie in syncCookies that was deleted', () => {
-            expect(cookieJar.syncCookies.length).eql(0);
+            expect(cookieJar.takePendingSyncCookies().length).eql(0);
 
             cookieJar.setCookies([{
                 name:   'apiCookie13',
@@ -642,9 +647,11 @@ describe('Cookies', () => {
 
             cookieJar.deleteCookies([{ name: 'apiCookie13' }]);
 
-            expect(cookieJar.syncCookies.length).eql(2);
-            expect(cookieJar.syncCookies[1].key).eql('apiCookie13');
-            expect(cookieJar.syncCookies[1].expires).eql(new Date(0));
+            const pendingSyncCookies = cookieJar.takePendingSyncCookies();
+
+            expect(pendingSyncCookies.length).eql(2);
+            expect(pendingSyncCookies[1].key).eql('apiCookie13');
+            expect(pendingSyncCookies[1].expires).eql(new Date(0));
         });
     });
 });

--- a/test/server/cookies-test.js
+++ b/test/server/cookies-test.js
@@ -607,7 +607,7 @@ describe('Cookies', () => {
     describe('Sync cookies', () => {
         beforeEach(() => {
             cookieJar.deleteCookies();
-            cookieJar._syncCookies = [];
+            cookieJar.syncCookies = [];
         });
 
         it('Should add cookie in syncCookies that was set', () => {

--- a/test/server/cookies-test.js
+++ b/test/server/cookies-test.js
@@ -603,4 +603,48 @@ describe('Cookies', () => {
             expect(currentCookies.some(c => c.name === 'apiCookie2')).not.ok;
         });
     });
+
+    describe('Sync cookies', () => {
+        afterEach(() => {
+            cookieJar.deleteCookies();
+            cookieJar._syncCookies = [];
+        });
+
+        it('Should add cookie in syncCookies that was set', () => {
+            expect(cookieJar.syncCookies.length).eql(0);
+
+            cookieJar.setCookies([{
+                name:   'apiCookie13',
+                value:  'value13',
+                domain: 'some-another-domain.com',
+                path:   '/',
+            }]);
+
+            expect(cookieJar.syncCookies.length).eql(1);
+            expect(cookieJar.syncCookies[0]).include({
+                key:     'apiCookie13',
+                value:   'value13',
+                domain:  'some-another-domain.com',
+                path:    '/',
+                expires: void 0,
+            });
+        });
+
+        it('Should add cookie in syncCookies that was deleted', () => {
+            expect(cookieJar.syncCookies.length).eql(0);
+
+            cookieJar.setCookies([{
+                name:   'apiCookie13',
+                value:  'value13',
+                domain: 'some-another-domain.com',
+                path:   '/',
+            }]);
+
+            cookieJar.deleteCookies([{ name: 'apiCookie13' }]);
+
+            expect(cookieJar.syncCookies.length).eql(2);
+            expect(cookieJar.syncCookies[1].key).eql('apiCookie13');
+            expect(cookieJar.syncCookies[1].expires).eql(new Date(0));
+        });
+    });
 });

--- a/test/server/proxy/index-test.js
+++ b/test/server/proxy/index-test.js
@@ -849,7 +849,7 @@ describe('Proxy', () => {
                 path:   '/',
             }]);
 
-            expect(session.cookies.syncCookies.length).eql(1);
+            expect(session.cookies._pendingSyncCookies.length).eql(1);
 
             session['ServiceTestCmd'] = (msg, serverInfo) => {
                 expect(serverInfo).to.be.an('object');
@@ -858,7 +858,7 @@ describe('Proxy', () => {
 
             return request(options)
                 .then(() => {
-                    expect(session.cookies.syncCookies.length).eql(0);
+                    expect(session.cookies._pendingSyncCookies.length).eql(0);
                     expect(session.cookies.getClientString('https://example.com/')).eql('Test=Data');
                 });
         });

--- a/test/server/proxy/index-test.js
+++ b/test/server/proxy/index-test.js
@@ -827,6 +827,41 @@ describe('Proxy', () => {
                     });
             });
         });
+
+        it('Should put cookies to the request and remove from store', () => {
+            const options = {
+                method: 'POST',
+                url:    'http://localhost:1836/messaging',
+                json:   true,
+                body:   {
+                    cmd:       'ServiceTestCmd',
+                    data:      '42',
+                    sessionId: session.id
+                }
+            };
+
+            proxy.openSession('https://example.com', session);
+
+            session.cookies.setCookies([{
+                name:   'Test',
+                value:  'Data',
+                domain: 'example.com',
+                path:   '/',
+            }]);
+
+            expect(session.cookies.syncCookies.length).eql(1);
+
+            session['ServiceTestCmd'] = (msg, serverInfo) => {
+                expect(serverInfo).to.be.an('object');
+                return 'answer: ' + msg.data;
+            };
+
+            return request(options)
+                .then(() => {
+                    expect(session.cookies.syncCookies.length).eql(0);
+                    expect(session.cookies.getClientString('https://example.com/')).eql('Test=Data');
+                });
+        });
     });
 
     describe('Headers', () => {


### PR DESCRIPTION
## Purpose
Add synchronization the tough-cookie with the client after changing them with methods `setCookies` and `deleteCookie`

## Approach
1. Add `syncCookies` property to the Cookies
2. Add filling `syncCookies` in the methods `setCookies` and `deleteCookie`
3. Set new cookies on the service message
4. Add unit tests

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
