### PR TITLE
fix: removed cookies when `max-age` equal to the lifespan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "28.4.1",
+  "version": "28.4.2",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/client/sandbox/cookie/index.ts
+++ b/src/client/sandbox/cookie/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import MessageSandbox from '../event/message';
 import UnloadSandbox from '../event/unload';
 import SandboxBase from '../base';
@@ -118,6 +119,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
         }
     }
 
+    /* eslint-disable */
     syncCookie (gettingCookies = false): void {
         const cookies           = nativeMethods.documentCookieGetter.call(this.document);
         const parsedCookies     = parseClientSyncCookieStr(cookies);
@@ -140,7 +142,7 @@ class CookieSandboxProxyStrategy implements CookieSandboxStrategy {
                 const maxAge      = !isNull(parsedCookie.maxAge) && Number(parsedCookie.maxAge);
                 const expires     = Number(parsedCookie.expires);
 
-                if (!isNaN(maxAge) && isNumber(maxAge) && maxAge * 1000 < currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||
+                if (!isNaN(maxAge) && isNumber(maxAge) && maxAge * 1000 <= currentDate.getTime() - parsedCookie.lastAccessed.getTime() ||
                     !isNaN(expires) && isNumber(expires) && expires < currentDate.getTime()) {
                     nativeMethods.documentCookieSetter.call(this.document, generateDeleteSyncCookieStr(parsedCookie));
                     CookieSandbox._updateClientCookieStr(parsedCookie.key, null);

--- a/test/client/fixtures/sandbox/cookie-test.js
+++ b/test/client/fixtures/sandbox/cookie-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // NOTE: You should clear a browser's cookie if tests are fail,
 // because document.cookie can contains cookie from another sites which was run through playground
 var sharedCookieUtils = hammerhead.sharedUtils.cookie;
@@ -107,7 +108,8 @@ if (!isGreaterThanSafari15_1) { //eslint-disable-line camelcase
                     'TestExpired1=value; expires=' + new Date((Math.floor(Date.now() / 1000) + 1) * 1000).toUTCString(),
                     'TestExpired2=value; max-age=' + 1,
                     'TestNotExpired3=value',
-                ], 'TestNotExpired3=value', 2000);
+                    'TestExpired4=value; max-age=' + 2,
+                ], 'TestNotExpired3=value', 2100);
             })
             .then(function () {
                 return destLocation.forceLocation(storedForcedLocation);


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Remove cookies when `max-age` equal to the lifespan

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
