### PR TITLE
fix: hammerhead no longer throws an error due to missing dns.setDefaultResultOrder

### DIFF
--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -83,8 +83,10 @@ export default class Proxy extends Router {
 
         super(prepareOptions);
 
-        // NOTE: to avoid https://github.com/nodejs/node/issues/40537
-        dns.setDefaultResultOrder('ipv4first');
+        // NOTE: to avoid https://github.com/DevExpress/testcafe/issues/7447
+        if (typeof dns.setDefaultResultOrder === 'function')
+            // NOTE: to avoid https://github.com/nodejs/node/issues/40537
+            dns.setDefaultResultOrder('ipv4first');
 
         const {
             ssl,


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Using `dns.setDefaultResultOrder('ipv4first')` ([src/proxy/index.ts#L87](https://github.com/DevExpress/testcafe-hammerhead/blob/4190c0031a6ffa0768dae7db43dae3f4f6e9f0c4/src/proxy/index.ts#L87)) results in an error when run with some versions of Node.js where this function is not yet implemented.

## Approach
`dns.setDefaultResultOrder` is intended to change the default protocol (ipv6) used for `localhost` in Node.js v17. There is no need to use this feature, or anything similar, in versions of Node.js that don't have it.

## References
https://github.com/nodejs/node/issues/40537
Closes https://github.com/DevExpress/testcafe/issues/7447

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
