### PR TITLE
fix: fixed deleting cookies from the client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "24.5.19",
+  "version": "24.5.20",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/client/utils/cookie.ts
+++ b/src/client/utils/cookie.ts
@@ -62,7 +62,7 @@ export function parse (str) {
                 break;
 
             case 'max-age':
-                parsedCookie.maxAge = value;
+                parsedCookie.maxAge = Number(value);
                 break;
 
             case 'path':
@@ -113,6 +113,9 @@ export function setDefaultValues (parsedCookie, { hostname, pathname }) {
 
     if (!parsedCookie.expires)
         parsedCookie.expires = 'Infinity';
+
+    if (isNaN(parsedCookie.maxAge))
+        parsedCookie.maxAge = 'Infinity';
 }
 
 export function domainMatch (currentDomain, cookieDomain) {

--- a/src/typings/cookie.d.ts
+++ b/src/typings/cookie.d.ts
@@ -4,6 +4,7 @@ export interface CookieRecord {
     domain: string;
     path: string;
     expires: Date | 'Infinity';
+    maxAge: number | 'Infinity' | '-Infinity';
     lastAccessed: Date;
     syncKey?: string;
     cookieStr?: string;

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -8,7 +8,7 @@ import { CookieRecord, ParsedClientSyncCookie } from '../typings/cookie';
 
 const TIME_RADIX                            = 36;
 const CLEAR_COOKIE_VALUE_STR                = '=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT';
-const CLIENT_COOKIE_SYNC_KEY_FRAGMENT_COUNT = 7;
+const CLIENT_COOKIE_SYNC_KEY_FRAGMENT_COUNT = 8;
 const KEY_VALUE_REGEX                       = /(?:^([^=]+)=([\s\S]*))?/;
 
 export const SYNCHRONIZATION_TYPE = {
@@ -67,8 +67,9 @@ function formatSyncCookieKey (cookie: CookieRecord): string {
     const path         = encodeURIComponent(cookie.path);
     const expires      = cookie.expires !== 'Infinity' ? cookie.expires.getTime().toString(TIME_RADIX) : '';
     const lastAccessed = cookie.lastAccessed.getTime().toString(TIME_RADIX);
+    const maxAge       = cookie.maxAge !== 'Infinity' ? cookie.maxAge.toString(TIME_RADIX) : '';
 
-    return `${syncType}|${cookie.sid}|${key}|${domain}|${path}|${expires}|${lastAccessed}`;
+    return `${syncType}|${cookie.sid}|${key}|${domain}|${path}|${expires}|${lastAccessed}|${maxAge}`;
 }
 
 export function parseClientSyncCookieStr (cookieStr: string): ParsedClientSyncCookie {
@@ -114,6 +115,7 @@ export function parseSyncCookie (cookieStr: string): CookieRecord | null {
         path:         decodeURIComponent(parsedKey[4]),
         expires:      parsedKey[5] ? new Date(parseInt(parsedKey[5], TIME_RADIX)) : 'Infinity',
         lastAccessed: new Date(parseInt(parsedKey[6], TIME_RADIX)),
+        maxAge:       parseInt(parsedKey[7], TIME_RADIX),
         syncKey:      key,
 
         value,

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -67,7 +67,7 @@ function formatSyncCookieKey (cookie: CookieRecord): string {
     const path         = encodeURIComponent(cookie.path);
     const expires      = cookie.expires !== 'Infinity' ? cookie.expires.getTime().toString(TIME_RADIX) : '';
     const lastAccessed = cookie.lastAccessed.getTime().toString(TIME_RADIX);
-    const maxAge       = cookie.maxAge !== 'Infinity' ? cookie.maxAge.toString(TIME_RADIX) : '';
+    const maxAge       = cookie.maxAge && cookie.maxAge !== 'Infinity' ? cookie.maxAge.toString(TIME_RADIX) : '';
 
     return `${syncType}|${cookie.sid}|${key}|${domain}|${path}|${expires}|${lastAccessed}|${maxAge}`;
 }

--- a/test/client/config-qunit-server-app.js
+++ b/test/client/config-qunit-server-app.js
@@ -88,7 +88,7 @@ module.exports = function (app) {
             '// QUnit patch start',
             'if (msg.rejectForTest || msg.rejectForTestOnce && msg.retriesCount === 1)',
             '    xhr.abort();',
-            '// QUnit patch end'
+            '// QUnit patch end',
         ].join('$1');
 
         res
@@ -122,7 +122,7 @@ module.exports = function (app) {
     }, req.params.delay || 0));
 
     app.get('/xhr-with-sync-cookie/', function (req, res) {
-        res.setHeader('set-cookie', 's|sessionId|hello|example.com|%2F||1fckm5lnl=world;path=/');
+        res.setHeader('set-cookie', 's|sessionId|hello|example.com|%2F||1fckm5lnl|=world;path=/');
         res.setHeader('cache-control', 'no-cache, no-store, must-revalidate');
         res.setHeader('pragma', 'no-cache');
         res.send();
@@ -188,7 +188,7 @@ module.exports = function (app) {
                 for (var i = 0; i < msg.queue.length; i++) {
                     cookies[userAgent].setCookieSync(msg.queue[i].cookie, 'https://example.com/', {
                         http:        false,
-                        ignoreError: true
+                        ignoreError: true,
                     });
                 }
 

--- a/test/client/data/cookie-sandbox/cross-domain-iframe.html
+++ b/test/client/data/cookie-sandbox/cross-domain-iframe.html
@@ -17,7 +17,7 @@
                 case 'get cookie':
                     return window[INSTRUCTION.callMethod](e.source, 'postMessage', [settings.get().cookie, '*']);
                 case 'set cookie':
-                    nativeMethods.documentCookieSetter.call(document, 's|sessionId|set|example.com|%2F||1fckm6lnl=cookie;path=/');
+                    nativeMethods.documentCookieSetter.call(document, 's|sessionId|set|example.com|%2F||1fckm6lnl|=cookie;path=/');
                     document.cookie;
             }
         });

--- a/test/client/fixtures/sandbox/cookie-test.js
+++ b/test/client/fixtures/sandbox/cookie-test.js
@@ -82,6 +82,16 @@ if (!isGreaterThanSafari15_1) { //eslint-disable-line camelcase
             'Test9=DomainNotMatch; domain=b.example.com',
         ], 'Test1=DomainMatch; Test2=DomainMatch; Test3=DomainMatch; Test4=DomainMatch; Test5=DomainMatch');
 
+        await testCookies(storedForcedLocation, [
+            'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
+            'Test2=Expired; max-age=' + 1,
+        ], 'Test1=Expired; Test2=Expired');
+
+        await testCookies(storedForcedLocation, [
+            'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
+            'Test2=Expired; max-age=' + 1,
+        ], '', 2000);
+
         destLocation.forceLocation(storedForcedLocation);
     });
 

--- a/test/client/fixtures/sandbox/cookie-test.js
+++ b/test/client/fixtures/sandbox/cookie-test.js
@@ -30,10 +30,11 @@ if (!isGreaterThanSafari15_1) { //eslint-disable-line camelcase
         settings.get().cookie = '';
     });
 
