### PR TITLE
fix: fixed getSelectElementSize

### DIFF
--- a/src/client/utils/style.ts
+++ b/src/client/utils/style.ts
@@ -207,7 +207,7 @@ export function getSelectElementSize (select) {
         return 1;
 
     const sizeAttr     = nativeMethods.getAttribute.call(select, 'size');
-    const multipleAttr = nativeMethods.getAttribute.call(select, 'multiple');
+    const multipleAttr = nativeMethods.hasAttribute.call(select, 'multiple');
     let size           = !sizeAttr ? 1 : parseInt(sizeAttr, 10);
 
     if (multipleAttr && (!sizeAttr || size < 1))

--- a/test/client/fixtures/utils/style-test.js
+++ b/test/client/fixtures/utils/style-test.js
@@ -270,7 +270,8 @@ test('getSelectElementSize', function () {
         strictEqual(size, 4);
 
     select.removeAttribute('size');
-    select.setAttribute('multiple', 'multiple');
+    select.setAttribute('multiple', '');
+    size = styleUtils.getSelectElementSize(select);
 
     if (browserUtils.isSafari && featureDetection.hasTouchEvents || browserUtils.isAndroid)
         strictEqual(size, 1);


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

Upgrade `getSelectElementSize` function

## Purpose
When a `select` has the attribute `multiple` it should check for the existence of the attribute, not its value.

## Approach
1. Replace `getAttribute` to `hasAttribute`
2. Fix test

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
