### PR TITLE
fix: fixed clearing cookies

### DIFF
--- a/src/client/sandbox/cookie/index.ts
+++ b/src/client/sandbox/cookie/index.ts
@@ -137,11 +137,11 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
                 this.setCookie(parsedCookie);
             else if (gettingCookies && parsedCookie.isClientSync) {
                 const currentDate = cookieUtils.getUTCDate();
-                const maxAge      = !isNull(parsedCookie.maxAge) && Number(parsedCookie.maxAge) || void 0;
+                const maxAge      = !isNull(parsedCookie.maxAge) && Number(parsedCookie.maxAge);
                 const expires     = Number(parsedCookie.expires);
 
-                if (!isNaN(maxAge) && maxAge * 1000 < currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||
-                        !isNaN(expires) && expires < currentDate.getTime()) {
+                if (typeof maxAge === 'number' && maxAge * 1000 < currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||
+                    typeof expires === 'number' && expires < currentDate.getTime()) {
                     nativeMethods.documentCookieSetter.call(this.document, generateDeleteSyncCookieStr(parsedCookie));
                     CookieSandbox._updateClientCookieStr(parsedCookie.key, null);
                 }

--- a/src/client/sandbox/cookie/index.ts
+++ b/src/client/sandbox/cookie/index.ts
@@ -140,8 +140,8 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
                 const maxAge      = !isNull(parsedCookie.maxAge) && Number(parsedCookie.maxAge);
                 const expires     = Number(parsedCookie.expires);
 
-                if (isNumber(maxAge) && maxAge * 1000 < currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||
-                    isNumber(expires) && expires < currentDate.getTime()) {
+                if (!isNaN(maxAge) && isNumber(maxAge) && maxAge * 1000 < currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||
+                    !isNaN(expires) && isNumber(expires) && expires < currentDate.getTime()) {
                     nativeMethods.documentCookieSetter.call(this.document, generateDeleteSyncCookieStr(parsedCookie));
                     CookieSandbox._updateClientCookieStr(parsedCookie.key, null);
                 }

--- a/src/client/sandbox/cookie/index.ts
+++ b/src/client/sandbox/cookie/index.ts
@@ -137,7 +137,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
                 this.setCookie(parsedCookie);
             else if (gettingCookies && parsedCookie.isClientSync) {
                 const currentDate = cookieUtils.getUTCDate();
-                const maxAge      = !isNull(parsedCookie.maxAge) && Number(parsedCookie.maxAge);
+                const maxAge      = !isNull(parsedCookie.maxAge) && Number(parsedCookie.maxAge) || void 0;
                 const expires     = Number(parsedCookie.expires);
 
                 if (!isNaN(maxAge) && maxAge * 1000 < currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||

--- a/src/client/sandbox/cookie/index.ts
+++ b/src/client/sandbox/cookie/index.ts
@@ -18,7 +18,7 @@ import {
 import { CookieRecord } from '../../../typings/cookie';
 import ChildWindowSandbox from '../child-window';
 import getTopOpenerWindow from '../../utils/get-top-opener-window';
-import { isNull } from '../../utils/types';
+import { isNull, isNumber } from '../../utils/types';
 
 const MIN_DATE_VALUE = new nativeMethods.date(0).toUTCString(); // eslint-disable-line new-cap
 
@@ -140,8 +140,8 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
                 const maxAge      = !isNull(parsedCookie.maxAge) && Number(parsedCookie.maxAge);
                 const expires     = Number(parsedCookie.expires);
 
-                if (typeof maxAge === 'number' && maxAge * 1000 < currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||
-                    typeof expires === 'number' && expires < currentDate.getTime()) {
+                if (isNumber(maxAge) && maxAge * 1000 < currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||
+                    isNumber(expires) && expires < currentDate.getTime()) {
                     nativeMethods.documentCookieSetter.call(this.document, generateDeleteSyncCookieStr(parsedCookie));
                     CookieSandbox._updateClientCookieStr(parsedCookie.key, null);
                 }

--- a/src/client/sandbox/upload/info-manager.ts
+++ b/src/client/sandbox/upload/info-manager.ts
@@ -6,6 +6,7 @@ import Promise from 'pinkie';
 import { GetUploadedFilesServiceMessage, StoreUploadedFilesServiceMessage } from '../../../typings/upload';
 import Transport from '../../transport';
 import nativeMethods from '../native-methods';
+import { isNumber } from '../../utils/types';
 
 // NOTE: https://html.spec.whatwg.org/multipage/forms.html#fakepath-srsly.
 const FAKE_PATH_STRING = 'C:\\fakepath\\';
@@ -140,7 +141,7 @@ export default class UploadInfoManager {
                     name: file.name,
                 };
 
-                if (typeof file.lastModified === 'number')
+                if (isNumber(file.lastModified))
                     info.lastModified = file.lastModified;
 
                 if (file.lastModifiedDate)

--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -17,6 +17,7 @@ import {
 
 import { getNativeQuerySelectorAll } from './query-selector';
 import { instanceAndPrototypeToStringAreEqual } from './feature-detection';
+import { isNumber } from './types';
 
 let scrollbarSize = 0;
 
@@ -900,7 +901,7 @@ export function isInputWithoutSelectionProperties (el): boolean {
     if (!isNumberOrEmailInput(el))
         return false;
 
-    const hasSelectionProperties = typeof el.selectionStart === 'number' && typeof el.selectionEnd === 'number';
+    const hasSelectionProperties = isNumber(el.selectionStart) && isNumber(el.selectionEnd);
 
     return !hasSelectionProperties;
 }

--- a/src/client/utils/types.ts
+++ b/src/client/utils/types.ts
@@ -21,3 +21,7 @@ export function isNull (obj) {
         ? obj == null
         : obj === null;
 }
+
+export function isNumber (val) {
+    return typeof val === 'number';
+}

--- a/test/client/fixtures/sandbox/cookie-test.js
+++ b/test/client/fixtures/sandbox/cookie-test.js
@@ -98,16 +98,16 @@ if (!isGreaterThanSafari15_1) { //eslint-disable-line camelcase
             })
             .then(function () {
                 return testCookies(storedForcedLocation, [
-                    'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
-                    'Test2=Expired; max-age=' + 1,
-                ], 'Test1=Expired; Test2=Expired');
+                    'TestNotExpired1=value; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
+                    'TestNotExpired2=value; max-age=' + 1,
+                ], 'TestNotExpired1=value; TestNotExpired2=value');
             })
             .then(function () {
                 return testCookies(storedForcedLocation, [
-                    'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
-                    'Test2=Expired; max-age=' + 1,
-                    'Test3=Expired',
-                ], 'Test3=Expired', 2000);
+                    'TestExpired1=value; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
+                    'TestExpired2=value; max-age=' + 1,
+                    'TestNotExpired3=value',
+                ], 'TestNotExpired3=value', 2000);
             })
             .then(function () {
                 return destLocation.forceLocation(storedForcedLocation);

--- a/test/client/fixtures/sandbox/cookie-test.js
+++ b/test/client/fixtures/sandbox/cookie-test.js
@@ -106,7 +106,8 @@ if (!isGreaterThanSafari15_1) { //eslint-disable-line camelcase
                 return testCookies(storedForcedLocation, [
                     'Test1=Expired; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
                     'Test2=Expired; max-age=' + 1,
-                ], '', 2000);
+                    'Test3=Expired',
+                ], 'Test3=Expired', 2000);
             })
             .then(function () {
                 return destLocation.forceLocation(storedForcedLocation);


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Fix clearing cookies when the `max-age` property has the value `null`. When it is `null` we assign `false` to variable `maxAge` and in the next check `!isNaN` we get true, but we shouldn't clear the cookie.

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
