### PR TITLE
Fix: Cookie with secure attribute are not attached to the request on localhost(closes #2715)

### DIFF
--- a/src/request-pipeline/context.ts
+++ b/src/request-pipeline/context.ts
@@ -30,7 +30,7 @@ import getMockResponse from '../request-pipeline/request-hooks/response-mock/get
 import { Http2Response } from './destination-request/http2';
 import RequestEvent from '../session/events/request-event';
 
-interface DestInfo {
+export interface DestInfo {
     url: string;
     protocol: string;
     host: string;

--- a/src/request-pipeline/header-transforms/transforms.ts
+++ b/src/request-pipeline/header-transforms/transforms.ts
@@ -103,12 +103,12 @@ export const requestTransforms = {
     [BUILTIN_HEADERS.ifModifiedSince]:    skipIfStateSnapshotIsApplied,
     [BUILTIN_HEADERS.ifNoneMatch]:        skipIfStateSnapshotIsApplied,
     [BUILTIN_HEADERS.authorization]:      transformAuthorizationHeader,
-    [BUILTIN_HEADERS.proxyAuthorization]: transformAuthorizationHeader
+    [BUILTIN_HEADERS.proxyAuthorization]: transformAuthorizationHeader,
 };
 
 export const forcedRequestTransforms = {
     [BUILTIN_HEADERS.cookie]: (_src: string, ctx: RequestPipelineContext) =>
-        shouldOmitCredentials(ctx) ? void 0 : ctx.session.cookies.getHeader(ctx.dest) || void 0
+                                  shouldOmitCredentials(ctx) ? void 0 : ctx.session.cookies.getHeader(ctx.dest) || void 0,
 };
 
 // Response headers
@@ -125,19 +125,19 @@ export const responseTransforms = {
     [BUILTIN_HEADERS.proxyAuthenticate]: addAuthenticatePrefix,
 
     [BUILTIN_HEADERS.accessControlAllowOrigin]: (_src: string, ctx: RequestPipelineContext) =>
-        ctx.isSameOriginPolicyFailed ? void 0 : ctx.getProxyOrigin(!!ctx.dest.reqOrigin),
+                                                    ctx.isSameOriginPolicyFailed ? void 0 : ctx.getProxyOrigin(!!ctx.dest.reqOrigin),
 
     // NOTE: Change the transform type if we have an iframe with an image as src,
     // because it was transformed to HTML with the image tag.
     [BUILTIN_HEADERS.contentType]: (src: string, ctx: RequestPipelineContext) =>
-        ctx.contentInfo.isIframeWithImageSrc || ctx.contentInfo.isTextPage ? 'text/html' : src,
+                                       ctx.contentInfo.isIframeWithImageSrc || ctx.contentInfo.isTextPage ? 'text/html' : src,
 
     [BUILTIN_HEADERS.contentLength]: (src: string, ctx: RequestPipelineContext) =>
-        ctx.contentInfo.requireProcessing ? ctx.destResBody.length.toString() : src,
+                                         ctx.contentInfo.requireProcessing ? ctx.destResBody.length.toString() : src,
 
     // NOTE: We should skip an invalid trailer header (GH-2692).
     [BUILTIN_HEADERS.trailer]: (src: string, ctx: RequestPipelineContext) =>
-        ctx.destRes.headers[BUILTIN_HEADERS.transferEncoding] === 'chunked' ? src : void 0,
+                                   ctx.destRes.headers[BUILTIN_HEADERS.transferEncoding] === 'chunked' ? src : void 0,
 
     [BUILTIN_HEADERS.location]: (src: string, ctx: RequestPipelineContext) => {
         // NOTE: The RFC 1945 standard requires location URLs to be absolute. However, most popular browsers
@@ -160,7 +160,7 @@ export const responseTransforms = {
         src = src.replace('ALLOW-FROM', '').trim();
 
         const isCrossDomain = ctx.isIframe && !urlUtils.sameOriginCheck(ctx.dest.url, src);
-        const proxiedUrl = ctx.toProxyUrl(src, isCrossDomain, ctx.contentInfo.contentTypeUrlToken);
+        const proxiedUrl    = ctx.toProxyUrl(src, isCrossDomain, ctx.contentInfo.contentTypeUrlToken);
 
         return 'ALLOW-FROM ' + proxiedUrl;
     },
@@ -174,7 +174,7 @@ export const responseTransforms = {
             return void 0;
 
         return src;
-    }
+    },
 };
 
 export const forcedResponseTransforms = {

--- a/src/request-pipeline/header-transforms/transforms.ts
+++ b/src/request-pipeline/header-transforms/transforms.ts
@@ -103,12 +103,12 @@ export const requestTransforms = {
     [BUILTIN_HEADERS.ifModifiedSince]:    skipIfStateSnapshotIsApplied,
     [BUILTIN_HEADERS.ifNoneMatch]:        skipIfStateSnapshotIsApplied,
     [BUILTIN_HEADERS.authorization]:      transformAuthorizationHeader,
-    [BUILTIN_HEADERS.proxyAuthorization]: transformAuthorizationHeader,
+    [BUILTIN_HEADERS.proxyAuthorization]: transformAuthorizationHeader
 };
 
 export const forcedRequestTransforms = {
     [BUILTIN_HEADERS.cookie]: (_src: string, ctx: RequestPipelineContext) =>
-        shouldOmitCredentials(ctx) ? void 0 : ctx.session.cookies.getHeader(ctx.dest.url) || void 0,
+        shouldOmitCredentials(ctx) ? void 0 : ctx.session.cookies.getHeader(ctx.dest) || void 0
 };
 
 // Response headers
@@ -174,7 +174,7 @@ export const responseTransforms = {
             return void 0;
 
         return src;
-    },
+    }
 };
 
 export const forcedResponseTransforms = {

--- a/src/request-pipeline/header-transforms/transforms.ts
+++ b/src/request-pipeline/header-transforms/transforms.ts
@@ -108,7 +108,7 @@ export const requestTransforms = {
 
 export const forcedRequestTransforms = {
     [BUILTIN_HEADERS.cookie]: (_src: string, ctx: RequestPipelineContext) =>
-                                  shouldOmitCredentials(ctx) ? void 0 : ctx.session.cookies.getHeader(ctx.dest) || void 0,
+        shouldOmitCredentials(ctx) ? void 0 : ctx.session.cookies.getHeader(ctx.dest) || void 0,
 };
 
 // Response headers
@@ -125,19 +125,19 @@ export const responseTransforms = {
     [BUILTIN_HEADERS.proxyAuthenticate]: addAuthenticatePrefix,
 
     [BUILTIN_HEADERS.accessControlAllowOrigin]: (_src: string, ctx: RequestPipelineContext) =>
-                                                    ctx.isSameOriginPolicyFailed ? void 0 : ctx.getProxyOrigin(!!ctx.dest.reqOrigin),
+        ctx.isSameOriginPolicyFailed ? void 0 : ctx.getProxyOrigin(!!ctx.dest.reqOrigin),
 
     // NOTE: Change the transform type if we have an iframe with an image as src,
     // because it was transformed to HTML with the image tag.
     [BUILTIN_HEADERS.contentType]: (src: string, ctx: RequestPipelineContext) =>
-                                       ctx.contentInfo.isIframeWithImageSrc || ctx.contentInfo.isTextPage ? 'text/html' : src,
+        ctx.contentInfo.isIframeWithImageSrc || ctx.contentInfo.isTextPage ? 'text/html' : src,
 
     [BUILTIN_HEADERS.contentLength]: (src: string, ctx: RequestPipelineContext) =>
-                                         ctx.contentInfo.requireProcessing ? ctx.destResBody.length.toString() : src,
+        ctx.contentInfo.requireProcessing ? ctx.destResBody.length.toString() : src,
 
     // NOTE: We should skip an invalid trailer header (GH-2692).
     [BUILTIN_HEADERS.trailer]: (src: string, ctx: RequestPipelineContext) =>
-                                   ctx.destRes.headers[BUILTIN_HEADERS.transferEncoding] === 'chunked' ? src : void 0,
+        ctx.destRes.headers[BUILTIN_HEADERS.transferEncoding] === 'chunked' ? src : void 0,
 
     [BUILTIN_HEADERS.location]: (src: string, ctx: RequestPipelineContext) => {
         // NOTE: The RFC 1945 standard requires location URLs to be absolute. However, most popular browsers

--- a/src/session/cookies.ts
+++ b/src/session/cookies.ts
@@ -83,7 +83,8 @@ export default class Cookies {
 
                 if (!cookie)
                     return resultCookies;
-            } else
+            }
+            else
                 cookie = cookieStr;
 
             // NOTE: If cookie.domain and url hostname are equal to localhost/127.0.0.1,
@@ -110,8 +111,8 @@ export default class Cookies {
 
     setJar (serializedJar): void {
         this._cookieJar = serializedJar
-            ? CookieJar.deserializeSync(parseJSON(serializedJar))
-            : new CookieJar();
+                          ? CookieJar.deserializeSync(parseJSON(serializedJar))
+                          : new CookieJar();
     }
 
     private _convertToExternalCookies (internalCookies: Cookie[]): ExternalCookies[] {
@@ -144,8 +145,8 @@ export default class Cookies {
     private _findCookiesByApi (urls: Url[], key?: string): (Cookie | Cookie[])[] {
         return urls.map(({ domain, path }) => {
             const cookies = key
-                ? this._findCookieSync(domain, path, key)
-                : this._findCookiesSync(domain, path);
+                            ? this._findCookieSync(domain, path, key)
+                            : this._findCookiesSync(domain, path);
 
             return cookies || [];
         });
@@ -285,8 +286,8 @@ export default class Cookies {
         const cookieJarOpts =
                   hostname === LOCALHOST_DOMAIN ||
                   hostname === LOCALHOST_IP ?
-                      { http: true, secure: true } :
-                      { http: true };
+                  { http: true, secure: true } :
+                  { http: true };
         return this._cookieJar.getCookieStringSync(url, cookieJarOpts) || null;
     }
 }

--- a/src/session/cookies.ts
+++ b/src/session/cookies.ts
@@ -62,9 +62,11 @@ export default class Cookies {
         };
     }
 
+    static _isLocalHostDomain = (domain): boolean => domain === LOCALHOST_DOMAIN || domain === LOCALHOST_IP;
+
     static _hasLocalhostDomain (cookie): boolean {
         if (cookie)
-            return cookie.domain === LOCALHOST_DOMAIN || cookie.domain === LOCALHOST_IP;
+            return this._isLocalHostDomain(cookie.domain);
 
         return false;
     }
@@ -111,8 +113,8 @@ export default class Cookies {
 
     setJar (serializedJar): void {
         this._cookieJar = serializedJar
-                          ? CookieJar.deserializeSync(parseJSON(serializedJar))
-                          : new CookieJar();
+            ? CookieJar.deserializeSync(parseJSON(serializedJar))
+            : new CookieJar();
     }
 
     private _convertToExternalCookies (internalCookies: Cookie[]): ExternalCookies[] {
@@ -145,8 +147,8 @@ export default class Cookies {
     private _findCookiesByApi (urls: Url[], key?: string): (Cookie | Cookie[])[] {
         return urls.map(({ domain, path }) => {
             const cookies = key
-                            ? this._findCookieSync(domain, path, key)
-                            : this._findCookiesSync(domain, path);
+                ? this._findCookieSync(domain, path, key)
+                : this._findCookiesSync(domain, path);
 
             return cookies || [];
         });
@@ -283,11 +285,10 @@ export default class Cookies {
         // NOTE: https://github.com/DevExpress/testcafe-hammerhead/issues/2715
         // Cookies with the secure attribute should be passed to the localhost server(without ssl) or any other server(with ssl).
         // CookieJar only checks the protocol, but not a hostname. That is why we should to add secure attribute in case of localhost.
-        const cookieJarOpts =
-                  hostname === LOCALHOST_DOMAIN ||
-                  hostname === LOCALHOST_IP ?
-                  { http: true, secure: true } :
-                  { http: true };
+        const cookieJarOpts = Cookies._isLocalHostDomain(hostname) ?
+            { http: true, secure: true } :
+            { http: true };
+
         return this._cookieJar.getCookieStringSync(url, cookieJarOpts) || null;
     }
 }

--- a/test/server/cookies-test.js
+++ b/test/server/cookies-test.js
@@ -380,6 +380,49 @@ describe('Cookies', () => {
             expect(expectedCookies).eql(cookies);
         });
     });
+    describe('Attach secure cookies to request', () => {
+        beforeEach(() => {
+            cookieJar.setCookies([
+                { name: 'apiCookie1', value: 'value1', domain: 'domain1.com', path: '/', secure: true },
+                { name: 'apiCookie2', value: 'value2', domain: 'localhost', path: '/', secure: true },
+                { name: 'apiCookie3', value: 'value3', domain: '127.0.0.1', path: '/', secure: true },
+            ]);
+        });
+
+        afterEach(() => {
+            cookieJar.deleteCookies();
+            cookieJar._pendingSyncCookies = [];
+        });
+
+        it('Should get secure cookies string from ssl domain', () => {
+            const expectedCookieString = 'apiCookie1=value1';
+            const destInfo             = { url: 'https://domain1.com/', hostname: 'domain1.com' };
+            const cookieStr            = cookieJar.getHeader(destInfo);
+
+            expect(cookieStr).eql(expectedCookieString);
+        });
+
+        it('Should get secure cookies string from localhost', () => {
+            const expectedCookieString1 = 'apiCookie2=value2';
+            const expectedCookieString2 = 'apiCookie3=value3';
+
+            const destInfo1  = { url: 'http://localhost:3006', hostname: 'localhost' };
+            const destInfo2  = { url: 'http://127.0.0.1:3001', hostname: '127.0.0.1' };
+            const cookieStr1 = cookieJar.getHeader(destInfo1);
+            const cookieStr2 = cookieJar.getHeader(destInfo2);
+
+            expect(cookieStr1).eql(expectedCookieString1);
+            expect(cookieStr2).eql(expectedCookieString2);
+        });
+
+        it('Should return null if domain is not HTTPS', () => {
+            const expectedCookieString = null;
+            const destInfo1  = { url: 'http://domain1.com', hostname: 'domain1.com' };
+            const cookieStr1 = cookieJar.getHeader(destInfo1);
+
+            expect(cookieStr1).eql(expectedCookieString);
+        });
+    });
 
     describe('Set cookies', () => {
         afterEach(() => {


### PR DESCRIPTION
## Purpose
Cookies with the secure attribute should be passed to the localhost server(without SSL) or any other server(with SSL). CookieJar only checks the protocol, but not a hostname. That is why we should add a secure attribute in the case of localhost.

## Approach
Manually check the host name and pass the secure attribute to the getCookieStringSync method in case of hostname is localhost.

## References
[Cookie not attached when request to server is redirected #2715](https://github.com/DevExpress/testcafe-hammerhead/issues/2715).