-    test('get/set', async function () {
+    test('get/set', function () {
         var storedForcedLocation = destLocation.getLocation();
 
-        async function testCookies (location, cookieStrs, expectedCookies, waitBeforeGet = 0) {
+        function testCookies (location, cookieStrs, expectedCookies, waitBeforeGet) {
+
             if (location !== storedForcedLocation)
                 destLocation.forceLocation(urlUtils.getProxyUrl(location));
 
@@ -42,61 +43,70 @@ if (!isGreaterThanSafari15_1) { //eslint-disable-line camelcase
             for (var i = 0; i < cookieStrs.length; i++)
                 document.cookie = cookieStrs[i];
 
-            if (waitBeforeGet)
-                await window.wait(waitBeforeGet);
-
-            strictEqual(document.cookie, expectedCookies, 'destLocation = ' + destLocation.getLocation());
+            return window.wait(waitBeforeGet || 0)
+                .then(function () {
+                    return strictEqual(document.cookie, expectedCookies, 'destLocation = ' + destLocation.getLocation());
+                });
         }
 
-        await testCookies(storedForcedLocation, [
-            'Test1=Basic; expires=' + validDateStr,
-            'Test2=PathMatch; expires=' + validDateStr + '; path=/',
-            'Test4=DomainMatch; expires=' + validDateStr + '; domain=.example.com',
-            'Test5=DomainNotMatch; expires=' + validDateStr + '; domain=.cbf4e2d79.com',
-            'Test6=HttpOnly; expires=' + validDateStr + '; path=/; HttpOnly',
-            'Test7=Secure; expires=' + validDateStr + '; path=/; Secure',
-            'Test8=Expired; expires=Wed, 13-Jan-1977 22:23:01 GMT; path=/',
-            'Test9=Duplicate; One=More; expires=' + validDateStr + '; path=/',
-            'Test10=' + new Array(350).join('(big cookie)'),
-            'value without key',
-            'Test11=Outdated; max-age=0; path=/',
-        ], 'Test1=Basic; Test2=PathMatch; Test4=DomainMatch; Test7=Secure; Test9=Duplicate; value without key');
-
-        await testCookies('http://localhost', [
-            'Test1=DomainMatch; expires=' + validDateStr + '; domain=localhost',
-            'Test2=DomainNotMatch; expires=' + validDateStr + '; domain=localhost:80',
-            'Test2=DomainNotMatch; expires=' + validDateStr + '; domain=127.0.0.1',
-        ], 'Test1=DomainMatch');
-
-        await testCookies('http://127.0.0.1', [
-            'Test1=DomainMatch; expires=' + validDateStr + '; domain=127.0.0.1',
-            'Test2=DomainNotMatch; expires=' + validDateStr + '; domain=127.0.0.1:80',
-            'Test2=DomainNotMatch; expires=' + validDateStr + '; domain=localhost',
-        ], 'Test1=DomainMatch');
-
-        await testCookies('http://sub.example.com/', [
-            'Test1=DomainMatch; domain=sub.example.com',
-            'Test2=DomainMatch; domain=.sub.example.com',
-            'Test3=DomainMatch; Domain=SUB.Example.com',
-            'Test4=DomainMatch; Domain=example.com',
-            'Test5=DomainMatch; Domain=.example.com',
-            'Test6=DomainNotMatch; domain=123',
-            'Test7=DomainNotMatch; domain=sub.example',
-            'Test8=DomainNotMatch; domain=example.co',
-            'Test9=DomainNotMatch; domain=b.example.com',
-        ], 'Test1=DomainMatch; Test2=DomainMatch; Test3=DomainMatch; Test4=DomainMatch; Test5=DomainMatch');
-
-        await testCookies(storedForcedLocation, [
-            'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
-            'Test2=Expired; max-age=' + 1,
-        ], 'Test1=Expired; Test2=Expired');
-
-        await testCookies(storedForcedLocation, [
-            'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
-            'Test2=Expired; max-age=' + 1,
-        ], '', 2000);
-
-        destLocation.forceLocation(storedForcedLocation);
+        return Promise.resolve()
+            .then(function () {
+                return testCookies(storedForcedLocation, [
+                    'Test1=Basic; expires=' + validDateStr,
+                    'Test2=PathMatch; expires=' + validDateStr + '; path=/',
+                    'Test4=DomainMatch; expires=' + validDateStr + '; domain=.example.com',
+                    'Test5=DomainNotMatch; expires=' + validDateStr + '; domain=.cbf4e2d79.com',
+                    'Test6=HttpOnly; expires=' + validDateStr + '; path=/; HttpOnly',
+                    'Test7=Secure; expires=' + validDateStr + '; path=/; Secure',
+                    'Test8=Expired; expires=Wed, 13-Jan-1977 22:23:01 GMT; path=/',
+                    'Test9=Duplicate; One=More; expires=' + validDateStr + '; path=/',
+                    'Test10=' + new Array(350).join('(big cookie)'),
+                    'value without key',
+                    'Test11=Outdated; max-age=0; path=/',
+                ], 'Test1=Basic; Test2=PathMatch; Test4=DomainMatch; Test7=Secure; Test9=Duplicate; value without key');
+            })
+            .then(function () {
+                return testCookies('http://localhost', [
+                    'Test1=DomainMatch; expires=' + validDateStr + '; domain=localhost',
+                    'Test2=DomainNotMatch; expires=' + validDateStr + '; domain=localhost:80',
+                    'Test2=DomainNotMatch; expires=' + validDateStr + '; domain=127.0.0.1',
+                ], 'Test1=DomainMatch');
+            })
+            .then(function () {
+                return testCookies('http://127.0.0.1', [
+                    'Test1=DomainMatch; expires=' + validDateStr + '; domain=127.0.0.1',
+                    'Test2=DomainNotMatch; expires=' + validDateStr + '; domain=127.0.0.1:80',
+                    'Test2=DomainNotMatch; expires=' + validDateStr + '; domain=localhost',
+                ], 'Test1=DomainMatch');
+            })
+            .then(function () {
+                return testCookies('http://sub.example.com/', [
+                    'Test1=DomainMatch; domain=sub.example.com',
+                    'Test2=DomainMatch; domain=.sub.example.com',
+                    'Test3=DomainMatch; Domain=SUB.Example.com',
+                    'Test4=DomainMatch; Domain=example.com',
+                    'Test5=DomainMatch; Domain=.example.com',
+                    'Test6=DomainNotMatch; domain=123',
+                    'Test7=DomainNotMatch; domain=sub.example',
+                    'Test8=DomainNotMatch; domain=example.co',
+                    'Test9=DomainNotMatch; domain=b.example.com',
+                ], 'Test1=DomainMatch; Test2=DomainMatch; Test3=DomainMatch; Test4=DomainMatch; Test5=DomainMatch');
+            })
+            .then(function () {
+                return testCookies(storedForcedLocation, [
+                    'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
+                    'Test2=Expired; max-age=' + 1,
+                ], 'Test1=Expired; Test2=Expired');
+            })
+            .then(function () {
+                return testCookies(storedForcedLocation, [
+                    'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
+                    'Test2=Expired; max-age=' + 1,
+                ], '', 2000);
+            })
+            .then(function () {
+                return destLocation.forceLocation(storedForcedLocation);
+            });
     });
 
     test('path validation', function () {

--- a/test/client/fixtures/utils/cookie-test.js
+++ b/test/client/fixtures/utils/cookie-test.js
@@ -50,7 +50,7 @@ test('parse', function () {
     deepEqual(cookieUtil.parse('Test7=Duplicate; Max-Age=35; path=/'), {
         key:    'Test7',
         value:  'Duplicate',
-        maxAge: '35',
+        maxAge: 35,
         path:   '/',
     });
 });
@@ -113,6 +113,7 @@ test('setDefaultValues', function () {
         domain:  'example.com',
         path:    '/',
         expires: 'Infinity',
+        maxAge:  'Infinity',
     });
 
     parsedCookie = { key: 'test', value: 'test' };
@@ -125,6 +126,7 @@ test('setDefaultValues', function () {
         domain:  'example.com',
         path:    '/',
         expires: 'Infinity',
+        maxAge:  'Infinity',
     });
 
     parsedCookie = { key: 'test', value: 'test' };
@@ -137,6 +139,7 @@ test('setDefaultValues', function () {
         domain:  'example.com',
         path:    '/path',
         expires: 'Infinity',
+        maxAge:  'Infinity',
     });
 
     parsedCookie = { key: 'test', value: 'test', path: '/path' };
@@ -149,6 +152,7 @@ test('setDefaultValues', function () {
         domain:  'example.com',
         path:    '/path',
         expires: 'Infinity',
+        maxAge:  'Infinity',
     });
 
     parsedCookie = { key: 'test', value: 'test', path: '123' };
@@ -161,6 +165,7 @@ test('setDefaultValues', function () {
         domain:  'example.com',
         path:    '/path',
         expires: 'Infinity',
+        maxAge:  'Infinity',
     });
 
     parsedCookie = { key: 'test', value: 'test', domain: 'localhost' };
@@ -173,6 +178,7 @@ test('setDefaultValues', function () {
         domain:  'localhost',
         path:    '/path',
         expires: 'Infinity',
+        maxAge:  'Infinity',
     });
 
     parsedCookie = { key: 'test', value: 'test', expires: new Date() };
@@ -185,5 +191,19 @@ test('setDefaultValues', function () {
         domain:  'example.com',
         path:    '/path',
         expires: parsedCookie.expires,
+        maxAge:  'Infinity',
+    });
+
+    parsedCookie = { key: 'test', value: 'test', maxAge: 10 };
+
+    cookieUtil.setDefaultValues(parsedCookie, { hostname: 'example.com', pathname: '/path/example' });
+
+    deepEqual(parsedCookie, {
+        key:     'test',
+        value:   'test',
+        domain:  'example.com',
+        path:    '/path',
+        expires: 'Infinity',
+        maxAge:  parsedCookie.maxAge,
     });
 });

--- a/test/server/common/utils.js
+++ b/test/server/common/utils.js
@@ -117,5 +117,5 @@ exports.normalizeNewLine = function (str) {
 };
 
 exports.replaceLastAccessedTime = function (cookie) {
-    return cookie.replace(/[a-z0-9]+=/, '%lastAccessed%=');
+    return cookie.replace(/[a-z0-9]+\|=/, '%lastAccessed%|=');
 };

--- a/test/server/proxy/index-test.js
+++ b/test/server/proxy/index-test.js
@@ -1155,7 +1155,7 @@ describe('Proxy', () => {
                 .then(res => {
                     expect(res.statusCode).eql(200);
                     expect(replaceLastAccessedTime(res.headers['set-cookie'][0]))
-                        .eql(`s|${session.id}|key|127.0.0.1|%2F||%lastAccessed%=value;path=/`);
+                        .eql(`s|${session.id}|key|127.0.0.1|%2F||%lastAccessed%|=value;path=/`);
                     expect(res.headers[BUILTIN_HEADERS.accessControlAllowOrigin]).to.be.empty;
                     expect(session.cookies.getClientString('http://127.0.0.1:2000')).eql('key=value');
                 });

--- a/test/server/proxy/index-test.js
+++ b/test/server/proxy/index-test.js
@@ -733,7 +733,7 @@ describe('Proxy', () => {
                 return request(options)
                     .then(res => {
                         expect(replaceLastAccessedTime(res.headers['set-cookie'][0]))
-                            .eql(`s|${session.id}|aaa|127.0.0.1|%2Fpath||%lastAccessed%=111;path=/`);
+                            .eql(`s|${session.id}|aaa|127.0.0.1|%2Fpath||%lastAccessed%|=111;path=/`);
                     });
             });
 
@@ -752,7 +752,7 @@ describe('Proxy', () => {
                 return request(options)
                     .then(res => {
                         expect(replaceLastAccessedTime(res.headers['set-cookie'][0]))
-                            .eql(`s|${session.id}|aaa|127.0.0.1|%2Fpath||%lastAccessed%=111;path=/`);
+                            .eql(`s|${session.id}|aaa|127.0.0.1|%2Fpath||%lastAccessed%|=111;path=/`);
                     });
             });
 
@@ -763,9 +763,9 @@ describe('Proxy', () => {
                     url:     proxy.openSession('http://127.0.0.1:2000/cookie-server-sync/' + cookie, session),
                     headers: {
                         cookie: [
-                            `s|${session.id}|aaa|127.0.0.1|%2F||123456788=temp`,
-                            `s|${session.id}|aaa|127.0.0.1|%2F||123456789=test`,
-                            `s|${session.id}|bbb|127.0.0.1|%2F||${obsoleteTime}=321`,
+                            `s|${session.id}|aaa|127.0.0.1|%2F||123456788|=temp`,
+                            `s|${session.id}|aaa|127.0.0.1|%2F||123456789|=test`,
+                            `s|${session.id}|bbb|127.0.0.1|%2F||${obsoleteTime}|=321`,
                         ].join('; '),
                     },
 
@@ -776,11 +776,11 @@ describe('Proxy', () => {
                 return request(options)
                     .then(res => {
                         expect(res.headers['set-cookie'][0])
-                            .eql(`s|${session.id}|aaa|127.0.0.1|%2F||123456788=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT`);
+                            .eql(`s|${session.id}|aaa|127.0.0.1|%2F||123456788|=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT`);
                         expect(res.headers['set-cookie'][1])
-                            .eql(`s|${session.id}|bbb|127.0.0.1|%2F||${obsoleteTime}=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT`);
+                            .eql(`s|${session.id}|bbb|127.0.0.1|%2F||${obsoleteTime}|=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT`);
                         expect(replaceLastAccessedTime(res.headers['set-cookie'][2]))
-                            .eql(`s|${session.id}|bbb|127.0.0.1|%2F||%lastAccessed%=321;path=/`);
+                            .eql(`s|${session.id}|bbb|127.0.0.1|%2F||%lastAccessed%|=321;path=/`);
                     });
             });
 
@@ -805,8 +805,8 @@ describe('Proxy', () => {
                 const options = {
                     url:     proxy.openSession('http://127.0.0.1:2000/cookie/echo', session),
                     headers: {
-                        cookie: `c|${session.id}|Test1|127.0.0.1|%2F||1fdkm5ln1=Data1; ` +
-                                `c|${session.id}|Test2|localhost|%2F||1fdkm5ln1=Data2`,
+                        cookie: `c|${session.id}|Test1|127.0.0.1|%2F||1fdkm5ln1|=Data1; ` +
+                                `c|${session.id}|Test2|localhost|%2F||1fdkm5ln1|=Data2`,
                     },
                 };
 
@@ -822,8 +822,8 @@ describe('Proxy', () => {
                 const options = {
                     url:     proxy.openSession('http://127.0.0.1:2000/cookie/echo', session),
                     headers: {
-                        cookie: `c|${session.id}|Test1|127.0.0.1|%2F||1fdkm5ln1=Data1; ` +
-                                `cw|${session.id}|Test2|127.0.0.1|%2F||1fdkm5ln1=Data2`,
+                        cookie: `c|${session.id}|Test1|127.0.0.1|%2F||1fdkm5ln1|=Data1; ` +
+                                `cw|${session.id}|Test2|127.0.0.1|%2F||1fdkm5ln1|=Data2`,
                     },
 
                     resolveWithFullResponse: true,
@@ -834,7 +834,7 @@ describe('Proxy', () => {
                         expect(res.body).eql('%% Test1=Data1; Test2=Data2 %%');
                         expect(res.headers['set-cookie'].length).eql(1);
                         expect(res.headers['set-cookie'][0])
-                            .eql(`c|${session.id}|Test1|127.0.0.1|%2F||1fdkm5ln1=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT`);
+                            .eql(`c|${session.id}|Test1|127.0.0.1|%2F||1fdkm5ln1|=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT`);
                         expect(session.cookies.getClientString('http://127.0.0.1:12354/')).eql('Test1=Data1; Test2=Data2');
                     });
             });
@@ -843,9 +843,9 @@ describe('Proxy', () => {
                 const options = {
                     url:     proxy.openSession('http://127.0.0.1:2000/cookie/echo', session),
                     headers: {
-                        cookie: `c|${session.id}|Test1|example.com|%2Fcookie||1fdkm5ln1=Data1; ` +
-                                `c|${session.id}|Test2|example.com|%2Fpath||1fdkm5ln1=Data2; ` +
-                                `c|${session.id}|Test3|example.com|%2F||1fdkm5ln1=Data3`,
+                        cookie: `c|${session.id}|Test1|example.com|%2Fcookie||1fdkm5ln1|=Data1; ` +
+                                `c|${session.id}|Test2|example.com|%2Fpath||1fdkm5ln1|=Data2; ` +
+                                `c|${session.id}|Test3|example.com|%2F||1fdkm5ln1|=Data3`,
                     },
                 };
 


### PR DESCRIPTION
[closes DevExpress/testcafe#5929]

## Purpose
Delete client cookies if max age is up.

## Approach
1. Add test
2. Delete cookies while setting if maxAge is less or equal to 0.
3. Delete cookies while getting if max age or expires are up

## References
https://github.com/DevExpress/testcafe/issues/5929

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [X] Make sure that existing tests do not fail
