### PR TITLE
add stub cookie strategy for proxyless mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "25.0.0",
+  "version": "25.0.1",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/client/sandbox/cookie/index.ts
+++ b/src/client/sandbox/cookie/index.ts
@@ -33,9 +33,6 @@ interface CookieSandboxStrategy {
     removeAllSyncCookie: () => void;
 }
 
-
-
-
 class CookieSandboxStrategyFactory {
     static create (proxyless: boolean, document: Document | null, windowSync: WindowSync) {
         return proxyless ? new CookieSandboxProxylessStrategy() : new CookieSandboxProxyStrategy(document, windowSync);
@@ -224,8 +221,6 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
 
         this._windowSync.syncBetweenWindows([parsedCookie]);
     }
-
-    
 }
 
 export default class CookieSandbox extends SandboxBase {

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -307,10 +307,12 @@ export default class DocumentSandbox extends SandboxBase {
 
         const documentCookiePropOwnerPrototype = window[nativeMethods.documentCookiePropOwnerName].prototype;
 
-        overrideDescriptor(documentCookiePropOwnerPrototype, 'cookie', {
-            getter: () => documentSandbox._cookieSandbox.getCookie(),
-            setter: value => documentSandbox._cookieSandbox.setCookie(String(value)),
-        });
+        if (!this.proxyless) {
+            overrideDescriptor(documentCookiePropOwnerPrototype, 'cookie', {
+                getter: () => documentSandbox._cookieSandbox.getCookie(),
+                setter: value => documentSandbox._cookieSandbox.setCookie(String(value)),
+            });
+        }
 
         overrideDescriptor(docPrototype, 'activeElement', {
             getter: function (this: Document) {

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -109,7 +109,7 @@ interface SessionOptions {
 export default abstract class Session extends EventEmitter {
     uploadStorage: UploadStorage;
     id: string = generateUniqueId();
-    cookies: Cookies = new Cookies();
+    cookies: Cookies;
     proxy: Proxy | null = null;
     externalProxySettings: ExternalProxySettings | null = null;
     pageLoadCount = 0;
@@ -127,6 +127,7 @@ export default abstract class Session extends EventEmitter {
         this.uploadStorage         = new UploadStorage(uploadRoots);
         this.options               = this._getOptions(options);
         this._requestHookEventData = this._initRequestHookEventData();
+        this.cookies               = this.createCookies();
     }
 
     private _initRequestHookEventData (): RequestHookEventData {
@@ -142,6 +143,10 @@ export default abstract class Session extends EventEmitter {
             allowMultipleWindows: false,
             windowId:             '',
         }, options);
+    }
+
+    protected createCookies (): Cookies {
+        return new Cookies();
     }
 
     // State


### PR DESCRIPTION
1. Added the `createCookies` virtual method to override it on the TestCafe side.
2. Do not override `document.cookie` if proxyless mode is enabled
3. Add CookieSandox proxyless strategy to remove all cookie related code in the proxyless mode.