### PR TITLE
refactor!: make session request events asynchronous

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "24.7.4",
+  "version": "25.0.0",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -297,7 +297,7 @@ export default abstract class Session extends EventEmitter {
         return !!this.requestEventListeners.size;
     }
 
-    addRequestEventListeners (rule: RequestFilterRule, listeners: RequestEventListeners, errorHandler: (event: RequestEventListenerError) => void): void {
+    async addRequestEventListeners (rule: RequestFilterRule, listeners: RequestEventListeners, errorHandler: (event: RequestEventListenerError) => void): Promise<void> {
         const listenersData = {
             listeners,
             errorHandler,
@@ -307,7 +307,7 @@ export default abstract class Session extends EventEmitter {
         this.requestEventListeners.set(rule.id, listenersData);
     }
 
-    removeRequestEventListeners (rule: RequestFilterRule): void {
+    async removeRequestEventListeners (rule: RequestFilterRule): Promise<void> {
         this.requestEventListeners.delete(rule.id);
     }
 

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -231,10 +231,10 @@ declare module 'testcafe-hammerhead' {
 
         /** Adds request event listeners **/
         addRequestEventListeners (rule: RequestFilterRule, listeners: RequestEventListeners,
-                                  errorHandler: (event: RequestEventListenerError) => void): void;
+                                  errorHandler: (event: RequestEventListenerError) => void): Promise<void>;
 
         /** Removes request event listeners **/
-        removeRequestEventListeners (rule: RequestFilterRule): void;
+        removeRequestEventListeners (rule: RequestFilterRule): Promise<void>;
 
         /** Remove request event listeners for all request filter rules **/
         clearRequestEventListeners(): void;


### PR DESCRIPTION
Part of DevExpress/testcafe-private#15

BREAKING CHANGE: calls to `addRequestEventListeners` and `removeRequestEventListeners` should be awaited from now!