### PR TITLE
fix: fiexed setting `max-age` to the cookies

### DIFF
--- a/src/client/sandbox/cookie/index.ts
+++ b/src/client/sandbox/cookie/index.ts
@@ -18,6 +18,7 @@ import {
 import { CookieRecord } from '../../../typings/cookie';
 import ChildWindowSandbox from '../child-window';
 import getTopOpenerWindow from '../../utils/get-top-opener-window';
+import { isNil } from 'lodash';
 
 const MIN_DATE_VALUE = new nativeMethods.date(0).toUTCString(); // eslint-disable-line new-cap
 
@@ -67,7 +68,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
     }
 
     getCookie (): string {
-        this.syncCookie();
+        this.syncCookie(true);
 
         // eslint-disable-next-line no-restricted-properties
         return settings.get().cookie || '';
@@ -103,7 +104,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
             let clientCookieStr = null;
 
             if ((!parsedCookie.expires || parsedCookie.expires === 'Infinity' || parsedCookie.expires > currentDate) &&
-                (isNaN(parsedCookie.maxAge) || parsedCookie.maxAge > 0))
+                (isNil(parsedCookie.maxAge) || isNaN(parsedCookie.maxAge) || parsedCookie.maxAge > 0))
                 clientCookieStr = cookieUtils.formatClientString(parsedCookie);
 
             CookieSandbox._updateClientCookieStr(parsedCookie.key, clientCookieStr);
@@ -117,7 +118,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
         }
     }
 
-    syncCookie (): void {
+    syncCookie (gettingCookies = false): void {
         const cookies           = nativeMethods.documentCookieGetter.call(this.document);
         const parsedCookies     = parseClientSyncCookieStr(cookies);
         const sessionId         = settings.get().sessionId;
@@ -134,6 +135,17 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
                 serverSyncCookies.push(parsedCookie);
             else if (parsedCookie.isWindowSync)
                 this.setCookie(parsedCookie);
+            else if (gettingCookies && parsedCookie.isClientSync) {
+                const currentDate = cookieUtils.getUTCDate();
+                const maxAge      = !isNil(parsedCookie.maxAge) && Number(parsedCookie.maxAge);
+                const expires     = Number(parsedCookie.expires);
+
+                if (!isNaN(maxAge) && maxAge * 1000 < currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||
+                        !isNaN(expires) && expires < currentDate.getTime()) {
+                    nativeMethods.documentCookieSetter.call(this.document, generateDeleteSyncCookieStr(parsedCookie));
+                    CookieSandbox._updateClientCookieStr(parsedCookie.key, null);
+                }
+            }
         }
 
         if (serverSyncCookies.length)
@@ -202,7 +214,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
         parsedCookie.isClientSync = true;
         parsedCookie.isWindowSync = true;
         parsedCookie.sid          = settings.get().sessionId;
-        parsedCookie.lastAccessed = new nativeMethods.date(); //eslint-disable-line new-cap
+        parsedCookie.lastAccessed = cookieUtils.getUTCDate();
 
         prepareSyncCookieProperties(parsedCookie);
 

--- a/src/client/sandbox/cookie/index.ts
+++ b/src/client/sandbox/cookie/index.ts
@@ -134,18 +134,6 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
                 serverSyncCookies.push(parsedCookie);
             else if (parsedCookie.isWindowSync)
                 this.setCookie(parsedCookie);
-            else if (parsedCookie.isClientSync) {
-                const currentDate = new nativeMethods.date(); //eslint-disable-line new-cap
-                const maxAge      = Number(parsedCookie.maxAge);
-                const expires     = Number(parsedCookie.expires);
-
-                if (!isNaN(maxAge) && maxAge * 1000 <= currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||
-                      !isNaN(expires) && expires < currentDate.getTime()) {
-                    nativeMethods.documentCookieSetter.call(this.document, generateDeleteSyncCookieStr(parsedCookie));
-                    CookieSandbox._updateClientCookieStr(parsedCookie.key, null);
-                    serverSyncCookies.push(parsedCookie);
-                }
-            }
         }
 
         if (serverSyncCookies.length)

--- a/src/client/sandbox/cookie/index.ts
+++ b/src/client/sandbox/cookie/index.ts
@@ -18,7 +18,7 @@ import {
 import { CookieRecord } from '../../../typings/cookie';
 import ChildWindowSandbox from '../child-window';
 import getTopOpenerWindow from '../../utils/get-top-opener-window';
-import { isLooseNull } from '../../utils/types';
+import { isNull } from '../../utils/types';
 
 const MIN_DATE_VALUE = new nativeMethods.date(0).toUTCString(); // eslint-disable-line new-cap
 
@@ -104,7 +104,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
             let clientCookieStr = null;
 
             if ((!parsedCookie.expires || parsedCookie.expires === 'Infinity' || parsedCookie.expires > currentDate) &&
-                (isLooseNull(parsedCookie.maxAge) || isNaN(parsedCookie.maxAge) || parsedCookie.maxAge > 0))
+                (isNull(parsedCookie.maxAge) || isNaN(parsedCookie.maxAge) || parsedCookie.maxAge > 0))
                 clientCookieStr = cookieUtils.formatClientString(parsedCookie);
 
             CookieSandbox._updateClientCookieStr(parsedCookie.key, clientCookieStr);
