### PR TITLE
fix: fixed setting referer for request from `http` to `https`

### DIFF
--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -188,6 +188,8 @@ export default class Proxy extends Router {
         const windowId    = refererDest && refererDest.windowId || void 0;
 
         if (session) {
+            session.options.referer = referer || session.options.referer;
+
             res.setHeader(BUILTIN_HEADERS.contentType, 'application/x-javascript');
             addPreventCachingHeaders(res);
 

--- a/src/request-pipeline/context.ts
+++ b/src/request-pipeline/context.ts
@@ -215,13 +215,13 @@ export default class RequestPipelineContext {
 
     // API
     dispatch (openSessions: Map<string, Session>): boolean {
-        const parsedReqUrl  = urlUtils.parseProxyUrl(this.req.url || '');
-        const referer       = this.req.headers[BUILTIN_HEADERS.referer] as string;
-        const parsedReferer = referer && urlUtils.parseProxyUrl(referer) || null;
+        const parsedReqUrl = urlUtils.parseProxyUrl(this.req.url || '');
+        const referer      = this.req.headers[BUILTIN_HEADERS.referer] as string;
+        let parsedReferer  = referer && urlUtils.parseProxyUrl(referer) || null;
 
         // TODO: Remove it after parseProxyURL is rewritten.
-        let flattenParsedReqUrl    = RequestPipelineContext._flattenParsedProxyUrl(parsedReqUrl);
-        const flattenParsedReferer = RequestPipelineContext._flattenParsedProxyUrl(parsedReferer);
+        let flattenParsedReqUrl  = RequestPipelineContext._flattenParsedProxyUrl(parsedReqUrl);
+        let flattenParsedReferer = RequestPipelineContext._flattenParsedProxyUrl(parsedReferer);
 
         // NOTE: Remove that after implementing the https://github.com/DevExpress/testcafe-hammerhead/issues/2155
         if (!flattenParsedReqUrl && flattenParsedReferer)
@@ -237,6 +237,11 @@ export default class RequestPipelineContext {
 
         if (!this.session)
             return false;
+
+        if (!flattenParsedReferer && this.session.options.referer) {
+            parsedReferer        = urlUtils.parseProxyUrl(this.session.options.referer) || null;
+            flattenParsedReferer = RequestPipelineContext._flattenParsedProxyUrl(parsedReferer);
+        }
 
         this.dest               = flattenParsedReqUrl.dest;
         this.windowId           = flattenParsedReqUrl.windowId;

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -102,6 +102,7 @@ interface SessionOptions {
     allowMultipleWindows: boolean;
     windowId: string;
     requestTimeout?: RequestTimeout;
+    referer?: string;
 }
 
 export default abstract class Session extends EventEmitter {

--- a/test/server/proxy/regression-test.js
+++ b/test/server/proxy/regression-test.js
@@ -1570,7 +1570,7 @@ describe('Regression', () => {
             .then(() => new Promise(resolve => server.close(() => resolve())));
     });
 
-    it('Should set referer during the task', () => {
+    it('Should set referer during the task (GH-6295)', () => {
         const url = 'http://localhost:1836/task.js';
 
         session.getPayloadScript       = async () => 'PayloadScript';
@@ -1591,7 +1591,7 @@ describe('Regression', () => {
             });
     });
 
-    it('Should use `referrer` from the session options if it is not exists in request (GH-6295)', () => {
+    it('Should use `referrer` from the session options if it is not existed in request (GH-6295)', () => {
         const req        = {
             url:     getProxyUrl('http://example.com/'),
             headers: {

--- a/test/server/proxy/regression-test.js
+++ b/test/server/proxy/regression-test.js
@@ -1569,4 +1569,44 @@ describe('Regression', () => {
             })
             .then(() => new Promise(resolve => server.close(() => resolve())));
     });
+
+    it('Should set referer during the task', () => {
+        const url = 'http://localhost:1836/task.js';
+
+        session.getPayloadScript       = async () => 'PayloadScript';
+        session.getIframePayloadScript = async () => 'IframePayloadScript';
+
+        const options = {
+            headers: {
+                referer: proxy.openSession('http://example.com', session),
+            },
+
+            url:                     url,
+            resolveWithFullResponse: true,
+        };
+
+        return request(options)
+            .then(() => {
+                expect(session.options.referer).eql(getProxyUrl('http://example.com/'),);
+            });
+    });
+
+    it('Should use `referrer` from the session options if it is not exists in request (GH-6295)', () => {
+        const req        = {
+            url:     getProxyUrl('http://example.com/'),
+            headers: {
+                accept: PAGE_ACCEPT_HEADER,
+            },
+        };
+        const ctx        = new RequestPipelineContext(req, {}, {});
+        const sessionUrl = 'https://example-session.com/';
+
+        proxy.openSession(sessionUrl, session);
+
+        session.options.referer = getProxyUrl(sessionUrl);
+
+        ctx.dispatch(proxy.openSessions);
+
+        expect(ctx.dest.referer).eql(sessionUrl);
+    });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->
[closes DevExpress/testcafe#6295]

## Purpose
Rerferer in request from `http` to `https` should be set.

## Approach
1. Add test
2. Set a referer in the session options on the task script request
3. Set the referer header from session options to the request

## References
https://github.com/DevExpress/testcafe/issues/6295

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
