### PR TITLE
Add support for HTMLElement.removeAttributeNode.

### DIFF
--- a/src/client/sandbox/native-methods.ts
+++ b/src/client/sandbox/native-methods.ts
@@ -60,6 +60,8 @@ class NativeMethods {
     elementQuerySelectorAll: any;
     getAttribute: any;
     getAttributeNS: any;
+    getAttributeNode: any;
+    getAttributeNodeNS: any;
     insertBefore: Node['insertBefore'];
     insertCell: any;
     insertTableRow: any;
@@ -67,6 +69,7 @@ class NativeMethods {
     importScripts: (...urls: string[]) => void
     removeAttribute: any;
     removeAttributeNS: any;
+    removeAttributeNode: any;
     removeChild: Node['removeChild'];
     remove: Element['remove'];
     elementReplaceWith: Element['replaceWith'];
@@ -537,12 +540,15 @@ class NativeMethods {
         this.elementQuerySelectorAll       = nativeElement.querySelectorAll;
         this.getAttribute                  = nativeElement.getAttribute;
         this.getAttributeNS                = nativeElement.getAttributeNS;
+        this.getAttributeNode              = nativeElement.getAttributeNode;
+        this.getAttributeNodeNS            = nativeElement.getAttributeNodeNS;
         this.insertBefore                  = nativeElement.insertBefore;
         this.insertCell                    = createElement('tr').insertCell;
         this.insertTableRow                = createElement('table').insertRow;
         this.insertTBodyRow                = createElement('tbody').insertRow;
         this.removeAttribute               = nativeElement.removeAttribute;
         this.removeAttributeNS             = nativeElement.removeAttributeNS;
+        this.removeAttributeNode           = nativeElement.removeAttributeNode;
         this.removeChild                   = win.Node.prototype.removeChild;
         this.remove                        = win.Element.prototype.remove;
         this.elementReplaceWith            = win.Element.prototype.replaceWith;

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -452,8 +452,9 @@ export default class ElementSandbox extends SandboxBase {
 
         if (formatedAttr !== 'autocomplete') {
             if (isNode) {
-                const original = nativeMethods.getAttributeNodeNS.call(el, node.namespaceURI, node.name);
-                result = nativeMethods.removeAttributeNode.apply(el, [original].concat(Array.from(args).slice(1)));
+                const removeArgs = [nativeMethods.getAttributeNodeNS.call(el, node.namespaceURI, node.name)];
+                for (let i = 1, ilen = args.length; i < ilen; ++i) removeArgs.push(args[i]);
+                result = nativeMethods.removeAttributeNode.apply(el, removeArgs);
             }
             else {
                 const removeAttrFunc = isNs ? nativeMethods.removeAttributeNS : nativeMethods.removeAttribute;

--- a/test/client/fixtures/sandbox/node/element-test.js
+++ b/test/client/fixtures/sandbox/node/element-test.js
@@ -83,6 +83,8 @@ test('wrappers of native functions should return the correct string representati
         'Element.prototype.removeAttribute');
     window.checkStringRepresentation(window.Element.prototype.removeAttributeNS, nativeMethods.removeAttributeNS,
         'Element.prototype.removeAttributeNS');
+    window.checkStringRepresentation(window.Element.prototype.removeAttributeNode, nativeMethods.removeAttributeNode,
+        'Element.prototype.removeAttributeNode');
     window.checkStringRepresentation(window.Element.prototype.cloneNode, nativeMethods.cloneNode,
         'Element.prototype.cloneNode');
     window.checkStringRepresentation(window.Element.prototype.querySelector, nativeMethods.elementQuerySelector,

--- a/test/client/fixtures/sandbox/node/methods-test.js
+++ b/test/client/fixtures/sandbox/node/methods-test.js
@@ -121,6 +121,46 @@ test('element.removeAttribute, element.removeAttributeNS', function () {
     ok(!nativeMethods.getAttributeNS.call(el, namespace, storedAttr));
 });
 
+test('element.removeAttributeNode', function () {
+    var el         = document.createElement('a');
+    var attr       = 'href';
+    var storedAttr = DomProcessor.getStoredAttrName(attr);
+    var namespace  = 'http://www.w3.org/1999/xhtml';
+    var url        = '/test.html';
+
+    el.setAttribute(attr, url);
+    el.setAttributeNS(namespace, attr, url);
+
+    ok(nativeMethods.getAttributeNode.call(el, attr));
+    ok(nativeMethods.getAttributeNode.call(el, storedAttr));
+    ok(nativeMethods.getAttributeNodeNS.call(el, namespace, attr));
+    ok(nativeMethods.getAttributeNodeNS.call(el, namespace, storedAttr));
+
+    wrapNativeFn('removeAttributeNode');
+
+    let node = nativeMethods.getAttributeNodeNS.call(el, namespace, attr);
+
+    el.removeAttributeNode(node);
+
+    ok(nativeMethodCalled);
+    ok(nativeMethods.getAttribute.call(el, attr));
+    ok(nativeMethods.getAttribute.call(el, storedAttr));
+    ok(!nativeMethods.getAttributeNS.call(el, namespace, attr));
+    ok(!nativeMethods.getAttributeNS.call(el, namespace, storedAttr));
+
+    wrapNativeFn('removeAttributeNode');
+
+    node = nativeMethods.getAttributeNode.call(el, attr);
+
+    el.removeAttributeNode(node);
+
+    ok(nativeMethodCalled);
+    ok(!nativeMethods.getAttributeNode.call(el, attr));
+    ok(!nativeMethods.getAttributeNode.call(el, storedAttr));
+    ok(!nativeMethods.getAttributeNodeNS.call(el, namespace, attr));
+    ok(!nativeMethods.getAttributeNodeNS.call(el, namespace, storedAttr));
+});
+
 test('element.getAttributeNS, element.setAttributeNS', function () {
     var image = document.createElementNS('xlink', 'image');
 


### PR DESCRIPTION
## Purpose
`HTMLElement.attributes` [returns an attributes wrapper](https://github.dev/DevExpress/testcafe-hammerhead/blob/3615919985eaf7bd66694a769a6048a203cdd532/src/client/sandbox/node/attributes/index.ts#L63) that [clones stored attribute nodes](https://github.dev/DevExpress/testcafe-hammerhead/blob/3615919985eaf7bd66694a769a6048a203cdd532/src/client/sandbox/node/attributes/index.ts#L30). Iterating over the attributes and passing a cloned attribute to [HTMLElement.removeAttributeNode](https://developer.mozilla.org/en-US/docs/Web/API/Element/removeAttributeNode) results in an exception that fails tests.

## Approach
Add support for `HTMLElement.removeAttributeNode` that reuses the `removeAttributeCore` implementation and supports namespaced attributes. Base [attribute node](https://dom.spec.whatwg.org/#interface-attr) and [removeAttributeNode](https://dom.spec.whatwg.org/#dom-element-removeattributenode) usage on the DOM living standard. Attempt to remove stored nodes, but continue not to the throw. Pass the attribute from the native attributes list to the native `removeAttributeNode`, and allow the call to `refreshAttributesWrapper` to remove it or the clone from the wrapper. Add string representation and method unit tests, and base them on the existing tests for `removeAttribute`. Native function argument DOM tests don't apply. Make a concerted effort to match existing code style.

## References
- DevExpress/testcafe#6785
- #1901 

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