@@ -137,7 +137,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
                 this.setCookie(parsedCookie);
             else if (gettingCookies && parsedCookie.isClientSync) {
                 const currentDate = cookieUtils.getUTCDate();
-                const maxAge      = !isLooseNull(parsedCookie.maxAge) && Number(parsedCookie.maxAge);
+                const maxAge      = !isNull(parsedCookie.maxAge) && Number(parsedCookie.maxAge);
                 const expires     = Number(parsedCookie.expires);
 
                 if (!isNaN(maxAge) && maxAge * 1000 < currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||

--- a/src/client/sandbox/cookie/index.ts
+++ b/src/client/sandbox/cookie/index.ts
@@ -18,7 +18,7 @@ import {
 import { CookieRecord } from '../../../typings/cookie';
 import ChildWindowSandbox from '../child-window';
 import getTopOpenerWindow from '../../utils/get-top-opener-window';
-import { isNil } from 'lodash';
+import { isNullOrUndefined } from '../../utils/types';
 
 const MIN_DATE_VALUE = new nativeMethods.date(0).toUTCString(); // eslint-disable-line new-cap
 
@@ -104,7 +104,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
             let clientCookieStr = null;
 
             if ((!parsedCookie.expires || parsedCookie.expires === 'Infinity' || parsedCookie.expires > currentDate) &&
-                (isNil(parsedCookie.maxAge) || isNaN(parsedCookie.maxAge) || parsedCookie.maxAge > 0))
+                (isNullOrUndefined(parsedCookie.maxAge) || isNaN(parsedCookie.maxAge) || parsedCookie.maxAge > 0))
                 clientCookieStr = cookieUtils.formatClientString(parsedCookie);
 
             CookieSandbox._updateClientCookieStr(parsedCookie.key, clientCookieStr);
@@ -137,7 +137,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
                 this.setCookie(parsedCookie);
             else if (gettingCookies && parsedCookie.isClientSync) {
                 const currentDate = cookieUtils.getUTCDate();
-                const maxAge      = !isNil(parsedCookie.maxAge) && Number(parsedCookie.maxAge);
+                const maxAge      = !isNullOrUndefined(parsedCookie.maxAge) && Number(parsedCookie.maxAge);
                 const expires     = Number(parsedCookie.expires);
 
                 if (!isNaN(maxAge) && maxAge * 1000 < currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||

--- a/src/client/sandbox/cookie/index.ts
+++ b/src/client/sandbox/cookie/index.ts
@@ -18,7 +18,7 @@ import {
 import { CookieRecord } from '../../../typings/cookie';
 import ChildWindowSandbox from '../child-window';
 import getTopOpenerWindow from '../../utils/get-top-opener-window';
-import { isNullOrUndefined } from '../../utils/types';
+import { isLooseNull } from '../../utils/types';
 
 const MIN_DATE_VALUE = new nativeMethods.date(0).toUTCString(); // eslint-disable-line new-cap
 
@@ -104,7 +104,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
             let clientCookieStr = null;
 
             if ((!parsedCookie.expires || parsedCookie.expires === 'Infinity' || parsedCookie.expires > currentDate) &&
-                (isNullOrUndefined(parsedCookie.maxAge) || isNaN(parsedCookie.maxAge) || parsedCookie.maxAge > 0))
+                (isLooseNull(parsedCookie.maxAge) || isNaN(parsedCookie.maxAge) || parsedCookie.maxAge > 0))
                 clientCookieStr = cookieUtils.formatClientString(parsedCookie);
 
             CookieSandbox._updateClientCookieStr(parsedCookie.key, clientCookieStr);
@@ -137,7 +137,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
                 this.setCookie(parsedCookie);
             else if (gettingCookies && parsedCookie.isClientSync) {
                 const currentDate = cookieUtils.getUTCDate();
-                const maxAge      = !isNullOrUndefined(parsedCookie.maxAge) && Number(parsedCookie.maxAge);
+                const maxAge      = !isLooseNull(parsedCookie.maxAge) && Number(parsedCookie.maxAge);
                 const expires     = Number(parsedCookie.expires);
 
                 if (!isNaN(maxAge) && maxAge * 1000 < currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||

--- a/src/client/utils/cookie.ts
+++ b/src/client/utils/cookie.ts
@@ -62,7 +62,9 @@ export function parse (str) {
                 break;
 
             case 'max-age':
-                parsedCookie.maxAge = Number(value);
+                if (value)
+                    parsedCookie.maxAge = Number(value);
+
                 break;
 
             case 'path':

--- a/src/client/utils/types.ts
+++ b/src/client/utils/types.ts
@@ -3,6 +3,8 @@
 // Do not use any browser or node-specific API!
 // -------------------------------------------------------------
 
+import { isIE } from './browser';
+
 export function inaccessibleTypeToStr (obj) {
     return obj === null ? 'null' : 'undefined';
 }
@@ -17,8 +19,10 @@ export function isPrimitiveType (obj) {
     return objType !== 'object' && objType !== 'function';
 }
 
-export function isLooseNull (obj) {
+export function isNull (obj) {
     //Some times IE cannot compare null correctly
+    return isIE
     // eslint-disable-next-line eqeqeq
-    return obj == null;
+        ? obj == null
+        : obj === null;
 }

--- a/src/client/utils/types.ts
+++ b/src/client/utils/types.ts
@@ -16,3 +16,9 @@ export function isPrimitiveType (obj) {
 
     return objType !== 'object' && objType !== 'function';
 }
+
+export function isLooseNull (obj) {
+    //Some times IE cannot compare null correctly
+    // eslint-disable-next-line eqeqeq
+    return obj == null;
+}

--- a/src/client/utils/types.ts
+++ b/src/client/utils/types.ts
@@ -1,8 +1,3 @@
-// -------------------------------------------------------------
-// WARNING: this file is used by both the client and the server.
-// Do not use any browser or node-specific API!
-// -------------------------------------------------------------
-
 import { isIE } from './browser';
 
 export function inaccessibleTypeToStr (obj) {

--- a/src/typings/cookie.d.ts
+++ b/src/typings/cookie.d.ts
@@ -4,7 +4,7 @@ export interface CookieRecord {
     domain: string;
     path: string;
     expires: Date | 'Infinity';
-    maxAge: number | 'Infinity' | '-Infinity';
+    maxAge: number | 'Infinity' | '-Infinity' | null;
     lastAccessed: Date;
     syncKey?: string;
     cookieStr?: string;

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -116,7 +116,7 @@ export function parseSyncCookie (cookieStr: string): CookieRecord | null {
         path:         decodeURIComponent(parsedKey[4]),
         expires:      parsedKey[5] ? new Date(parseInt(parsedKey[5], TIME_RADIX)) : 'Infinity',
         lastAccessed: new Date(parseInt(parsedKey[6], TIME_RADIX)),
-        maxAge:       parseInt(parsedKey[7], TIME_RADIX),
+        maxAge:       parsedKey[7] ? parseInt(parsedKey[7], TIME_RADIX) : null,
         syncKey:      key,
 
         value,

--- a/test/client/fixtures/sandbox/cookie-test.js
+++ b/test/client/fixtures/sandbox/cookie-test.js
@@ -104,8 +104,8 @@ if (!isGreaterThanSafari15_1) { //eslint-disable-line camelcase
             })
             .then(function () {
                 return testCookies(storedForcedLocation, [
-                    'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) - 1) * 1000).toUTCString(),
-                    'Test2=Expired; max-age=' + 0,
+                    'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
+                    'Test2=Expired; max-age=' + 1,
                 ], '', 2000);
             })
             .then(function () {

--- a/test/client/fixtures/sandbox/cookie-test.js
+++ b/test/client/fixtures/sandbox/cookie-test.js
@@ -186,6 +186,17 @@ if (!isGreaterThanSafari15_1) { //eslint-disable-line camelcase
         strictEqual(parsedCookie.actual[0].value, '123=456=789');
     });
 
+    test('max age should be null if not specified', function () {
+        nativeMethods.documentCookieSetter.call(document, 's|sessionId|test|example.com|%2F||1fckm5ln2|=123;path=/');
+
+        var parsedCookie = sharedCookieUtils.parseClientSyncCookieStr(nativeMethods.documentCookieGetter.call(document));
+
+        strictEqual(parsedCookie.actual.length, 1);
+        strictEqual(parsedCookie.outdated.length, 0);
+        strictEqual(parsedCookie.actual[0].syncKey, 's|sessionId|test|example.com|%2F||1fckm5ln2|');
+        strictEqual(parsedCookie.actual[0].maxAge, null);
+    });
+
     module('server synchronization with client');
 
     test('process synchronization cookies on document.cookie getter', function () {

--- a/test/client/fixtures/sandbox/cookie-test.js
+++ b/test/client/fixtures/sandbox/cookie-test.js
@@ -104,7 +104,7 @@ if (!isGreaterThanSafari15_1) { //eslint-disable-line camelcase
             })
             .then(function () {
                 return testCookies(storedForcedLocation, [
-                    'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
+                    'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) - 1) * 1000).toUTCString(),
                     'Test2=Expired; max-age=' + 0,
                 ], '', 2000);
             })


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

[closes DevExpress/testcafe#7432]
[closes DevExpress/testcafe#2828]

## Purpose
_Describe the problem you want to address or the feature you want to implement._

If `max-age` isn't null when it isn't specified, `tough-cookie` won't take into account `expires`. It should be fixed. Also, we shouldn't additionally synchronize client cookies if we are setting them or synchronizing for another reason.

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._
1. Research the issue
2. Set `null` value in `max-age` if  it isn't specified
3. Additionally synchronize client cookies only when we get them
4. Add test

## References
https://stackoverflow.com/questions/74684772/deleted-cookies-arent-deleted-properly-and-still-sent-with-requests
https://github.com/DevExpress/testcafe/issues/7432
https://github.com/DevExpress/testcafe-hammerhead/issues/2828

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
