### PR TITLE
fix: ExternalCookies type definitions and request cookies passing

### DIFF
--- a/src/request-pipeline/header-transforms/transforms.ts
+++ b/src/request-pipeline/header-transforms/transforms.ts
@@ -117,8 +117,14 @@ export const requestTransforms = {
 };
 
 export const forcedRequestTransforms = {
-    [BUILTIN_HEADERS.cookie]: (_src: string, ctx: RequestPipelineContext) =>
-        shouldOmitCredentials(ctx) ? void 0 : ctx.session.cookies.getHeader(ctx.dest) || void 0,
+    [BUILTIN_HEADERS.cookie]: (_src: string, ctx: RequestPipelineContext) => {
+        const isApiRequest = !!ctx.req.headers[BUILTIN_HEADERS.isApiRequest];
+
+        if (isApiRequest)
+            return ctx.req.headers[BUILTIN_HEADERS.cookie] || void 0;
+
+        return shouldOmitCredentials(ctx) ? void 0 : ctx.session.cookies.getHeader(ctx.dest) || void 0;
+    },
 };
 
 // Response headers

--- a/test/functional/run-testcafe-functional-tests.sh
+++ b/test/functional/run-testcafe-functional-tests.sh
@@ -2,7 +2,7 @@
 
 mkdir ../testcafe
 cd ../testcafe
-git clone --branch Babich-fix-request https://github.com/Artem-Babich/testcafe.git .
+git clone https://github.com/DevExpress/testcafe .
 
 # NOTE: testcafe's Gulpfile.js tries to alias the 'travis' task to the value of GULP_TASK
 # We should define a valid testcafe's task in GULP_TASK before running 'npm install',

--- a/test/functional/run-testcafe-functional-tests.sh
+++ b/test/functional/run-testcafe-functional-tests.sh
@@ -2,11 +2,11 @@
 
 mkdir ../testcafe
 cd ../testcafe
-git clone https://github.com/DevExpress/testcafe .
+git clone --branch Babich-fix-request https://github.com/Artem-Babich/testcafe.git .
 
 # NOTE: testcafe's Gulpfile.js tries to alias the 'travis' task to the value of GULP_TASK
 # We should define a valid testcafe's task in GULP_TASK before running 'npm install',
-# which automatically builds testcafe with Gulp. 
+# which automatically builds testcafe with Gulp.
 export GULP_TASK="test-functional-local-headless-chrome"
 
 npm install testcafe-hammerhead ../testcafe-hammerhead --save

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -104,15 +104,15 @@ declare module 'testcafe-hammerhead' {
     }
 
     interface ExternalCookies {
-        name: string;
-        value: string;
-        domain: string;
-        path: string;
-        expires: Date;
-        maxAge: number | 'Infinity' | '-Infinity';
-        secure: boolean;
-        httpOnly: boolean;
-        sameSite: string;
+        name?: string;
+        value?: string;
+        domain?: string;
+        path?: string;
+        expires?: Date;
+        maxAge?: number | 'Infinity' | '-Infinity';
+        secure?: boolean;
+        httpOnly?: boolean;
+        sameSite?: string;
     }
 
     interface Cookies {


### PR DESCRIPTION
## Purpose
ExternalCookies object is used for filtering cookies. However, its real structure is different form the structure in type definintions
Previously we did not attach cookies to the cross-domain request even if withCredentials property is set to true. We collect such cookies on the testcafe side, so we just need to get these cookies from the source request and pass them then

## Approach
Fix definitions

## References

https://github.com/DevExpress/testcafe/pull/7504

## Pre-Merge TODO
- [x] Make sure that existing tests do not fail
- [ ] Remove fork dependency
