### PR TITLE
fix: fixed function findParent

### DIFF
--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -858,13 +858,13 @@ function getParent (el) {
 
 export function findParent (node, includeSelf = false, predicate) {
     if (!includeSelf)
-        node = nativeMethods.nodeParentNodeGetter.call(node);
+        node = getParent(node);
 
     while (node) {
         if (typeof predicate !== 'function' || predicate(node))
             return node;
 
-        node = nativeMethods.nodeParentNodeGetter.call(node);
+        node = getParent(node);
     }
 
     return null;

--- a/test/client/fixtures/utils/dom-test.js
+++ b/test/client/fixtures/utils/dom-test.js
@@ -1100,7 +1100,11 @@ if (window.HTMLElement.prototype.attachShadow) {
         div.appendChild(input);
         root.appendChild(div);
 
-        var parent = domUtils.findParent(input, false, (el) => !domUtils.isShadowRoot(el) && nativeMethods.getAttribute.call(el, 'id') === 'host');
+        function findParenPredicate (el) {
+            return !domUtils.isShadowRoot(el) && nativeMethods.getAttribute.call(el, 'id') === 'host';
+        }
+
+        var parent = domUtils.findParent(input, false, findParenPredicate);
 
         deepEqual(parent, host);
         document.body.removeChild(host);

--- a/test/client/fixtures/utils/dom-test.js
+++ b/test/client/fixtures/utils/dom-test.js
@@ -1088,6 +1088,24 @@ if (window.HTMLElement.prototype.attachShadow) {
         document.body.removeChild(host);
     });
 
+    test('"findParent" should work properly for elements inside shadowDOM', function () {
+        var host  = document.createElement('div');
+        var root  = host.attachShadow({ mode: 'open' });
+        var div   = document.createElement('div');
+        var input = document.createElement('input');
+
+        nativeMethods.setAttribute.call(host, 'id', 'host');
+
+        document.body.appendChild(host);
+        div.appendChild(input);
+        root.appendChild(div);
+
+        var parent = domUtils.findParent(input, false, (el) => !domUtils.isShadowRoot(el) && nativeMethods.getAttribute.call(el, 'id') === 'host');
+
+        deepEqual(parent, host);
+        document.body.removeChild(host);
+    });
+
     test('"getParents" should work property for elements with slots/templates', function () {
         var template = document.createElement('template');
 


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
In some cases, we try to find parents by an element in `shadowRoot`, but we don't continue finding after `shadowRoot`

## Approach
1. Add test
2. Get `host` of the shadow root

## References
https://github.com/DevExpress/testcafe/issues/7454

[testcafe-hammerhead-28.2.6.zip](https://github.com/DevExpress/testcafe-hammerhead/files/10409050/testcafe-hammerhead-28.2.6.zip)

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
