### PR TITLE
fix: fixed getting cookies only by path or domain

### DIFF
--- a/src/session/cookies.ts
+++ b/src/session/cookies.ts
@@ -164,7 +164,6 @@ export default class Cookies {
 
     /*eslint-disable*/
     private _getCookiesByApi (cookie: Cookie.Properties, urls?: Url[], strict = false): Cookie[] {
-        debugger;
         const { key, domain, path, ...filters } = cookie;
 
         const currentUrls = domain && path ? [{ domain, path }] : urls;

--- a/src/session/cookies.ts
+++ b/src/session/cookies.ts
@@ -142,7 +142,7 @@ export default class Cookies {
         return externalCookie.map(cookie => {
             const { name, ...rest } = cookie;
 
-            return { key: name, ...rest };
+            return name ? { key: name, ...rest } : rest;
         });
     }
 
@@ -162,7 +162,9 @@ export default class Cookies {
         return cookies.filter(cookie => filterKeys.every(key => cookie[key] === filters[key]));
     }
 
+    /*eslint-disable*/
     private _getCookiesByApi (cookie: Cookie.Properties, urls?: Url[], strict = false): Cookie[] {
+        debugger;
         const { key, domain, path, ...filters } = cookie;
 
         const currentUrls = domain && path ? [{ domain, path }] : urls;
@@ -173,11 +175,7 @@ export default class Cookies {
         else {
             receivedCookies = flattenDeep(this._getAllCookiesSync());
 
-            if (currentUrls?.[0])
-                Object.assign(filters, currentUrls[0]);
-
-            if (key)
-                Object.assign(filters, { key });
+            Object.assign(filters, cookie);
         }
 
         return Object.keys(filters).length ? this._filterCookies(receivedCookies, filters) : receivedCookies;

--- a/src/session/cookies.ts
+++ b/src/session/cookies.ts
@@ -162,7 +162,6 @@ export default class Cookies {
         return cookies.filter(cookie => filterKeys.every(key => cookie[key] === filters[key]));
     }
 
-    /*eslint-disable*/
     private _getCookiesByApi (cookie: Cookie.Properties, urls?: Url[], strict = false): Cookie[] {
         const { key, domain, path, ...filters } = cookie;
 

--- a/test/server/cookies-test.js
+++ b/test/server/cookies-test.js
@@ -325,6 +325,55 @@ describe('Cookies', () => {
             expect(expectedCookies).eql(cookies);
         });
 
+        it('Should get cookies only by domain', () => {
+            const expectedCookies = [
+                {
+                    'name':     'apiCookie1',
+                    'value':    'value1',
+                    'domain':   'domain1.com',
+                    'path':     '/',
+                    'expires':  void 0,
+                    'maxAge':   void 0,
+                    'secure':   false,
+                    'httpOnly': false,
+                    'sameSite': 'none',
+                },
+                {
+                    'name':     'apiCookie4',
+                    'value':    'value4',
+                    'domain':   'domain1.com',
+                    'path':     '/path-2',
+                    'expires':  void 0,
+                    'maxAge':   void 0,
+                    'secure':   false,
+                    'httpOnly': false,
+                    'sameSite': 'none',
+                },
+            ];
+            const cookies         = cookieJar.getCookies([{ domain: 'domain1.com' }]);
+
+            expect(expectedCookies).eql(cookies);
+        });
+
+        it('Should get cookies only by path', () => {
+            const expectedCookies = [
+                {
+                    'name':     'apiCookie4',
+                    'value':    'value4',
+                    'domain':   'domain1.com',
+                    'path':     '/path-2',
+                    'expires':  void 0,
+                    'maxAge':   void 0,
+                    'secure':   false,
+                    'httpOnly': false,
+                    'sameSite': 'none',
+                },
+            ];
+            const cookies         = cookieJar.getCookies([{ path: '/path-2' }]);
+
+            expect(expectedCookies).eql(cookies);
+        });
+
         it('Should get cookies by name, domain and path', () => {
             const expectedCookies = [
                 {
@@ -380,6 +429,7 @@ describe('Cookies', () => {
             expect(expectedCookies).eql(cookies);
         });
     });
+
     describe('Attach secure cookies to request', () => {
         beforeEach(() => {
             cookieJar.setCookies([
@@ -632,6 +682,28 @@ describe('Cookies', () => {
 
             expect(currentCookies.length).eql(5);
             expect(currentCookies.some(c => c.domain === 'domain1.com' && c.path === 'path-2')).not.ok;
+
+        });
+
+        it('Should delete cookies only by domain', () => {
+            expect(cookieJar.getCookies().length).eql(6);
+            cookieJar.deleteCookies([{ domain: 'domain1.com' }]);
+
+            const currentCookies = cookieJar.getCookies();
+
+            expect(currentCookies.length).eql(4);
+            expect(currentCookies.some(c => c.domain === 'domain1.com')).not.ok;
+
+        });
+
+        it('Should delete cookies only by path', () => {
+            expect(cookieJar.getCookies().length).eql(6);
+            cookieJar.deleteCookies([{ path: '/path-2' }]);
+
+            const currentCookies = cookieJar.getCookies();
+
+            expect(currentCookies.length).eql(5);
+            expect(currentCookies.some(c => c.path === 'path-2')).not.ok;
 
         });
 


### PR DESCRIPTION
## Purpose
Getting or deleting cookies separately by path or domain doesn't work.  It should work.

## Approach
Add path and domain to the filters also when one of them wasn't set.

## References
[testcafe-hammerhead-24.5.18.zip](https://github.com/DevExpress/testcafe-hammerhead/files/8618991/testcafe-hammerhead-24.5.18.zip)


## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
