### PR TITLE
fix: avoid focusing already removed iframe(closes #2178)

### DIFF
--- a/src/client/sandbox/event/focus-blur.ts
+++ b/src/client/sandbox/event/focus-blur.ts
@@ -291,6 +291,11 @@ export default class FocusBlurSandbox extends SandboxBase {
                                    !styleUtils.isElementInInvisibleIframe(el);
         const elDocument         = (el[INTERNAL_PROPS.processedContext] || this.window).document;
 
+        // NOTE: In some cases focus event can be raised for the element in the iframe at the moment when the iframe is removed from the document.
+        // For example, in React application by its internal mechanism: https://github.com/DevExpress/testcafe-hammerhead/issues/2178
+        if(!elDocument.defaultView)
+            return null;
+
         if (!raiseEventInIframe || isNativeFocus && !styleUtils.isElementVisible(el, elDocument))
             return null;
 


### PR DESCRIPTION
## Purpose
In some cases, a focus event can be raised for the element in the iframe at the moment when the iframe is removed from the document. For example in React application:
If you call the parent.postMessage from the iframe page and update the parent component state to remove the iframe element, the reference to the element in the "iframe" will be alive at the time when the "iframe" is fully removed from the page. React internal mechanism tries to focus this element. HammerHead's internal mechanism catches this focus event and tries to focus a non-existent element, which results in an error.

## Approach
Check the "defaultView" value before making any manipulation in the focus method.

## References
[Error: "TypeError: window.location.toString is not a function"](https://github.com/DevExpress/testcafe-hammerhead/issues/2178)
