### PR TITLE
fix: session referer rewritten in iframe tasks

### DIFF
--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -211,7 +211,8 @@ export default class Proxy extends Router {
         const windowId    = refererDest && refererDest.windowId || void 0;
 
         if (session) {
-            session.options.referer = referer || session.options.referer;
+            if (referer && !isIframe)
+                session.options.referer = referer;
 
             res.setHeader(BUILTIN_HEADERS.contentType, 'application/x-javascript');
             addPreventCachingHeaders(res);

--- a/test/server/proxy/regression-test.js
+++ b/test/server/proxy/regression-test.js
@@ -1609,4 +1609,31 @@ describe('Regression', () => {
 
         expect(ctx.dest.referer).eql(sessionUrl);
     });
+
+    it('Should not alter referer after the iframe task (GH-7376)', async () => {
+        session.getPayloadScript       = async () => 'PayloadScript';
+        session.getIframePayloadScript = async () => 'IframePayloadScript';
+
+        const expectedReferer = getProxyUrl('http://example.com/');
+
+        await request({
+            headers: {
+                referer: proxy.openSession('http://example.com', session),
+            },
+            url:                     'http://localhost:1836/task.js',
+            resolveWithFullResponse: true,
+        });
+
+        expect(session.options.referer).eql(expectedReferer);
+
+        await request({
+            headers: {
+                referer: proxy.openSession('http://iframe.example.com', session),
+            },
+            url:                     'http://localhost:1836/iframe-task.js',
+            resolveWithFullResponse: true,
+        });
+
+        expect(session.options.referer).eql(expectedReferer);
+    });
 });


### PR DESCRIPTION
Closes https://github.com/DevExpress/testcafe/issues/7376

<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
This partially undoes https://github.com/DevExpress/testcafe-hammerhead/commit/55209a53653be23536624654a3b5119437a5450c so that the session referer option does not get rewritten by iframe tasks.

## Approach
I simply added the condition before this rewrite happens, but I am not familiar enough with the codebase nor proxies in general to fully justify the change.
Let me know if it makes sense as well as the test. I can close it otherwise.
## References
https://github.com/DevExpress/testcafe/issues/7376

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
