### PR TITLE
Temporary remove some checks & errors due to bad support of optional chaining

### DIFF
--- a/src/client/sandbox/code-instrumentation/methods.ts
+++ b/src/client/sandbox/code-instrumentation/methods.ts
@@ -73,7 +73,7 @@ export default class MethodCallInstrumentation extends SandboxBase {
                     MethodCallInstrumentation._error(`Cannot call method '${methName}' of ${typeUtils.inaccessibleTypeToStr(owner)}`);
 
                 if (typeof owner[methName] !== 'function')
-                    MethodCallInstrumentation._error(`'${methName}' is not a function`);
+                    return void 0
 
                 // OPTIMIZATION: previously we've performed the
                 // `this.methodWrappers.hasOwnProperty(methName)`

--- a/src/client/sandbox/code-instrumentation/properties/index.ts
+++ b/src/client/sandbox/code-instrumentation/properties/index.ts
@@ -89,7 +89,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
 
     private static _propertyGetter (owner: any, propName: any, optional = false) {
         if (isNullOrUndefined(owner) && !optional)
-            PropertyAccessorsInstrumentation._error(`Cannot read property '${propName}' of ${inaccessibleTypeToStr(owner)}`);
+            return void 0;
 
         if (typeof propName === 'string' && shouldInstrumentProperty(propName)) {
             if (optional && isNullOrUndefined(owner))


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose

closes https://github.com/DevExpress/testcafe/issues/7387 & https://github.com/DevExpress/testcafe/issues/7424

## Approach

The goal here is to prevent testcafe to throw blocking errors whereas the code is totally fine. If there was a syntax error it should throw inside the browser, caught by linter, code editor, whatever, but testcafe logging the callstack shouldn't be that much a feature.

If you really want to maintain testcafe wrapping, checking, logging callstack feature then a better check for the 1st issue should be something like

*if object is undefined and there is optional chaining in chain of calls, return undefined, else throw*

And for the 2nd

*if property access on undefined and there is optional chaining in chain of calls, return undefined, else throw*

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
