### PR TITLE
fix: regression of RequestMock with 500 http status code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "24.7.1",
+  "version": "24.7.2",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/request-pipeline/request-hooks/response-mock/get-response.ts
+++ b/src/request-pipeline/request-hooks/response-mock/get-response.ts
@@ -36,6 +36,7 @@ export default async function (mock: ResponseMock): Promise<IncomingMessageLike>
         }
         catch (err) {
             response.statusCode = 500;
+            mock.hasError       = true;
             mock.error          = err;
             response.body       = Buffer.from(ERROR_MOCKING_PAGE_CONTENT);
         }

--- a/src/request-pipeline/request-hooks/response-mock/index.ts
+++ b/src/request-pipeline/request-hooks/response-mock/index.ts
@@ -15,6 +15,7 @@ export default class ResponseMock {
     public readonly id: string;
     public isPredicate: boolean;
     public error: Error | null;
+    public hasError: boolean;
 
     public constructor (body?: ResponseMockBodyInit, statusCode?: number, headers?: Record<string, string>) {
         validateResponseMockParameters(body, statusCode, headers);
@@ -23,6 +24,7 @@ export default class ResponseMock {
         this.body        = body;
         this.isPredicate = isPredicate(body);
         this.error       = null;
+        this.hasError    = false;
 
         if (headers)
             this.headers = lowerCaseHeaderNames(headers);

--- a/src/request-pipeline/utils.ts
+++ b/src/request-pipeline/utils.ts
@@ -198,7 +198,7 @@ export async function callOnResponseEventCallbackForMotModifiedResource (ctx: Re
 }
 
 export async function handleRequestMockingErrorIfNecessary (ctx: RequestPipelineContext): Promise<void> {
-    if (ctx.destRes.statusCode !== 500)
+    if (!ctx.mock.hasError)
         return;
 
     const targetRule = ctx.requestFilterRules[0];


### PR DESCRIPTION
Closes https://github.com/DevExpress/testcafe/issues/7213