### PR TITLE
proxyless: use a separate script processing header in the proxyless mode

### DIFF
--- a/src/client/sandbox/node/document/writer.ts
+++ b/src/client/sandbox/node/document/writer.ts
@@ -13,6 +13,7 @@ import { processScript } from '../../../../processing/script';
 import styleProcessor from '../../../../processing/style';
 import { getProxyUrl, convertToProxyUrl } from '../../../utils/url';
 import SELF_REMOVING_SCRIPTS from '../../../../utils/self-removing-scripts';
+import settings from '../../../settings';
 
 const BEGIN_MARKER_TAG_NAME = 'hammerhead_write_marker_begin';
 const END_MARKER_TAG_NAME   = 'hammerhead_write_marker_end';
@@ -291,7 +292,7 @@ export default class DocumentWriter {
             let processedContent = this.contentForProcessing;
 
             if (isScriptElement(this.nonClosedEl))
-                processedContent = processScript(this.contentForProcessing, true, false, convertToProxyUrl);
+                processedContent = processScript(this.contentForProcessing, true, false, convertToProxyUrl, void 0, settings.get().proxyless);
             else if (isStyleElement(this.nonClosedEl))
                 processedContent = styleProcessor.process(this.contentForProcessing, getProxyUrl, true);
 

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -864,7 +864,7 @@ export default class ElementSandbox extends SandboxBase {
             return str;
 
         if (domUtils.isScriptElement(parentNode))
-            return processScript(str, true, false, urlUtils.convertToProxyUrl);
+            return processScript(str, true, false, urlUtils.convertToProxyUrl, void 0, settings.get().proxyless);
 
         if (domUtils.isStyleElement(parentNode))
             return styleProcessor.process(str, urlUtils.getProxyUrl);

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -287,7 +287,7 @@ export default class WindowSandbox extends SandboxBase {
 
         if (processedText) {
             if (isScriptElement(el))
-                return processScript(processedText, true, false, convertToProxyUrl);
+                return processScript(processedText, true, false, convertToProxyUrl, void 0, settings.get().proxyless);
             else if (isStyleElement(el))
                 return styleProcessor.process(processedText, getProxyUrl, true);
         }
@@ -622,7 +622,7 @@ export default class WindowSandbox extends SandboxBase {
                     return new nativeMethods.Blob();
 
                 if (WindowSandbox._isProcessableBlob(array, opts))
-                    array = [processScript(array.join(''), true, false, convertToProxyUrl)];
+                    array = [processScript(array.join(''), true, false, convertToProxyUrl, void 0, settings.get().proxyless)];
 
                 // NOTE: IE11 throws an error when the second parameter of the Blob function is undefined (GH-44)
                 // If the overridden function is called with one parameter, we need to call the original function
@@ -638,7 +638,7 @@ export default class WindowSandbox extends SandboxBase {
                     return new nativeMethods.File();
 
                 if (WindowSandbox._isProcessableBlob(array, opts))
-                    array = [processScript(array.join(''), true, false, convertToProxyUrl)];
+                    array = [processScript(array.join(''), true, false, convertToProxyUrl, void 0, settings.get().proxyless)];
 
                 return new nativeMethods.File(array, fileName, opts);
             });
@@ -1362,7 +1362,7 @@ export default class WindowSandbox extends SandboxBase {
                     if (isStyleEl)
                         processedValue = styleProcessor.process(processedValue, getProxyUrl, true);
                     else if (isScriptEl)
-                        processedValue = processScript(processedValue, true, false, convertToProxyUrl);
+                        processedValue = processScript(processedValue, true, false, convertToProxyUrl, void 0, settings.get().proxyless);
                     else {
                         processedValue = processHtml(processedValue, {
                             parentTag:        el.tagName,
@@ -1488,7 +1488,7 @@ export default class WindowSandbox extends SandboxBase {
                 return removeProcessingHeader(text);
             },
             setter: function (value) {
-                const processedValue = value ? processScript(String(value), true, false, convertToProxyUrl) : value;
+                const processedValue = value ? processScript(String(value), true, false, convertToProxyUrl, void 0, settings.get().proxyless) : value;
 
                 nativeMethods.scriptTextSetter.call(this, processedValue);
             },

--- a/src/processing/resources/script.ts
+++ b/src/processing/resources/script.ts
@@ -26,7 +26,8 @@ class ScriptResourceProcessor extends ResourceProcessorBase {
 
         if (!processedScript) {
             processedScript = processScript(script, true, false, urlReplacer,
-                ctx.destRes.headers[BUILTIN_HEADERS.serviceWorkerAllowed] as string);
+                ctx.destRes.headers[BUILTIN_HEADERS.serviceWorkerAllowed] as string,
+                ctx.proxyless);
             this.jsCache.set(script, processedScript);
         }
         else

--- a/src/processing/script/index.ts
+++ b/src/processing/script/index.ts
@@ -58,12 +58,12 @@ function removeSourceMap (code: string): string {
     return code.replace(SOURCEMAP_RE, '');
 }
 
-function postprocess (processed: string, withHeader: boolean, bom: string | null, strictMode: boolean, swScopeHeaderValue?: string): string {
+function postprocess (processed: string, withHeader: boolean, bom: string | null, strictMode: boolean, swScopeHeaderValue?: string, proxyless?: boolean): string {
     // NOTE: If the 'use strict' directive is not in the beginning of the file, it is ignored.
     // As we insert our header in the beginning of the script, we must put a new 'use strict'
     // before the header, otherwise it will be ignored.
     if (withHeader)
-        processed = addHeader(processed, strictMode, swScopeHeaderValue);
+        processed = addHeader(processed, strictMode, swScopeHeaderValue, proxyless);
 
     return bom ? bom + processed : processed;
 }
@@ -167,7 +167,7 @@ export function isScriptProcessed (code: string): boolean {
     return PROCESSED_SCRIPT_RE.test(code);
 }
 
-export function processScript (src: string, withHeader = false, wrapLastExprWithProcessHtml = false, resolver?: Function, swScopeHeaderValue?: string): string {
+export function processScript (src: string, withHeader = false, wrapLastExprWithProcessHtml = false, resolver?: Function, swScopeHeaderValue?: string, proxyless?: boolean): string {
     const { bom, preprocessed } = preprocess(src);
     const withoutHtmlComments   = removeHtmlComments(preprocessed);
     const { ast, isObject }     = analyze(withoutHtmlComments);
@@ -181,7 +181,7 @@ export function processScript (src: string, withHeader = false, wrapLastExprWith
 
     let processed = changes.length ? applyChanges(withoutHtmlComments, changes, isObject) : preprocessed;
 
-    processed = postprocess(processed, withHeader, bom, isStrictMode(ast), swScopeHeaderValue);
+    processed = postprocess(processed, withHeader, bom, isStrictMode(ast), swScopeHeaderValue, proxyless);
 
     if (isObject)
         processed = processed.replace(OBJECT_WRAPPER_RE, '$1');

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -235,7 +235,7 @@ export default class Proxy extends Router {
     _onRequest (req: http.IncomingMessage, res: http.ServerResponse | net.Socket, serverInfo: ServerInfo): void {
         // NOTE: Not a service request, execute the proxy pipeline.
         if (!this._route(req, res, serverInfo))
-            runRequestPipeline(req, res, serverInfo, this.openSessions);
+            runRequestPipeline(req, res, serverInfo, this.openSessions, this.options.proxyless);
     }
 
     _onUpgradeRequest (req: http.IncomingMessage, socket: net.Socket, head: Buffer, serverInfo: ServerInfo): void {

--- a/src/request-pipeline/context/index.ts
+++ b/src/request-pipeline/context/index.ts
@@ -125,7 +125,8 @@ export default class RequestPipelineContext extends BaseRequestPipelineContext {
 
     constructor (readonly req: IncomingMessage,
         readonly res: ServerResponse | Socket,
-        readonly serverInfo: ServerInfo) {
+        readonly serverInfo: ServerInfo,
+        readonly proxyless: boolean) {
         super(generateUniqueId());
         this._initParsedClientSyncCookie();
 

--- a/src/request-pipeline/index.ts
+++ b/src/request-pipeline/index.ts
@@ -7,8 +7,8 @@ import { respond404 } from '../utils/http';
 import logger from '../utils/logger';
 import requestPipelineStages from './stages';
 
-export async function run (req: http.IncomingMessage, res: http.ServerResponse | net.Socket, serverInfo: ServerInfo, openSessions: Map<string, Session>): Promise<void> {
-    const ctx = new RequestPipelineContext(req, res, serverInfo);
+export async function run (req: http.IncomingMessage, res: http.ServerResponse | net.Socket, serverInfo: ServerInfo, openSessions: Map<string, Session>, proxyless: boolean): Promise<void> {
+    const ctx = new RequestPipelineContext(req, res, serverInfo, proxyless);
 
     logger.proxy.onRequest(ctx);
 


### PR DESCRIPTION
I've checked this PR with the [TestCafe tests](https://github.com/DevExpress/testcafe/pull/7403).