### PR TITLE
draft: window.location.origin should return 'file://' for file url

### DIFF
--- a/src/request-pipeline/context.ts
+++ b/src/request-pipeline/context.ts
@@ -246,7 +246,11 @@ export default class RequestPipelineContext {
         this.dest               = flattenParsedReqUrl.dest;
         this.windowId           = flattenParsedReqUrl.windowId;
         this.dest.partAfterHost = RequestPipelineContext._preparePartAfterHost(this.dest.partAfterHost);
-        this.dest.domain        = urlUtils.getDomain(this.dest);
+
+        const domain = urlUtils.getDomain(this.dest);
+
+        this.dest.domain        = domain === 'file://' ? 'null' : domain;
+
 
         if (flattenParsedReferer) {
             this.dest.referer   = flattenParsedReferer.dest.url;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -185,7 +185,7 @@ export function getProxyUrl (url: string, opts: ProxyUrlOptions): string {
 
 export function getDomain (parsed: { protocol?: string, host?: string, hostname?: string, port?: string | number }): string {
     if (parsed.protocol === 'file:')
-        return 'null';
+        return 'file://';
 
     return formatUrl({
         protocol: parsed.protocol,


### PR DESCRIPTION
## Purpose

So I had problem when `getDomain` reruned 'null', because I used Kotlin Multiplatform (kompiled js library) with ktor library, and when library Ktor sending request it geting `window.location.origin` and do some logick depends of file or http, and when `getDomain` rerun 'null' Ktor is cruching. This PR fix this problem.

## Approach
Usually when we run `window.location.origin` with href `file://***` we should get 'file://', but before fix we got 'null'.

## References
I can't create issue, could you created it? 

## Pre-Merge TODO
- [ ] Write tests for your proposed changes 
And I don't know how add Regress test for "file://" route, because it runs wothout server.
I'm ready write test for it, but I need help for it.

- [ ] Make sure that existing tests do not fail - GitHub actions 
