### PR TITLE
proxyless: turned off overriding in sandbox-node for proxyless

### DIFF
--- a/src/client/sandbox/base.ts
+++ b/src/client/sandbox/base.ts
@@ -35,6 +35,10 @@ export default class SandboxBase extends EventEmitter {
         return true;
     }
 
+    static get isProxyless (): boolean {
+        return !!settings.get().proxyless;
+    }
+
     attach (window: Window & typeof globalThis, document?: Document): void {
         this.window    = window;
         this.document  = document || window.document;

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -49,7 +49,7 @@ export default class DocumentSandbox extends SandboxBase {
     }
 
     static forceProxySrcForImageIfNecessary (element: Element): void {
-        if (settings.get().proxyless)
+        if (SandboxBase.isProxyless)
             return;
 
         if (isImgElement(element) && settings.get().forceProxySrcForImage)

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -48,6 +48,14 @@ export default class DocumentSandbox extends SandboxBase {
         super();
     }
 
+    static forceProxySrcForImageIfNecessary (element: Element): void {
+        if (settings.get().proxyless)
+            return;
+
+        if (isImgElement(element) && settings.get().forceProxySrcForImage)
+            element[INTERNAL_PROPS.forceProxySrcForImage] = true;
+    }
+
     private static _isDocumentInDesignMode (doc: HTMLDocument): boolean {
         return doc.designMode === 'on';
     }
@@ -252,6 +260,7 @@ export default class DocumentSandbox extends SandboxBase {
         overrideFunction(docPrototype, 'createElement', function (this: Document, ...args: [string, ElementCreationOptions?]) {
             const el = nativeMethods.createElement.apply(this, args);
 
+            DocumentSandbox.forceProxySrcForImageIfNecessary(el);
             domProcessor.processElement(el, convertToProxyUrl);
             documentSandbox._nodeSandbox.processNodes(el);
 
@@ -263,6 +272,7 @@ export default class DocumentSandbox extends SandboxBase {
         overrideFunction(docPrototype, 'createElementNS', function (this: Document, ...args: [string, string, (string | ElementCreationOptions)?]) {
             const el = nativeMethods.createElementNS.apply(this, args);
 
+            DocumentSandbox.forceProxySrcForImageIfNecessary(el);
             domProcessor.processElement(el, convertToProxyUrl);
             documentSandbox._nodeSandbox.processNodes(el);
 

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -140,7 +140,7 @@ export default class DocumentSandbox extends SandboxBase {
         if (this._documentTitleStorageInitializer && !partialInitializationForNotLoadedIframe)
             this.overrideTitle(docPrototype, documentSandbox);
 
-        if (this.proxyless)
+        if (SandboxBase.isProxyless)
             return;
 
         this.overrideOpen(window, document, documentSandbox);

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -145,11 +145,6 @@ export default class DocumentSandbox extends SandboxBase {
         const docPrototype     = window.Document.prototype;
         const htmlDocPrototype = window.HTMLDocument.prototype;
 
-        this.overrideOpen(window, document, documentSandbox);
-        this.overrideClose(window, document, documentSandbox);
-        this.overrideWrite(window, document, documentSandbox);
-        this.overrideWriteln(window, document, documentSandbox);
-
         this.overrideCreateElement(docPrototype, documentSandbox);
         this.overrideCreateElementNS(docPrototype, documentSandbox);
         this.overrideCreateDocumentFragment(docPrototype, documentSandbox);
@@ -163,6 +158,11 @@ export default class DocumentSandbox extends SandboxBase {
 
         if (this.proxyless)
             return;
+
+        this.overrideOpen(window, document, documentSandbox);
+        this.overrideClose(window, document, documentSandbox);
+        this.overrideWrite(window, document, documentSandbox);
+        this.overrideWriteln(window, document, documentSandbox);
 
         if (nativeMethods.documentDocumentURIGetter)
             this.overrideDocumentURI(docPrototype);

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -48,14 +48,6 @@ export default class DocumentSandbox extends SandboxBase {
         super();
     }
 
-    static forceProxySrcForImageIfNecessary (element: Element): void {
-        if (settings.get().proxyless)
-            return;
-
-        if (isImgElement(element) && settings.get().forceProxySrcForImage)
-            element[INTERNAL_PROPS.forceProxySrcForImage] = true;
-    }
-
     private static _isDocumentInDesignMode (doc: HTMLDocument): boolean {
         return doc.designMode === 'on';
     }
@@ -260,7 +252,6 @@ export default class DocumentSandbox extends SandboxBase {
         overrideFunction(docPrototype, 'createElement', function (this: Document, ...args: [string, ElementCreationOptions?]) {
             const el = nativeMethods.createElement.apply(this, args);
 
-            DocumentSandbox.forceProxySrcForImageIfNecessary(el);
             domProcessor.processElement(el, convertToProxyUrl);
             documentSandbox._nodeSandbox.processNodes(el);
 
@@ -272,7 +263,6 @@ export default class DocumentSandbox extends SandboxBase {
         overrideFunction(docPrototype, 'createElementNS', function (this: Document, ...args: [string, string, (string | ElementCreationOptions)?]) {
             const el = nativeMethods.createElementNS.apply(this, args);
 
-            DocumentSandbox.forceProxySrcForImageIfNecessary(el);
             domProcessor.processElement(el, convertToProxyUrl);
             documentSandbox._nodeSandbox.processNodes(el);
 

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -162,13 +162,15 @@ export default class DocumentSandbox extends SandboxBase {
         this.overrideDomain(window, docPrototype, htmlDocPrototype);
         this.overrideStyleSheets(docPrototype, documentSandbox);
 
-        if (!this.proxyless)
-            this.overrideCookie(window, documentSandbox);
-
         this.overrideActiveElement(docPrototype, documentSandbox);
 
         if (this._documentTitleStorageInitializer && !partialInitializationForNotLoadedIframe)
             this.overrideTitle(docPrototype, documentSandbox);
+
+        if (this.proxyless)
+            return;
+
+        this.overrideCookie(window, documentSandbox);
     }
 
     private overrideOpen (window: Window, document: Document, documentSandbox: this) {

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -145,10 +145,6 @@ export default class DocumentSandbox extends SandboxBase {
         const docPrototype     = window.Document.prototype;
         const htmlDocPrototype = window.HTMLDocument.prototype;
 
-        this.overrideStyleSheets(docPrototype, documentSandbox);
-
-        this.overrideActiveElement(docPrototype, documentSandbox);
-
         if (this._documentTitleStorageInitializer && !partialInitializationForNotLoadedIframe)
             this.overrideTitle(docPrototype, documentSandbox);
 
@@ -170,7 +166,9 @@ export default class DocumentSandbox extends SandboxBase {
         this.overrideReferrer(docPrototype, htmlDocPrototype);
         this.overrideURL(docPrototype, htmlDocPrototype);
         this.overrideDomain(window, docPrototype, htmlDocPrototype);
+        this.overrideStyleSheets(docPrototype, documentSandbox);
         this.overrideCookie(window, documentSandbox);
+        this.overrideActiveElement(docPrototype, documentSandbox);
     }
 
     private overrideOpen (window: Window, document: Document, documentSandbox: this) {

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -154,12 +154,6 @@ export default class DocumentSandbox extends SandboxBase {
         this.overrideCreateElementNS(docPrototype, documentSandbox);
         this.overrideCreateDocumentFragment(docPrototype, documentSandbox);
 
-        if (nativeMethods.documentDocumentURIGetter)
-            this.overrideDocumentURI(docPrototype);
-
-        this.overrideReferrer(docPrototype, htmlDocPrototype);
-        this.overrideURL(docPrototype, htmlDocPrototype);
-        this.overrideDomain(window, docPrototype, htmlDocPrototype);
         this.overrideStyleSheets(docPrototype, documentSandbox);
 
         this.overrideActiveElement(docPrototype, documentSandbox);
@@ -170,6 +164,12 @@ export default class DocumentSandbox extends SandboxBase {
         if (this.proxyless)
             return;
 
+        if (nativeMethods.documentDocumentURIGetter)
+            this.overrideDocumentURI(docPrototype);
+
+        this.overrideReferrer(docPrototype, htmlDocPrototype);
+        this.overrideURL(docPrototype, htmlDocPrototype);
+        this.overrideDomain(window, docPrototype, htmlDocPrototype);
         this.overrideCookie(window, documentSandbox);
     }
 

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -145,10 +145,6 @@ export default class DocumentSandbox extends SandboxBase {
         const docPrototype     = window.Document.prototype;
         const htmlDocPrototype = window.HTMLDocument.prototype;
 
-        this.overrideCreateElement(docPrototype, documentSandbox);
-        this.overrideCreateElementNS(docPrototype, documentSandbox);
-        this.overrideCreateDocumentFragment(docPrototype, documentSandbox);
-
         this.overrideStyleSheets(docPrototype, documentSandbox);
 
         this.overrideActiveElement(docPrototype, documentSandbox);
@@ -163,6 +159,10 @@ export default class DocumentSandbox extends SandboxBase {
         this.overrideClose(window, document, documentSandbox);
         this.overrideWrite(window, document, documentSandbox);
         this.overrideWriteln(window, document, documentSandbox);
+
+        this.overrideCreateElement(docPrototype, documentSandbox);
+        this.overrideCreateElementNS(docPrototype, documentSandbox);
+        this.overrideCreateDocumentFragment(docPrototype, documentSandbox);
 
         if (nativeMethods.documentDocumentURIGetter)
             this.overrideDocumentURI(docPrototype);

--- a/src/client/sandbox/node/document/index.ts
+++ b/src/client/sandbox/node/document/index.ts
@@ -144,6 +144,9 @@ export default class DocumentSandbox extends SandboxBase {
         if (this._documentTitleStorageInitializer && !partialInitializationForNotLoadedIframe)
             this.overrideTitle(window);
 
+        this.overrideStyleSheets(window);
+        this.overrideActiveElement(window);
+
         if (SandboxBase.isProxyless)
             return;
 
@@ -151,7 +154,6 @@ export default class DocumentSandbox extends SandboxBase {
         this.overrideClose(window, document);
         this.overrideWrite(window, document);
         this.overrideWriteln(window, document);
-
         this.overrideCreateElement(window);
         this.overrideCreateElementNS(window);
         this.overrideCreateDocumentFragment(window);
@@ -162,9 +164,7 @@ export default class DocumentSandbox extends SandboxBase {
         this.overrideReferrer(window);
         this.overrideURL(window);
         this.overrideDomain(window);
-        this.overrideStyleSheets(window);
         this.overrideCookie(window);
-        this.overrideActiveElement(window);
     }
 
     private overrideOpen (window, document) {

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -1097,15 +1097,7 @@ export default class ElementSandbox extends SandboxBase {
                 ElementSandbox._setProxiedSrc(e.el);
         });
 
-        overrideDescriptor(window.HTMLElement.prototype, 'onload', {
-            getter: null,
-            setter: function (handler) {
-                if (domUtils.isImgElement(this) && isValidEventListener(handler))
-                    ElementSandbox._setProxiedSrc(this);
-
-                nativeMethods.htmlElementOnloadSetter.call(this, handler);
-            },
-        });
+        this.overrideDescriptorOnload(window);
     }
 
     private _setValidBrowsingContextOnElementClick (window): void {
@@ -1136,6 +1128,18 @@ export default class ElementSandbox extends SandboxBase {
         const storedAttr = nativeMethods.getAttribute.call(el, DomProcessor.getStoredAttrName('target'));
 
         el.setAttribute('target', storedAttr || attr);
+    }
+
+    private overrideDescriptorOnload (window) {
+        overrideDescriptor(window.HTMLElement.prototype, 'onload', {
+            getter: null,
+            setter: function (handler) {
+                if (domUtils.isImgElement(this) && isValidEventListener(handler))
+                    ElementSandbox._setProxiedSrc(this);
+
+                nativeMethods.htmlElementOnloadSetter.call(this, handler);
+            },
+        });
     }
 
     processElement (el: Element): void {

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -1032,6 +1032,48 @@ export default class ElementSandbox extends SandboxBase {
         if (nativeMethods.remove)
             overrideFunction(window.Element.prototype, 'remove', this.overriddenMethods.remove);
 
+        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentHTML', this.overriddenMethods.insertAdjacentHTML);
+        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentElement', this.overriddenMethods.insertAdjacentElement);
+        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentText', this.overriddenMethods.insertAdjacentText);
+
+        if (this.proxyless)
+            return;
+
+        overrideFunction(window.Element.prototype, 'setAttribute', this.overriddenMethods.setAttribute);
+        overrideFunction(window.Element.prototype, 'setAttributeNS', this.overriddenMethods.setAttributeNS);
+        overrideFunction(window.Element.prototype, 'getAttribute', this.overriddenMethods.getAttribute);
+        overrideFunction(window.Element.prototype, 'getAttributeNS', this.overriddenMethods.getAttributeNS);
+        overrideFunction(window.Element.prototype, 'removeAttribute', this.overriddenMethods.removeAttribute);
+        overrideFunction(window.Element.prototype, 'removeAttributeNS', this.overriddenMethods.removeAttributeNS);
+        overrideFunction(window.Element.prototype, 'removeAttributeNode', this.overriddenMethods.removeAttributeNode);
+        overrideFunction(window.Element.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
+        overrideFunction(window.Element.prototype, 'querySelector', this.overriddenMethods.querySelector);
+        overrideFunction(window.Element.prototype, 'querySelectorAll', this.overriddenMethods.querySelectorAll);
+        overrideFunction(window.Element.prototype, 'hasAttribute', this.overriddenMethods.hasAttribute);
+        overrideFunction(window.Element.prototype, 'hasAttributeNS', this.overriddenMethods.hasAttributeNS);
+        overrideFunction(window.Element.prototype, 'hasAttributes', this.overriddenMethods.hasAttributes);
+
+        // if (nativeMethods.attachShadow)
+        //     overrideFunction(window.Element.prototype, 'attachShadow', this.overriddenMethods.attachShadow);
+
+        overrideFunction(window.Node.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
+        // overrideFunction(window.Node.prototype, 'appendChild', this.overriddenMethods.appendChild);
+        // overrideFunction(window.Node.prototype, 'removeChild', this.overriddenMethods.removeChild);
+        // overrideFunction(window.Node.prototype, 'insertBefore', this.overriddenMethods.insertBefore);
+        overrideFunction(window.Node.prototype, 'replaceChild', this.overriddenMethods.replaceChild);
+
+        // if (nativeMethods.append)
+        //     overrideFunction(window.Element.prototype, 'append', this.overriddenMethods.append);
+
+        // if (nativeMethods.prepend)
+        //     overrideFunction(window.Element.prototype, 'prepend', this.overriddenMethods.prepend);
+
+        // if (nativeMethods.after)
+        //     overrideFunction(window.Element.prototype, 'after', this.overriddenMethods.after);
+
+        // if (nativeMethods.remove)
+        //     overrideFunction(window.Element.prototype, 'remove', this.overriddenMethods.remove);
+
         if (nativeMethods.elementReplaceWith)
             overrideFunction(window.Element.prototype, 'replaceWith', this.overriddenMethods.elementReplaceWith);
 
@@ -1053,9 +1095,9 @@ export default class ElementSandbox extends SandboxBase {
         if (window.Document.prototype.registerElement)
             overrideFunction(window.Document.prototype, 'registerElement', this.overriddenMethods.registerElement);
 
-        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentHTML', this.overriddenMethods.insertAdjacentHTML);
-        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentElement', this.overriddenMethods.insertAdjacentElement);
-        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentText', this.overriddenMethods.insertAdjacentText);
+        // overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentHTML', this.overriddenMethods.insertAdjacentHTML);
+        // overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentElement', this.overriddenMethods.insertAdjacentElement);
+        // overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentText', this.overriddenMethods.insertAdjacentText);
 
         this._setValidBrowsingContextOnElementClick(window);
 
@@ -1077,23 +1119,6 @@ export default class ElementSandbox extends SandboxBase {
                 nativeMethods.htmlElementOnloadSetter.call(this, handler);
             },
         });
-
-        if (this.proxyless)
-            return;
-
-        overrideFunction(window.Element.prototype, 'setAttribute', this.overriddenMethods.setAttribute);
-        overrideFunction(window.Element.prototype, 'setAttributeNS', this.overriddenMethods.setAttributeNS);
-        overrideFunction(window.Element.prototype, 'getAttribute', this.overriddenMethods.getAttribute);
-        overrideFunction(window.Element.prototype, 'getAttributeNS', this.overriddenMethods.getAttributeNS);
-        overrideFunction(window.Element.prototype, 'removeAttribute', this.overriddenMethods.removeAttribute);
-        overrideFunction(window.Element.prototype, 'removeAttributeNS', this.overriddenMethods.removeAttributeNS);
-        overrideFunction(window.Element.prototype, 'removeAttributeNode', this.overriddenMethods.removeAttributeNode);
-        overrideFunction(window.Element.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
-        overrideFunction(window.Element.prototype, 'querySelector', this.overriddenMethods.querySelector);
-        overrideFunction(window.Element.prototype, 'querySelectorAll', this.overriddenMethods.querySelectorAll);
-        overrideFunction(window.Element.prototype, 'hasAttribute', this.overriddenMethods.hasAttribute);
-        overrideFunction(window.Element.prototype, 'hasAttributeNS', this.overriddenMethods.hasAttributeNS);
-        overrideFunction(window.Element.prototype, 'hasAttributes', this.overriddenMethods.hasAttributes);
     }
 
     private _ensureTargetContainsExistingBrowsingContext (el: HTMLElement): void {

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -1011,14 +1011,9 @@ export default class ElementSandbox extends SandboxBase {
 
         this._createOverriddenMethods();
 
-        if (nativeMethods.attachShadow)
-            overrideFunction(window.Element.prototype, 'attachShadow', this.overriddenMethods.attachShadow);
-
-        overrideFunction(window.Node.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
         overrideFunction(window.Node.prototype, 'appendChild', this.overriddenMethods.appendChild);
         overrideFunction(window.Node.prototype, 'removeChild', this.overriddenMethods.removeChild);
         overrideFunction(window.Node.prototype, 'insertBefore', this.overriddenMethods.insertBefore);
-        overrideFunction(window.Node.prototype, 'replaceChild', this.overriddenMethods.replaceChild);
 
         if (nativeMethods.append)
             overrideFunction(window.Element.prototype, 'append', this.overriddenMethods.append);
@@ -1031,10 +1026,6 @@ export default class ElementSandbox extends SandboxBase {
 
         if (nativeMethods.remove)
             overrideFunction(window.Element.prototype, 'remove', this.overriddenMethods.remove);
-
-        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentHTML', this.overriddenMethods.insertAdjacentHTML);
-        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentElement', this.overriddenMethods.insertAdjacentElement);
-        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentText', this.overriddenMethods.insertAdjacentText);
 
         if (this.proxyless)
             return;
@@ -1053,26 +1044,11 @@ export default class ElementSandbox extends SandboxBase {
         overrideFunction(window.Element.prototype, 'hasAttributeNS', this.overriddenMethods.hasAttributeNS);
         overrideFunction(window.Element.prototype, 'hasAttributes', this.overriddenMethods.hasAttributes);
 
-        // if (nativeMethods.attachShadow)
-        //     overrideFunction(window.Element.prototype, 'attachShadow', this.overriddenMethods.attachShadow);
+        if (nativeMethods.attachShadow)
+            overrideFunction(window.Element.prototype, 'attachShadow', this.overriddenMethods.attachShadow);
 
         overrideFunction(window.Node.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
-        // overrideFunction(window.Node.prototype, 'appendChild', this.overriddenMethods.appendChild);
-        // overrideFunction(window.Node.prototype, 'removeChild', this.overriddenMethods.removeChild);
-        // overrideFunction(window.Node.prototype, 'insertBefore', this.overriddenMethods.insertBefore);
         overrideFunction(window.Node.prototype, 'replaceChild', this.overriddenMethods.replaceChild);
-
-        // if (nativeMethods.append)
-        //     overrideFunction(window.Element.prototype, 'append', this.overriddenMethods.append);
-
-        // if (nativeMethods.prepend)
-        //     overrideFunction(window.Element.prototype, 'prepend', this.overriddenMethods.prepend);
-
-        // if (nativeMethods.after)
-        //     overrideFunction(window.Element.prototype, 'after', this.overriddenMethods.after);
-
-        // if (nativeMethods.remove)
-        //     overrideFunction(window.Element.prototype, 'remove', this.overriddenMethods.remove);
 
         if (nativeMethods.elementReplaceWith)
             overrideFunction(window.Element.prototype, 'replaceWith', this.overriddenMethods.elementReplaceWith);
@@ -1095,9 +1071,9 @@ export default class ElementSandbox extends SandboxBase {
         if (window.Document.prototype.registerElement)
             overrideFunction(window.Document.prototype, 'registerElement', this.overriddenMethods.registerElement);
 
-        // overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentHTML', this.overriddenMethods.insertAdjacentHTML);
-        // overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentElement', this.overriddenMethods.insertAdjacentElement);
-        // overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentText', this.overriddenMethods.insertAdjacentText);
+        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentHTML', this.overriddenMethods.insertAdjacentHTML);
+        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentElement', this.overriddenMethods.insertAdjacentElement);
+        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentText', this.overriddenMethods.insertAdjacentText);
 
         this._setValidBrowsingContextOnElementClick(window);
 

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -1011,20 +1011,6 @@ export default class ElementSandbox extends SandboxBase {
 
         this._createOverriddenMethods();
 
-        overrideFunction(window.Element.prototype, 'setAttribute', this.overriddenMethods.setAttribute);
-        overrideFunction(window.Element.prototype, 'setAttributeNS', this.overriddenMethods.setAttributeNS);
-        overrideFunction(window.Element.prototype, 'getAttribute', this.overriddenMethods.getAttribute);
-        overrideFunction(window.Element.prototype, 'getAttributeNS', this.overriddenMethods.getAttributeNS);
-        overrideFunction(window.Element.prototype, 'removeAttribute', this.overriddenMethods.removeAttribute);
-        overrideFunction(window.Element.prototype, 'removeAttributeNS', this.overriddenMethods.removeAttributeNS);
-        overrideFunction(window.Element.prototype, 'removeAttributeNode', this.overriddenMethods.removeAttributeNode);
-        overrideFunction(window.Element.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
-        overrideFunction(window.Element.prototype, 'querySelector', this.overriddenMethods.querySelector);
-        overrideFunction(window.Element.prototype, 'querySelectorAll', this.overriddenMethods.querySelectorAll);
-        overrideFunction(window.Element.prototype, 'hasAttribute', this.overriddenMethods.hasAttribute);
-        overrideFunction(window.Element.prototype, 'hasAttributeNS', this.overriddenMethods.hasAttributeNS);
-        overrideFunction(window.Element.prototype, 'hasAttributes', this.overriddenMethods.hasAttributes);
-
         if (nativeMethods.attachShadow)
             overrideFunction(window.Element.prototype, 'attachShadow', this.overriddenMethods.attachShadow);
 
@@ -1091,6 +1077,23 @@ export default class ElementSandbox extends SandboxBase {
                 nativeMethods.htmlElementOnloadSetter.call(this, handler);
             },
         });
+
+        if (this.proxyless)
+            return;
+
+        overrideFunction(window.Element.prototype, 'setAttribute', this.overriddenMethods.setAttribute);
+        overrideFunction(window.Element.prototype, 'setAttributeNS', this.overriddenMethods.setAttributeNS);
+        overrideFunction(window.Element.prototype, 'getAttribute', this.overriddenMethods.getAttribute);
+        overrideFunction(window.Element.prototype, 'getAttributeNS', this.overriddenMethods.getAttributeNS);
+        overrideFunction(window.Element.prototype, 'removeAttribute', this.overriddenMethods.removeAttribute);
+        overrideFunction(window.Element.prototype, 'removeAttributeNS', this.overriddenMethods.removeAttributeNS);
+        overrideFunction(window.Element.prototype, 'removeAttributeNode', this.overriddenMethods.removeAttributeNode);
+        overrideFunction(window.Element.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
+        overrideFunction(window.Element.prototype, 'querySelector', this.overriddenMethods.querySelector);
+        overrideFunction(window.Element.prototype, 'querySelectorAll', this.overriddenMethods.querySelectorAll);
+        overrideFunction(window.Element.prototype, 'hasAttribute', this.overriddenMethods.hasAttribute);
+        overrideFunction(window.Element.prototype, 'hasAttributeNS', this.overriddenMethods.hasAttributeNS);
+        overrideFunction(window.Element.prototype, 'hasAttributes', this.overriddenMethods.hasAttributes);
     }
 
     private _ensureTargetContainsExistingBrowsingContext (el: HTMLElement): void {

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -181,7 +181,7 @@ export default class ElementSandbox extends SandboxBase {
                 if (value !== '' && (!isSpecialPage || tagName === 'a')) {
                     const isIframe         = tagName === 'iframe' || tagName === 'frame';
                     const isScript         = tagName === 'script';
-                    const isCrossDomainUrl = !this.proxyless && isSupportedProtocol && !sameOriginCheck(this.window.location.toString(), value);
+                    const isCrossDomainUrl = !SandboxBase.isProxyless && isSupportedProtocol && !sameOriginCheck(this.window.location.toString(), value);
                     let resourceType       = domProcessor.getElementResourceType(el);
                     const elCharset        = isScript && (el as HTMLScriptElement).charset; // eslint-disable-line no-extra-parens
                     const currentDocument  = el.ownerDocument || this.document;
@@ -201,7 +201,7 @@ export default class ElementSandbox extends SandboxBase {
                         domUtils.isElementInDocument(el, currentDocument))
                         urlResolver.updateBase(value, currentDocument);
 
-                    if (this.proxyless)
+                    if (SandboxBase.isProxyless)
                         args[valueIndex] = value;
                     else {
                         args[valueIndex] = isIframe && isCrossDomainUrl
@@ -866,7 +866,7 @@ export default class ElementSandbox extends SandboxBase {
             return str;
 
         if (domUtils.isScriptElement(parentNode))
-            return processScript(str, true, false, urlUtils.convertToProxyUrl, void 0, settings.get().proxyless);
+            return processScript(str, true, false, urlUtils.convertToProxyUrl, void 0, SandboxBase.isProxyless);
 
         if (domUtils.isStyleElement(parentNode))
             return styleProcessor.process(str, urlUtils.getProxyUrl);
@@ -1027,7 +1027,7 @@ export default class ElementSandbox extends SandboxBase {
         if (nativeMethods.remove)
             overrideFunction(window.Element.prototype, 'remove', this.overriddenMethods.remove);
 
-        if (this.proxyless)
+        if (SandboxBase.isProxyless)
             return;
 
         overrideFunction(window.Element.prototype, 'setAttribute', this.overriddenMethods.setAttribute);
@@ -1152,7 +1152,7 @@ export default class ElementSandbox extends SandboxBase {
     }
 
     private _handleImageLoadEventRaising (el: HTMLImageElement): void {
-        if (this.proxyless)
+        if (SandboxBase.isProxyless)
             return;
 
         this._eventSandbox.listeners.initElementListening(el, ['load']);

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -1011,6 +1011,9 @@ export default class ElementSandbox extends SandboxBase {
 
         this._createOverriddenMethods();
 
+        if (nativeMethods.attachShadow)
+            overrideFunction(window.Element.prototype, 'attachShadow', this.overriddenMethods.attachShadow);
+
         overrideFunction(window.Node.prototype, 'appendChild', this.overriddenMethods.appendChild);
         overrideFunction(window.Node.prototype, 'removeChild', this.overriddenMethods.removeChild);
         overrideFunction(window.Node.prototype, 'insertBefore', this.overriddenMethods.insertBefore);
@@ -1043,9 +1046,6 @@ export default class ElementSandbox extends SandboxBase {
         overrideFunction(window.Element.prototype, 'hasAttribute', this.overriddenMethods.hasAttribute);
         overrideFunction(window.Element.prototype, 'hasAttributeNS', this.overriddenMethods.hasAttributeNS);
         overrideFunction(window.Element.prototype, 'hasAttributes', this.overriddenMethods.hasAttributes);
-
-        if (nativeMethods.attachShadow)
-            overrideFunction(window.Element.prototype, 'attachShadow', this.overriddenMethods.attachShadow);
 
         overrideFunction(window.Node.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
         overrideFunction(window.Node.prototype, 'replaceChild', this.overriddenMethods.replaceChild);

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -1041,6 +1041,13 @@ export default class ElementSandbox extends SandboxBase {
         if (nativeMethods.remove)
             overrideFunction(window.Element.prototype, 'remove', this.overriddenMethods.remove);
 
+        if (nativeMethods.elementReplaceWith)
+            overrideFunction(window.Element.prototype, 'replaceWith', this.overriddenMethods.elementReplaceWith);
+
+        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentHTML', this.overriddenMethods.insertAdjacentHTML);
+        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentElement', this.overriddenMethods.insertAdjacentElement);
+        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentText', this.overriddenMethods.insertAdjacentText);
+
         if (SandboxBase.isProxyless)
             return;
 
@@ -1061,9 +1068,6 @@ export default class ElementSandbox extends SandboxBase {
         overrideFunction(window.Node.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
         overrideFunction(window.Node.prototype, 'replaceChild', this.overriddenMethods.replaceChild);
 
-        if (nativeMethods.elementReplaceWith)
-            overrideFunction(window.Element.prototype, 'replaceWith', this.overriddenMethods.elementReplaceWith);
-
         overrideFunction(window.DocumentFragment.prototype, 'querySelector', this.overriddenMethods.querySelector);
         overrideFunction(window.DocumentFragment.prototype, 'querySelectorAll', this.overriddenMethods.querySelectorAll);
 
@@ -1081,10 +1085,6 @@ export default class ElementSandbox extends SandboxBase {
 
         if (window.Document.prototype.registerElement)
             overrideFunction(window.Document.prototype, 'registerElement', this.overriddenMethods.registerElement);
-
-        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentHTML', this.overriddenMethods.insertAdjacentHTML);
-        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentElement', this.overriddenMethods.insertAdjacentElement);
-        overrideFunction(nativeMethods.insertAdjacentMethodsOwner, 'insertAdjacentText', this.overriddenMethods.insertAdjacentText);
 
         this._setValidBrowsingContextOnElementClick(window);
 

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -160,7 +160,75 @@ export default class WindowSandbox extends SandboxBase {
         this.SANDBOX_DOM_TOKEN_LIST_UPDATE_FN = SANDBOX_DOM_TOKEN_LIST_UPDATE_FN;
     }
 
-    private static _prepareStack (msg: string, stack: string): string {
+    static isProxyObject (obj: any): boolean {
+        try {
+            return obj[IS_PROXY_OBJECT_INTERNAL_PROP_NAME] === IS_PROXY_OBJECT_INTERNAL_PROP_VALUE;
+        }
+        catch (e) {
+            return false;
+        }
+    }
+
+    handleEvent (event) {
+        if (event.defaultPrevented)
+            return;
+
+        if (event.type === 'unhandledrejection')
+            this.raiseUncaughtJsErrorEvent(this.UNHANDLED_REJECTION_EVENT, event, this.window);
+        else if (event.type === 'error') {
+            if (event.message.indexOf('NS_ERROR_NOT_INITIALIZED') !== -1)
+                event.preventDefault();
+            else
+                this.raiseUncaughtJsErrorEvent(this.UNCAUGHT_JS_ERROR_EVENT, event, window);
+        }
+        else if (event.type === 'hashchange')
+            this.emit(this.HASH_CHANGE_EVENT);
+    }
+
+    private raiseUncaughtJsErrorEvent (type: string, event: ErrorEvent | PromiseRejectionEvent, window: Window): void {
+        if (isCrossDomainWindows(window, window.top))
+            return;
+
+        const sendToTopWindow = isIframeWindow(window);
+        const pageUrl         = destLocation.get();
+        let msg               = null;
+        let stack             = null;
+
+        if (type === this.UNHANDLED_REJECTION_EVENT) {
+            msg   = WindowSandbox.formatUnhandledRejectionReason((event as PromiseRejectionEvent).reason);
+            stack = (event as PromiseRejectionEvent).reason && (event as PromiseRejectionEvent).reason.stack;
+        }
+        else if (type === this.UNCAUGHT_JS_ERROR_EVENT) {
+            msg   = (event as ErrorEvent).error ? (event as ErrorEvent).error.message : (event as ErrorEvent).message;
+            stack = (event as ErrorEvent).error && (event as ErrorEvent).error.stack;
+        }
+
+        stack = WindowSandbox.prepareStack(msg, stack);
+        stack = replaceProxiedUrlsInStack(stack);
+
+        if (sendToTopWindow) {
+            this.emit(type, { msg, pageUrl, stack, inIframe: true });
+            this.messageSandbox.sendServiceMsg({ msg, pageUrl, stack, cmd: type }, window.top);
+        }
+        else
+            this.emit(type, { msg, pageUrl, stack });
+    }
+
+    private static formatUnhandledRejectionReason (reason: any): string {
+        if (!isPrimitiveType(reason)) {
+            if (reason instanceof (nativeMethods.Error as any)) {
+                const name = reason.name || DEFAULT_UNHANDLED_REJECTION_REASON_NAME;
+
+                return `${name}: ${reason.message}`;
+            }
+
+            return nativeMethods.objectToString.call(reason);
+        }
+
+        return String(reason);
+    }
+
+    private static prepareStack (msg: string, stack: string): string {
         // NOTE: Firefox does not include an error message in a stack trace (unlike other browsers)
         // It is possible to get a stack trace for unhandled Promise rejections only if Promise is rejected with the 'Error' instance value.
         // This is why we should convert the stack to a common format.
@@ -173,15 +241,418 @@ export default class WindowSandbox extends SandboxBase {
         return stack;
     }
 
-    private static _getBlobProcessingSettings (): BlobProcessingSettings {
-        return {
-            sessionId: settings.get().sessionId,
-            windowId:  settings.get().windowId,
-            origin:    destLocation.getOriginHeader(),
-        };
+    attach (window): void {
+        super.attach(window);
+
+        nativeMethods.arrayForEach.call(TRACKED_EVENTS, (event: string) => {
+            this.reattachHandler(event);
+        });
+
+        this.initElementListening();
+
+        this.overrideEventPropDescriptor('error', nativeMethods.winOnErrorSetter);
+        this.overrideEventPropDescriptor('hashchange', nativeMethods.winOnHashChangeSetter);
+
+        if (nativeMethods.winOnUnhandledRejectionSetter)
+            this.overrideEventPropDescriptor('unhandledrejection', nativeMethods.winOnUnhandledRejectionSetter);
+
+        this.addMessageSandBoxListeners();
+
+        this.overrideDrawImageInCanvasRenderingContext2D();
+
+        if (nativeMethods.objectAssign)
+            this.overrideAssignInObject();
+
+        this.overrideOpenInWindow();
+
+        if (window.FontFace && !this.proxyless)
+            this.overrideFontFaceInWindow();
+
+        if (window.Worker && !this.proxyless)
+            this.overrideWorkerInWindow();
+
+        if (window.Blob)
+            this.overrideBlobInWindow();
+
+        // NOTE: non-IE11 case. window.File in IE11 is not constructable.
+        if (nativeMethods.File)
+            this.overrideFileInWindow();
+
+        if (window.EventSource && !this.proxyless)
+            this.overrideEventSourceInWindow();
+
+        if (window.MutationObserver)
+            this.overrideMutationObserverInWindow();
+
+        if (window.Proxy)
+            this.overrideProxyInWindow();
+
+        if (nativeMethods.registerServiceWorker && !this.proxyless)
+            this.overrideRegisterInServiceWorker();
+
+        if (nativeMethods.getRegistrationServiceWorker && !this.proxyless)
+            this.overrideGetRegistrationInNavigator();
+
+        if (window.Range.prototype.createContextualFragment)
+            this.overrideCreateContextualFragmentInRange();
+
+        if (window.EventTarget)
+            this.overrideListenerMethodsInEventTarget();
+
+        if (!this.proxyless)
+            this.overrideImageInWindow();
+
+        this.overrideFunctionInWindow();
+        this.overrideToStringInFunction();
+
+        if (isFunction(window.history.pushState)
+            && isFunction(window.history.replaceState)
+            && !this.proxyless) {
+            this.overrideMethodInHistory('pushState', nativeMethods.historyPushState);
+            this.overrideMethodInHistory('replaceState', nativeMethods.historyReplaceState);
+        }
+
+        if (nativeMethods.sendBeacon && !this.proxyless)
+            this.overrideSendBeaconInNavigator();
+
+        if (window.navigator.registerProtocolHandler && !this.proxyless)
+            this.overrideRegisterProtocolHandlerInNavigator();
+
+        if (window.FormData)
+            this.overrideAppendInFormData();
+
+        if (window.WebSocket && !this.proxyless) {
+            this.overrideWebSocketInWindow();
+
+            if (nativeMethods.webSocketUrlGetter)
+                this.overrideUrlInWebSocket();
+        }
+
+        if (!this.proxyless)
+            this.overrideOriginInMessageEvent();
+
+        this.overrideLengthInHTMLCollection();
+        this.overrideLengthInNodeList();
+        this.overrideChildElementCountInElement();
+
+        if (nativeMethods.performanceEntryNameGetter && !this.proxyless)
+            this.overrideNameInPerformanceEntry();
+
+        this.overrideFilesInHTMLInputElement();
+        this.overrideValueInHTMLInputElement();
+
+        // NOTE: HTMLInputElement raises the `change` event on `disabled` only in Chrome
+        if (isChrome)
+            this.overrideDisabledInHTMLInputElement();
+
+        this.overrideRequiredInHTMLInputElement();
+        this.overrideValueInHTMLTextAreaElement();
+
+        if (!this.proxyless)
+            this.overrideAllUrlAttrDescriptors();
+
+        this.overrideAttrDescriptorsInElement('target', [
+            window.HTMLAnchorElement,
+            window.HTMLFormElement,
+            window.HTMLAreaElement,
+            window.HTMLBaseElement,
+        ]);
+
+        this.overrideAttrDescriptorsInElement('formTarget', [
+            window.HTMLInputElement,
+            window.HTMLButtonElement,
+        ]);
+
+        this.overrideAttrDescriptorsInElement('autocomplete', [window.HTMLInputElement]);
+        this.overrideAttrDescriptorsInElement('httpEquiv', [window.HTMLMetaElement]);
+
+        // NOTE: Some browsers (for example, Edge, Internet Explorer 11, Safari) don't support the 'integrity' property.
+        if (nativeMethods.scriptIntegrityGetter && nativeMethods.linkIntegrityGetter) {
+            this.overrideAttrDescriptorsInElement('integrity', [window.HTMLScriptElement]);
+            this.overrideAttrDescriptorsInElement('integrity', [window.HTMLLinkElement]);
+        }
+
+        this.overrideAttrDescriptorsInElement('rel', [window.HTMLLinkElement]);
+
+        if (nativeMethods.linkAsSetter)
+            this.overrideAttrDescriptorsInElement('as', [window.HTMLLinkElement]);
+
+        this.overrideTypeInHTMLInputElement();
+        this.overrideSandboxInHTMLIFrameElement();
+
+        if (nativeMethods.iframeSrcdocGetter)
+            this.overrideSrcdocInHTMLIFrameElement();
+
+        if (!this.proxyless) {
+            this.overrideUrlPropInHTMLAnchorElement('port', nativeMethods.anchorPortGetter, nativeMethods.anchorPortSetter);
+            this.overrideUrlPropInHTMLAnchorElement('host', nativeMethods.anchorHostGetter, nativeMethods.anchorHostSetter);
+            this.overrideUrlPropInHTMLAnchorElement('hostname', nativeMethods.anchorHostnameGetter, nativeMethods.anchorHostnameSetter);
+            this.overrideUrlPropInHTMLAnchorElement('pathname', nativeMethods.anchorPathnameGetter, nativeMethods.anchorPathnameSetter);
+            this.overrideUrlPropInHTMLAnchorElement('protocol', nativeMethods.anchorProtocolGetter, nativeMethods.anchorProtocolSetter);
+            this.overrideUrlPropInHTMLAnchorElement('search', nativeMethods.anchorSearchGetter, nativeMethods.anchorSearchSetter);
+        }
+
+        if (!this.proxyless) {
+            this.overrideHrefInSVGImageElement();
+            this.overrideBaseValInSVGAnimatedString();
+            this.overrideAnimValInSVGAnimatedString();
+        }
+
+        if (nativeMethods.anchorOriginGetter && !this.proxyless)
+            this.overrideOriginInHTMLAnchorElement();
+
+        if (!this.proxyless)
+            this.overrideHrefInStyleSheet();
+
+        if (nativeMethods.cssStyleSheetHrefGetter)
+            this.overrideHrefInCSSStyleSheet();
+
+        if (nativeMethods.nodeBaseURIGetter)
+            this.overrideBaseURIInNode();
+
+        if (window.DOMParser)
+            this.overrideParseFromStringInDOMParser();
+
+        this.overrideFirstChildInNode();
+        this.overrideFirstElementChildInElement();
+        this.overrideLastChildInNode();
+        this.overrideLastElementChildInElement();
+        this.overrideNextSiblingInNode();
+        this.overridePreviousSiblingInNode();
+        this.overrideNextElementSiblingInElement();
+        this.overridePreviousElementSiblingInElement();
+        this.overrideInnerHTMLInElement();
+        this.overrideOuterHTMLInElement();
+        this.overrideInnerTextInHTMLElement();
+        this.overrideTextInHTMLScriptElement();
+        this.overrideTextInHTMLAnchorElement();
+        this.overrideTextContentInNode();
+        this.overrideAttributesInElement();
+        this.overrideMethodInDOMTokenList('add', nativeMethods.tokenListAdd);
+        this.overrideMethodInDOMTokenList('remove', nativeMethods.tokenListRemove);
+        this.overrideMethodInDOMTokenList('toggle', nativeMethods.tokenListToggle);
+
+        if (nativeMethods.tokenListReplace)
+            this.overrideMethodInDOMTokenList('replace', nativeMethods.tokenListReplace);
+
+        if (nativeMethods.tokenListSupports)
+            this.overrideSupportsInDOMTokenList();
+
+        if (nativeMethods.tokenListValueSetter)
+            this.overrideValueInDOMTokenList();
+
+        this.overrideCreateHTMLDocumentInDOMImplementation();
+        this.overrideNextSiblingInMutationRecord();
+        this.overridePreviousSiblingInMutationRecord();
+
+        if (nativeMethods.windowOriginGetter)
+            this.overrideOriginInWindow();
+
+        if (this._documentTitleStorageInitializer)
+            this.overrideTextInHTMLTitleElement();
     }
 
-    private static _isProcessableBlobParts (parts: any[]): boolean {
+    private initElementListening () {
+        this.listenersSandbox.initElementListening(this.window, TRACKED_EVENTS);
+        this.listenersSandbox.on(this.listenersSandbox.EVENT_LISTENER_ATTACHED_EVENT, e => {
+            if (e.el !== this.window)
+                return;
+
+            if (TRACKED_EVENTS.indexOf(e.eventType) !== -1)
+                this.reattachHandler(e.eventType);
+        });
+    }
+
+    private reattachHandler (eventName: string): void {
+        const nativeAddEventListener    = Listeners.getNativeAddEventListener(this.window);
+        const nativeRemoveEventListener = Listeners.getNativeRemoveEventListener(this.window);
+
+        nativeRemoveEventListener.call(this.window, eventName, this);
+        nativeAddEventListener.call(this.window, eventName, this);
+    }
+
+    private addMessageSandBoxListeners () {
+        const messageSandbox = this.messageSandbox;
+        const windowSandbox  = this;
+
+        messageSandbox.on(messageSandbox.SERVICE_MSG_RECEIVED_EVENT, e => {
+            const { msg, pageUrl, stack, cmd } = e.message;
+
+            if (cmd === this.UNCAUGHT_JS_ERROR_EVENT || cmd === this.UNHANDLED_REJECTION_EVENT)
+                windowSandbox.emit(cmd, { msg, pageUrl, stack });
+        });
+    }
+
+    private overrideEventPropDescriptor (eventName: string, nativePropSetter): void {
+        const windowSandbox   = this;
+        const eventPropsOwner = nativeMethods.isEventPropsLocatedInProto ? this.window.Window.prototype : this.window;
+
+        //@ts-ignore
+        overrideDescriptor(eventPropsOwner, 'on' + eventName, {
+            getter: null,
+            setter: handler => {
+                nativePropSetter.call(windowSandbox.window, handler);
+
+                this.listenersSandbox.emit(this.listenersSandbox.EVENT_LISTENER_ATTACHED_EVENT, {
+                    el:        windowSandbox.window,
+                    listener:  handler,
+                    eventType: eventName,
+                });
+            },
+        });
+    }
+
+    private overrideDrawImageInCanvasRenderingContext2D () {
+        const windowSandbox = this;
+
+        overrideFunction(this.window.CanvasRenderingContext2D.prototype, 'drawImage', function (this: CanvasRenderingContext2D, ...args) {
+            let image = args[0];
+
+            if (isImgElement(image) && !image[INTERNAL_PROPS.forceProxySrcForImage]) {
+                const src = nativeMethods.imageSrcGetter.call(image);
+
+                if (destLocation.sameOriginCheck(location.toString(), src)) {
+                    image = nativeMethods.createElement.call(windowSandbox.window.document, 'img');
+
+                    nativeMethods.imageSrcSetter.call(image, getProxyUrl(src));
+
+                    args[0] = image;
+
+                    if (!image.complete) {
+                        nativeMethods.addEventListener.call(image, 'load',
+                            () => nativeMethods.canvasContextDrawImage.apply(this, args));
+                    }
+                }
+            }
+
+            return nativeMethods.canvasContextDrawImage.apply(this, args);
+        });
+    }
+
+    private overrideAssignInObject () {
+        const windowSandbox = this;
+
+        overrideFunction(this.window.Object, 'assign', function (this: ObjectConstructor, target: object, ...sources: any[]) {
+            let args         = [target] as [object, ...any[]];
+            const targetType = typeof target;
+
+            if (target && (targetType === 'object' || targetType === 'function') && sources.length) {
+                for (const source of sources) {
+                    const sourceType = typeof source;
+
+                    if (!source || sourceType !== 'object' && sourceType !== 'function') {
+                        nativeMethods.objectAssign.call(this, target, source);
+                        continue;
+                    }
+
+                    const sourceSymbols = nativeMethods.objectGetOwnPropertySymbols.call(windowSandbox.window.Object, source);
+                    const sourceKeys    = nativeMethods.arrayConcat.call(
+                        nativeMethods.objectKeys.call(windowSandbox.window.Object, source),
+                        sourceSymbols
+                    );
+
+                    for (const key of sourceKeys)
+                        windowSandbox.window[INSTRUCTION.setProperty](target, key, source[key]);
+                }
+            }
+            else
+                args = nativeMethods.arrayConcat.call(args, sources);
+
+            return nativeMethods.objectAssign.apply(this, args);
+        });
+    }
+
+    private overrideOpenInWindow () {
+        const windowSandbox  = this;
+
+        overrideFunction(this.window, 'open', function (...args: [string?, string?, string?, boolean?]) {
+            args[0] = getProxyUrl(args[0]);
+            args[1] = windowSandbox.getWindowOpenTarget(args[1]);
+
+            return windowSandbox._childWindowSandbox.handleWindowOpen(windowSandbox.window, args);
+        });
+    }
+
+    private getWindowOpenTarget (originTarget: string): string {
+        if (originTarget)
+            return this.nodeSandbox.element.getCorrectedTarget(String(originTarget));
+
+        return settings.get().allowMultipleWindows ? DefaultTarget.windowOpen : '_self';
+    }
+
+    private overrideFontFaceInWindow () {
+        overrideConstructor(this.window, 'FontFace', (family, source, descriptors) => {
+            source = styleProcessor.process(source, convertToProxyUrl);
+
+            return new nativeMethods.FontFace(family, source, descriptors);
+        });
+    }
+
+    private overrideWorkerInWindow () {
+        overrideConstructor(this.window, 'Worker', function WorkerWrapper (this: Worker, ...args: [string | URL, WorkerOptions?]) {
+            const isCalledWithoutNewKeyword = constructorIsCalledWithoutNewKeyword(this, WorkerWrapper);
+
+            if (arguments.length === 0)
+                // @ts-ignore
+                return isCalledWithoutNewKeyword ? nativeMethods.Worker() : new nativeMethods.Worker();
+
+            if (isCalledWithoutNewKeyword)
+                return nativeMethods.Worker.apply(this, args);
+
+            let scriptURL = args[0];
+
+            if (typeof scriptURL !== 'string')
+                scriptURL = String(scriptURL);
+
+            scriptURL = getProxyUrl(scriptURL, { resourceType: stringifyResourceType({ isScript: true }) });
+
+            const worker = arguments.length === 1
+                ? new nativeMethods.Worker(scriptURL)
+                : new nativeMethods.Worker(scriptURL, args[1]);
+
+            return worker;
+        }, true);
+    }
+
+    private overrideBlobInWindow () {
+        overrideConstructor(this.window, 'Blob', function (array, opts) {
+            if (arguments.length === 0)
+                return new nativeMethods.Blob();
+
+            if (WindowSandbox.isProcessableBlob(array, opts))
+                array = [processScript(array.join(''), true, false, convertToProxyUrl, void 0, settings.get().proxyless, WindowSandbox.getBlobProcessingSettings())];
+
+            // NOTE: IE11 throws an error when the second parameter of the Blob function is undefined (GH-44)
+            // If the overridden function is called with one parameter, we need to call the original function
+            // with one parameter as well.
+            return arguments.length === 1 ? new nativeMethods.Blob(array) : new nativeMethods.Blob(array, opts);
+        });
+    }
+
+    private overrideFileInWindow () {
+        overrideConstructor(this.window, 'File', function (array, fileName, opts) {
+            if (arguments.length === 0)
+                return new nativeMethods.File();
+
+            if (WindowSandbox.isProcessableBlob(array, opts))
+                array = [processScript(array.join(''), true, false, convertToProxyUrl, void 0, settings.get().proxyless, WindowSandbox.getBlobProcessingSettings())];
+
+            return new nativeMethods.File(array, fileName, opts);
+        });
+    }
+
+    private static isProcessableBlob (array, opts): boolean {
+        const type = opts && opts.type && opts.type.toString().toLowerCase() || getMimeType(array);
+
+        // NOTE: If we cannot identify the content type of data, we're trying to process it as a script
+        // (in the case of the "Array<string | number | boolean>" blob parts array: GH-2115).
+        // Unfortunately, we do not have the ability to exactly identify a script. That's why we make such
+        // an assumption. We cannot solve this problem at the Worker level either, because the operation of
+        // creating a new Blob instance is asynchronous. (GH-231)
+        return (!type || JAVASCRIPT_MIME_TYPES.indexOf(type) !== -1) && WindowSandbox.isProcessableBlobParts(array);
+    }
+
+    private static isProcessableBlobParts (parts: any[]): boolean {
         let hasStringItem = false;
 
         for (const item of parts) {
@@ -198,193 +669,229 @@ export default class WindowSandbox extends SandboxBase {
         return hasStringItem;
     }
 
-    private static _isProcessableBlob (array, opts): boolean {
-        const type = opts && opts.type && opts.type.toString().toLowerCase() || getMimeType(array);
-
-        // NOTE: If we cannot identify the content type of data, we're trying to process it as a script
-        // (in the case of the "Array<string | number | boolean>" blob parts array: GH-2115).
-        // Unfortunately, we do not have the ability to exactly identify a script. That's why we make such
-        // an assumption. We cannot solve this problem at the Worker level either, because the operation of
-        // creating a new Blob instance is asynchronous. (GH-231)
-        return (!type || JAVASCRIPT_MIME_TYPES.indexOf(type) !== -1) && WindowSandbox._isProcessableBlobParts(array);
-    }
-
-    _getWindowOpenTarget (originTarget: string): string {
-        if (originTarget)
-            return this.nodeSandbox.element.getCorrectedTarget(String(originTarget));
-
-        return settings.get().allowMultipleWindows ? DefaultTarget.windowOpen : '_self';
-    }
-
-    _raiseUncaughtJsErrorEvent (type: string, event: ErrorEvent | PromiseRejectionEvent, window: Window): void {
-        if (isCrossDomainWindows(window, window.top))
-            return;
-
-        const sendToTopWindow = isIframeWindow(window);
-        const pageUrl         = destLocation.get();
-        let msg               = null;
-        let stack             = null;
-
-        if (type === this.UNHANDLED_REJECTION_EVENT) {
-            msg   = WindowSandbox._formatUnhandledRejectionReason((event as PromiseRejectionEvent).reason);
-            stack = (event as PromiseRejectionEvent).reason && (event as PromiseRejectionEvent).reason.stack;
-        }
-        else if (type === this.UNCAUGHT_JS_ERROR_EVENT) {
-            msg   = (event as ErrorEvent).error ? (event as ErrorEvent).error.message : (event as ErrorEvent).message;
-            stack = (event as ErrorEvent).error && (event as ErrorEvent).error.stack;
-        }
-
-        stack = WindowSandbox._prepareStack(msg, stack);
-        stack = replaceProxiedUrlsInStack(stack);
-
-        if (sendToTopWindow) {
-            this.emit(type, { msg, pageUrl, stack, inIframe: true });
-            this.messageSandbox.sendServiceMsg({ msg, pageUrl, stack, cmd: type }, window.top);
-        }
-        else
-            this.emit(type, { msg, pageUrl, stack });
-    }
-
-    _reattachHandler (window: Window, eventName: string): void {
-        const nativeAddEventListener    = Listeners.getNativeAddEventListener(window);
-        const nativeRemoveEventListener = Listeners.getNativeRemoveEventListener(window);
-
-        nativeRemoveEventListener.call(window, eventName, this);
-        nativeAddEventListener.call(window, eventName, this);
-    }
-
-    static _formatUnhandledRejectionReason (reason: any): string {
-        if (!isPrimitiveType(reason)) {
-            if (reason instanceof (nativeMethods.Error as any)) {
-                const name = reason.name || DEFAULT_UNHANDLED_REJECTION_REASON_NAME;
-
-                return `${name}: ${reason.message}`;
-            }
-
-            return nativeMethods.objectToString.call(reason);
-        }
-
-        return String(reason);
-    }
-
-    static _getUrlAttr (el: HTMLElement, attr: string): string {
-        const attrValue       = nativeMethods.getAttribute.call(el, attr);
-        const currentDocument = el.ownerDocument || document;
-
-        if (attrValue === '' || attrValue === null && attr === 'action' && emptyActionAttrFallbacksToTheLocation)
-            return urlResolver.resolve('', currentDocument);
-
-        else if (attrValue === null)
-            return '';
-
-        else if (HASH_RE.test(attrValue))
-            return urlResolver.resolve(attrValue, currentDocument);
-
-        else if (!isValidUrl(attrValue))
-            return urlResolver.resolve(attrValue, currentDocument);
-
-        return resolveUrlAsDest(attrValue, attr === 'srcset');
-    }
-
-    static _removeProcessingInstructions (text: string): string {
-        if (text) {
-            text = removeProcessingHeader(text);
-
-            return styleProcessor.cleanUp(text, parseProxyUrl);
-        }
-
-        return text;
-    }
-
-    static _processTextPropValue (el: HTMLElement, text: string): string {
-        const processedText = text !== null && text !== void 0 ? String(text) : text;
-
-        if (processedText) {
-            if (isScriptElement(el))
-                return processScript(processedText, true, false, convertToProxyUrl, void 0, settings.get().proxyless);
-            else if (isStyleElement(el))
-                return styleProcessor.process(processedText, getProxyUrl, true);
-        }
-
-        return processedText;
-    }
-
-    _overrideUrlAttrDescriptors (attr, elementConstructors): void {
-        const windowSandbox = this;
-
-        for (const constructor of elementConstructors) {
-            overrideDescriptor(constructor.prototype, attr, {
-                getter: function (this: HTMLElement) {
-                    return WindowSandbox._getUrlAttr(this, attr);
-                },
-                setter: function (this: HTMLElement, value) {
-                    windowSandbox.nodeSandbox.element.setAttributeCore(this, [attr, value]);
-                },
-            });
-        }
-    }
-
-    _overrideAttrDescriptors (attr, elementConstructors): void {
-        const windowSandbox = this;
-
-        for (const constructor of elementConstructors) {
-            overrideDescriptor(constructor.prototype, attr, {
-                getter: function (this: HTMLElement) {
-                    return windowSandbox.nodeSandbox.element.getAttributeCore(this, [attr]) || '';
-                },
-                setter: function (this: HTMLElement, value) {
-                    windowSandbox.nodeSandbox.element.setAttributeCore(this, [attr, value]);
-                },
-            });
-        }
-    }
-
-    _overrideUrlPropDescriptor (prop, nativePropGetter, nativePropSetter): void {
-        // @ts-ignore
-        overrideDescriptor(window.HTMLAnchorElement.prototype, prop, {
-            getter: function (this: HTMLElement) {
-                return getAnchorProperty(this, nativePropGetter);
-            },
-            setter: function (this: HTMLElement, value) {
-                setAnchorProperty(this, nativePropSetter, value);
-            },
-        });
-    }
-
-    _overrideEventPropDescriptor (window: Window, eventName: string, nativePropSetter): void {
-        // @ts-ignore
-        const eventPropsOwner = nativeMethods.isEventPropsLocatedInProto ? window.Window.prototype : window;
-
-        overrideDescriptor(eventPropsOwner, 'on' + eventName, {
-            getter: null,
-            setter: handler => {
-                nativePropSetter.call(window, handler);
-
-                this.listenersSandbox.emit(this.listenersSandbox.EVENT_LISTENER_ATTACHED_EVENT, {
-                    el:        window,
-                    listener:  handler,
-                    eventType: eventName,
-                });
-            },
-        });
-    }
-
-    _createOverriddenDOMTokenListMethod (nativeMethod): Function {
-        const windowSandbox = this;
-
-        return function (this: DOMTokenList) {
-            const executionResult = nativeMethod.apply(this, arguments);
-            const tokenListOwner  = this[SANDBOX_DOM_TOKEN_LIST_OWNER];
-
-            if (tokenListOwner)
-                // eslint-disable-next-line no-restricted-properties
-                windowSandbox.nodeSandbox.element.setAttributeCore(tokenListOwner, ['sandbox', this.toString()]);
-
-            return executionResult;
+    private static getBlobProcessingSettings (): BlobProcessingSettings {
+        return {
+            sessionId: settings.get().sessionId,
+            windowId:  settings.get().windowId,
+            origin:    destLocation.getOriginHeader(),
         };
     }
 
-    private static _patchFunctionPrototype (fn: Function, ctx: any): void {
+    private overrideEventSourceInWindow () {
+        overrideConstructor(this.window, 'EventSource', function (url, opts) {
+            if (arguments.length) {
+                const proxyUrl = getProxyUrl(url, { resourceType: stringifyResourceType({ isEventSource: true }) });
+
+                if (arguments.length === 1)
+                    return new nativeMethods.EventSource(proxyUrl);
+
+                return new nativeMethods.EventSource(proxyUrl, opts);
+            }
+
+            return new nativeMethods.EventSource();
+        });
+
+        //@ts-ignore
+        this.window.EventSource.CONNECTING = nativeMethods.EventSource.CONNECTING;
+        //@ts-ignore
+        this.window.EventSource.OPEN = nativeMethods.EventSource.OPEN;
+        //@ts-ignore
+        this.window.EventSource.CLOSED = nativeMethods.EventSource.CLOSED;
+    }
+
+    private overrideMutationObserverInWindow () {
+        overrideConstructor(this.window, 'MutationObserver', callback => {
+            const wrapper = function (this: MutationObserver, mutations: MutationRecord[]) {
+                const result = [];
+
+                for (const mutation of mutations) {
+                    if (!ShadowUI.isShadowUIMutation(mutation))
+                        result.push(mutation);
+                }
+
+                if (result.length)
+                    callback.call(this, result, this);
+            };
+
+            return new nativeMethods.MutationObserver(wrapper);
+        });
+
+        //@ts-ignore
+        if (this.window.WebKitMutationObserver)
+            //@ts-ignore
+            this.window.WebKitMutationObserver = this.window.MutationObserver;
+    }
+
+    private overrideProxyInWindow () {
+        const windowSandbox = this;
+
+        overrideConstructor(this.window, 'Proxy', function (target, handler) {
+            if (handler.get && !handler.get[PROXY_HANDLER_FLAG]) {
+                const storedGet = handler.get;
+
+                handler.get = function (getterTarget, name, receiver) {
+                    if (name === IS_PROXY_OBJECT_INTERNAL_PROP_NAME)
+                        return IS_PROXY_OBJECT_INTERNAL_PROP_VALUE;
+                    else if (INSTRUCTION_VALUES.indexOf(name) > -1)
+                        return windowSandbox.window[name];
+
+                    const result = storedGet.call(this, getterTarget, name, receiver);
+
+                    if (name === 'eval' && result[CodeInstrumentation.WRAPPED_EVAL_FN])
+                        return result[CodeInstrumentation.WRAPPED_EVAL_FN];
+
+                    return result;
+                };
+
+                nativeMethods.objectDefineProperty(handler.get, PROXY_HANDLER_FLAG, { value: true, enumerable: false });
+            }
+
+            return new nativeMethods.Proxy(target, handler);
+        });
+
+        this.window.Proxy.revocable = nativeMethods.Proxy.revocable;
+    }
+
+    private overrideRegisterInServiceWorker () {
+        const windowSandbox = this;
+
+        overrideFunction(this.window.navigator.serviceWorker, 'register', (...args) => {
+            const [url, opts] = args;
+
+            if (typeof url === 'string') {
+                if (WindowSandbox.isSecureOrigin(url)) {
+                    // NOTE: We cannot create an instance of the DOMException in the Android 6.0 and in the Edge 17 browsers.
+                    // The 'TypeError: Illegal constructor' error is raised if we try to call the constructor.
+                    return Promise.reject(isAndroid || isMSEdge && browserVersion >= 17
+                        ? new Error('Only secure origins are allowed.')
+                        : new DOMException('Only secure origins are allowed.', 'SecurityError'));
+                }
+
+                args[0] = getProxyUrl(url, { resourceType: stringifyResourceType({ isServiceWorker: true }) });
+            }
+
+            args[1] = { scope: '/' };
+
+            return nativeMethods.registerServiceWorker.apply(windowSandbox.window.navigator.serviceWorker, args)
+                .then(reg => new Promise(function (resolve, reject) {
+                    const parsedProxyUrl = parseProxyUrl(args[0]);
+                    const serviceWorker  = reg.installing;
+
+                    if (!serviceWorker) {
+                        resolve(reg);
+
+                        return;
+                    }
+
+                    const channel = new nativeMethods.MessageChannel();
+
+                    serviceWorker.postMessage({
+                        cmd:          SET_SERVICE_WORKER_SETTINGS,
+                        currentScope: getScope(url),
+                        optsScope:    getScope(opts && opts.scope),
+                        protocol:     parsedProxyUrl.destResourceInfo.protocol, // eslint-disable-line no-restricted-properties
+                        host:         parsedProxyUrl.destResourceInfo.host, // eslint-disable-line no-restricted-properties
+                    }, [channel.port1]);
+
+                    channel.port2.onmessage = (e) => {
+                        const data = nativeMethods.messageEventDataGetter.call(e);
+
+                        if (data.error)
+                            reject(new Error(data.error));
+                        else
+                            resolve(reg);
+                    };
+                }));
+        });
+    }
+
+
+    private static isSecureOrigin (url: string): boolean {
+        // NOTE: https://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-features
+        const parsedUrl = parseUrl(resolveUrlAsDest(url));
+
+        /*eslint-disable no-restricted-properties*/
+        return ALLOWED_SERVICE_WORKER_PROTOCOLS.indexOf(parsedUrl.protocol) === -1 &&
+               ALLOWED_SERVICE_WORKER_HOST_NAMES.indexOf(parsedUrl.hostname) === -1;
+        /*eslint-enable no-restricted-properties*/
+    }
+
+    private overrideGetRegistrationInNavigator () {
+        const windowSandbox = this;
+
+        overrideFunction(this.window.navigator.serviceWorker, 'getRegistration', (...args) => {
+            if (typeof args[0] === 'string')
+                args[0] = '/';
+
+            return nativeMethods.getRegistrationServiceWorker.apply(windowSandbox.window.navigator.serviceWorker, args);
+        });
+    }
+
+    private overrideCreateContextualFragmentInRange () {
+        const nodeSandbox = this.nodeSandbox;
+
+        overrideFunction(this.window.Range.prototype, 'createContextualFragment', function (this: Range, ...args) {
+            const tagString = args[0];
+
+            if (typeof tagString === 'string') {
+                args[0] = processHtml(tagString, {
+                    processedContext: this.startContainer && this.startContainer[INTERNAL_PROPS.processedContext],
+                });
+            }
+
+            const fragment = nativeMethods.createContextualFragment.apply(this, args);
+
+            nodeSandbox.processNodes(fragment);
+
+            return fragment;
+        });
+    }
+
+    private overrideListenerMethodsInEventTarget () {
+        const overriddenMethods = this.listenersSandbox.createOverriddenMethods();
+
+        overrideFunction(this.window.EventTarget.prototype, 'addEventListener', overriddenMethods.addEventListener);
+        overrideFunction(this.window.EventTarget.prototype, 'removeEventListener', overriddenMethods.removeEventListener);
+    }
+
+    private overrideImageInWindow () {
+        const nodeSandbox = this.nodeSandbox;
+
+        overrideConstructor(this.window, 'Image', function () {
+            let image = null;
+
+            if (!arguments.length)
+                image = new nativeMethods.Image();
+            else if (arguments.length === 1)
+                image = new nativeMethods.Image(arguments[0]);
+            else
+                image = new nativeMethods.Image(arguments[0], arguments[1]);
+
+            image[INTERNAL_PROPS.forceProxySrcForImage] = true;
+
+            nodeSandbox.processNodes(image);
+
+            return image;
+        });
+    }
+
+    private overrideFunctionInWindow () {
+        overrideConstructor(this.window, 'Function', function (this: Function, ...args) {
+            const functionBodyArgIndex = args.length - 1;
+
+            if (typeof args[functionBodyArgIndex] === 'string')
+                args[functionBodyArgIndex] = processScript(args[functionBodyArgIndex], false, false, convertToProxyUrl);
+
+            const fn = nativeMethods.Function.apply(this, args);
+
+            WindowSandbox.patchFunctionPrototype(fn, this);
+
+            return fn;
+        }, true);
+
+    }
+
+    private static patchFunctionPrototype (fn: Function, ctx: any): void {
         if (!ctx || isFunction(ctx))
             return;
 
@@ -409,574 +916,148 @@ export default class WindowSandbox extends SandboxBase {
         nativeMethods.objectSetPrototypeOf(fn, inheritorProto);
     }
 
-    static _isSecureOrigin (url: string): boolean {
-        // NOTE: https://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-features
-        const parsedUrl = parseUrl(resolveUrlAsDest(url));
-
-        /*eslint-disable no-restricted-properties*/
-        return ALLOWED_SERVICE_WORKER_PROTOCOLS.indexOf(parsedUrl.protocol) === -1 &&
-               ALLOWED_SERVICE_WORKER_HOST_NAMES.indexOf(parsedUrl.hostname) === -1;
-        /*eslint-enable no-restricted-properties*/
-    }
-
-    private _setSandboxedTextForTitleElements (el: Node & ParentNode): void {
-        if (isIframeWindow(window))
-            return;
-
-        const titleElements = getNativeQuerySelectorAll(el).call(el, 'title');
-
-        for (const titleElement of titleElements) {
-            // NOTE: SVGTitleElement can be here (GH-2364)
-            if (!isTitleElement(titleElement))
-                continue;
-
-            const nativeText = nativeMethods.titleElementTextGetter.call(titleElement);
-
-            this._documentTitleStorageInitializer.storage.setTitleElementPropertyValue(titleElement, nativeText);
-        }
-    }
-
-    private _overrideAllUrlAttrDescriptors (): void {
-        this._overrideUrlAttrDescriptors('data', [window.HTMLObjectElement]);
-
-        if (!this.proxyless) {
-            this._overrideUrlAttrDescriptors('src', [
-                window.HTMLImageElement,
-                window.HTMLScriptElement,
-                window.HTMLEmbedElement,
-                window.HTMLSourceElement,
-                window.HTMLMediaElement,
-                window.HTMLInputElement,
-                window.HTMLFrameElement,
-                window.HTMLIFrameElement,
-            ]);
-        }
-
-        this._overrideUrlAttrDescriptors('action', [window.HTMLFormElement]);
-
-        this._overrideUrlAttrDescriptors('formAction', [
-            window.HTMLInputElement,
-            window.HTMLButtonElement,
-        ]);
-
-        if (!this.proxyless) {
-            this._overrideUrlAttrDescriptors('href', [
-                window.HTMLAnchorElement,
-                window.HTMLLinkElement,
-                window.HTMLAreaElement,
-                window.HTMLBaseElement,
-            ]);
-        }
-
-        if (nativeMethods.htmlManifestGetter)
-            this._overrideUrlAttrDescriptors('manifest', [window.HTMLHtmlElement]);
-    }
-
-    static isProxyObject (obj: any): boolean {
-        try {
-            return obj[IS_PROXY_OBJECT_INTERNAL_PROP_NAME] === IS_PROXY_OBJECT_INTERNAL_PROP_VALUE;
-        }
-        catch (e) {
-            return false;
-        }
-    }
-
-    handleEvent (event) {
-        if (event.defaultPrevented)
-            return;
-
-        if (event.type === 'unhandledrejection')
-            this._raiseUncaughtJsErrorEvent(this.UNHANDLED_REJECTION_EVENT, event, this.window);
-        else if (event.type === 'error') {
-            if (event.message.indexOf('NS_ERROR_NOT_INITIALIZED') !== -1)
-                event.preventDefault();
-            else
-                this._raiseUncaughtJsErrorEvent(this.UNCAUGHT_JS_ERROR_EVENT, event, window);
-        }
-        else if (event.type === 'hashchange')
-            this.emit(this.HASH_CHANGE_EVENT);
-    }
-
-    attach (window): void {
-        super.attach(window);
-
-        const messageSandbox = this.messageSandbox;
-        const nodeSandbox    = this.nodeSandbox;
-        const windowSandbox  = this;
-
-        nativeMethods.arrayForEach.call(TRACKED_EVENTS, (event: string) => {
-            this._reattachHandler(window, event);
-        });
-
-        this.listenersSandbox.initElementListening(window, TRACKED_EVENTS);
-        this.listenersSandbox.on(this.listenersSandbox.EVENT_LISTENER_ATTACHED_EVENT, e => {
-            if (e.el !== window)
-                return;
-
-            if (TRACKED_EVENTS.indexOf(e.eventType) !== -1)
-                this._reattachHandler(window, e.eventType);
-        });
-        this._overrideEventPropDescriptor(window, 'error', nativeMethods.winOnErrorSetter);
-        this._overrideEventPropDescriptor(window, 'hashchange', nativeMethods.winOnHashChangeSetter);
-
-        if (nativeMethods.winOnUnhandledRejectionSetter)
-            this._overrideEventPropDescriptor(window, 'unhandledrejection', nativeMethods.winOnUnhandledRejectionSetter);
-
-        messageSandbox.on(messageSandbox.SERVICE_MSG_RECEIVED_EVENT, e => {
-            const { msg, pageUrl, stack, cmd } = e.message;
-
-            if (cmd === this.UNCAUGHT_JS_ERROR_EVENT || cmd === this.UNHANDLED_REJECTION_EVENT)
-                windowSandbox.emit(cmd, { msg, pageUrl, stack });
-        });
-
-        overrideFunction(window.CanvasRenderingContext2D.prototype, 'drawImage', function (this: CanvasRenderingContext2D, ...args) {
-            let image = args[0];
-
-            if (isImgElement(image) && !image[INTERNAL_PROPS.forceProxySrcForImage]) {
-                const src = nativeMethods.imageSrcGetter.call(image);
-
-                if (destLocation.sameOriginCheck(location.toString(), src)) {
-                    image = nativeMethods.createElement.call(window.document, 'img');
-
-                    nativeMethods.imageSrcSetter.call(image, getProxyUrl(src));
-
-                    args[0] = image;
-
-                    if (!image.complete) {
-                        nativeMethods.addEventListener.call(image, 'load',
-                            () => nativeMethods.canvasContextDrawImage.apply(this, args));
-                    }
-                }
-            }
-
-            return nativeMethods.canvasContextDrawImage.apply(this, args);
-        });
-
-        if (nativeMethods.objectAssign) {
-            overrideFunction(window.Object, 'assign', function (this: ObjectConstructor, target: object, ...sources: any[]) {
-                let args         = [target] as [object, ...any[]];
-                const targetType = typeof target;
-
-                if (target && (targetType === 'object' || targetType === 'function') && sources.length) {
-                    for (const source of sources) {
-                        const sourceType = typeof source;
-
-                        if (!source || sourceType !== 'object' && sourceType !== 'function') {
-                            nativeMethods.objectAssign.call(this, target, source);
-                            continue;
-                        }
-
-                        const sourceSymbols = nativeMethods.objectGetOwnPropertySymbols.call(window.Object, source);
-                        const sourceKeys    = nativeMethods.arrayConcat.call(
-                            nativeMethods.objectKeys.call(window.Object, source),
-                            sourceSymbols
-                        );
-
-                        for (const key of sourceKeys)
-                            window[INSTRUCTION.setProperty](target, key, source[key]);
-                    }
-                }
-                else
-                    args = nativeMethods.arrayConcat.call(args, sources);
-
-                return nativeMethods.objectAssign.apply(this, args);
-            });
-        }
-
-        overrideFunction(window, 'open', function (...args: [string?, string?, string?, boolean?]) {
-            args[0] = getProxyUrl(args[0]);
-            args[1] = windowSandbox._getWindowOpenTarget(args[1]);
-
-            return windowSandbox._childWindowSandbox.handleWindowOpen(window, args);
-        });
-
-        if (window.FontFace && !this.proxyless) {
-            overrideConstructor(window, 'FontFace', (family, source, descriptors) => {
-                source = styleProcessor.process(source, convertToProxyUrl);
-
-                return new nativeMethods.FontFace(family, source, descriptors);
-            });
-        }
-
-        if (window.Worker && !this.proxyless) {
-            overrideConstructor(window, 'Worker', function WorkerWrapper (this: Worker, ...args: [string | URL, WorkerOptions?]) {
-                const isCalledWithoutNewKeyword = constructorIsCalledWithoutNewKeyword(this, WorkerWrapper);
-
-                if (arguments.length === 0)
-                    // @ts-ignore
-                    return isCalledWithoutNewKeyword ? nativeMethods.Worker() : new nativeMethods.Worker();
-
-                if (isCalledWithoutNewKeyword)
-                    return nativeMethods.Worker.apply(this, args);
-
-                let scriptURL = args[0];
-
-                if (typeof scriptURL !== 'string')
-                    scriptURL = String(scriptURL);
-
-                scriptURL = getProxyUrl(scriptURL, { resourceType: stringifyResourceType({ isScript: true }) });
-
-                const worker = arguments.length === 1
-                    ? new nativeMethods.Worker(scriptURL)
-                    : new nativeMethods.Worker(scriptURL, args[1]);
-
-                return worker;
-            }, true);
-        }
-
-        if (window.Blob) {
-            overrideConstructor(window, 'Blob', function (array, opts) {
-                if (arguments.length === 0)
-                    return new nativeMethods.Blob();
-
-                if (WindowSandbox._isProcessableBlob(array, opts))
-                    array = [processScript(array.join(''), true, false, convertToProxyUrl, void 0, settings.get().proxyless, WindowSandbox._getBlobProcessingSettings())];
-
-                // NOTE: IE11 throws an error when the second parameter of the Blob function is undefined (GH-44)
-                // If the overridden function is called with one parameter, we need to call the original function
-                // with one parameter as well.
-                return arguments.length === 1 ? new nativeMethods.Blob(array) : new nativeMethods.Blob(array, opts);
-            });
-        }
-
-        // NOTE: non-IE11 case. window.File in IE11 is not constructable.
-        if (nativeMethods.File) {
-            overrideConstructor(window, 'File', function (array, fileName, opts) {
-                if (arguments.length === 0)
-                    return new nativeMethods.File();
-
-                if (WindowSandbox._isProcessableBlob(array, opts))
-                    array = [processScript(array.join(''), true, false, convertToProxyUrl, void 0, settings.get().proxyless, WindowSandbox._getBlobProcessingSettings())];
-
-                return new nativeMethods.File(array, fileName, opts);
-            });
-        }
-
-        if (window.EventSource && !this.proxyless) {
-            overrideConstructor(window, 'EventSource', function (url, opts) {
-                if (arguments.length) {
-                    const proxyUrl = getProxyUrl(url, { resourceType: stringifyResourceType({ isEventSource: true }) });
-
-                    if (arguments.length === 1)
-                        return new nativeMethods.EventSource(proxyUrl);
-
-                    return new nativeMethods.EventSource(proxyUrl, opts);
-                }
-
-                return new nativeMethods.EventSource();
-            });
-
-            window.EventSource.CONNECTING = nativeMethods.EventSource.CONNECTING;
-            window.EventSource.OPEN       = nativeMethods.EventSource.OPEN;
-            window.EventSource.CLOSED     = nativeMethods.EventSource.CLOSED;
-        }
-
-        if (window.MutationObserver) {
-            overrideConstructor(window, 'MutationObserver', callback => {
-                const wrapper = function (this: MutationObserver, mutations: MutationRecord[]) {
-                    const result = [];
-
-                    for (const mutation of mutations) {
-                        if (!ShadowUI.isShadowUIMutation(mutation))
-                            result.push(mutation);
-                    }
-
-                    if (result.length)
-                        callback.call(this, result, this);
-                };
-
-                return new nativeMethods.MutationObserver(wrapper);
-            });
-
-            if (window.WebKitMutationObserver)
-                window.WebKitMutationObserver = window.MutationObserver;
-        }
-
-        if (window.Proxy) {
-            overrideConstructor(window, 'Proxy', function (target, handler) {
-                if (handler.get && !handler.get[PROXY_HANDLER_FLAG]) {
-                    const storedGet = handler.get;
-
-                    handler.get = function (getterTarget, name, receiver) {
-                        if (name === IS_PROXY_OBJECT_INTERNAL_PROP_NAME)
-                            return IS_PROXY_OBJECT_INTERNAL_PROP_VALUE;
-                        else if (INSTRUCTION_VALUES.indexOf(name) > -1)
-                            return window[name];
-
-                        const result = storedGet.call(this, getterTarget, name, receiver);
-
-                        if (name === 'eval' && result[CodeInstrumentation.WRAPPED_EVAL_FN])
-                            return result[CodeInstrumentation.WRAPPED_EVAL_FN];
-
-                        return result;
-                    };
-
-                    nativeMethods.objectDefineProperty(handler.get, PROXY_HANDLER_FLAG, { value: true, enumerable: false });
-                }
-
-                return new nativeMethods.Proxy(target, handler);
-            });
-
-            window.Proxy.revocable = nativeMethods.Proxy.revocable;
-        }
-
-        if (nativeMethods.registerServiceWorker && !this.proxyless) {
-            overrideFunction(window.navigator.serviceWorker, 'register', (...args) => {
-                const [url, opts] = args;
-
-                if (typeof url === 'string') {
-                    if (WindowSandbox._isSecureOrigin(url)) {
-                        // NOTE: We cannot create an instance of the DOMException in the Android 6.0 and in the Edge 17 browsers.
-                        // The 'TypeError: Illegal constructor' error is raised if we try to call the constructor.
-                        return Promise.reject(isAndroid || isMSEdge && browserVersion >= 17
-                            ? new Error('Only secure origins are allowed.')
-                            : new DOMException('Only secure origins are allowed.', 'SecurityError'));
-                    }
-
-                    args[0] = getProxyUrl(url, { resourceType: stringifyResourceType({ isServiceWorker: true }) });
-                }
-
-                args[1] = { scope: '/' };
-
-                return nativeMethods.registerServiceWorker.apply(window.navigator.serviceWorker, args)
-                    .then(reg => new Promise(function (resolve, reject) {
-                        const parsedProxyUrl = parseProxyUrl(args[0]);
-                        const serviceWorker  = reg.installing;
-
-                        if (!serviceWorker) {
-                            resolve(reg);
-
-                            return;
-                        }
-
-                        const channel = new nativeMethods.MessageChannel();
-
-                        serviceWorker.postMessage({
-                            cmd:          SET_SERVICE_WORKER_SETTINGS,
-                            currentScope: getScope(url),
-                            optsScope:    getScope(opts && opts.scope),
-                            protocol:     parsedProxyUrl.destResourceInfo.protocol, // eslint-disable-line no-restricted-properties
-                            host:         parsedProxyUrl.destResourceInfo.host, // eslint-disable-line no-restricted-properties
-                        }, [channel.port1]);
-
-                        channel.port2.onmessage = (e) => {
-                            const data = nativeMethods.messageEventDataGetter.call(e);
-
-                            if (data.error)
-                                reject(new Error(data.error));
-                            else
-                                resolve(reg);
-                        };
-                    }));
-            });
-        }
-
-        if (nativeMethods.getRegistrationServiceWorker && !this.proxyless) {
-            overrideFunction(window.navigator.serviceWorker, 'getRegistration', (...args) => {
-                if (typeof args[0] === 'string')
-                    args[0] = '/';
-
-                return nativeMethods.getRegistrationServiceWorker.apply(window.navigator.serviceWorker, args);
-            });
-        }
-
-        if (window.Range.prototype.createContextualFragment) {
-            overrideFunction(window.Range.prototype, 'createContextualFragment', function (this: Range, ...args) {
-                const tagString = args[0];
-
-                if (typeof tagString === 'string') {
-                    args[0] = processHtml(tagString, {
-                        processedContext: this.startContainer && this.startContainer[INTERNAL_PROPS.processedContext],
-                    });
-                }
-
-                const fragment = nativeMethods.createContextualFragment.apply(this, args);
-
-                nodeSandbox.processNodes(fragment);
-
-                return fragment;
-            });
-        }
-
-        if (window.EventTarget) {
-            const overriddenMethods = this.listenersSandbox.createOverriddenMethods();
-
-            overrideFunction(window.EventTarget.prototype, 'addEventListener', overriddenMethods.addEventListener);
-            overrideFunction(window.EventTarget.prototype, 'removeEventListener', overriddenMethods.removeEventListener);
-        }
-
-        if (!this.proxyless) {
-            overrideConstructor(window, 'Image', function () {
-                let image = null;
-
-                if (!arguments.length)
-                    image = new nativeMethods.Image();
-                else if (arguments.length === 1)
-                    image = new nativeMethods.Image(arguments[0]);
-                else
-                    image = new nativeMethods.Image(arguments[0], arguments[1]);
-
-                image[INTERNAL_PROPS.forceProxySrcForImage] = true;
-
-                nodeSandbox.processNodes(image);
-
-                return image;
-            });
-        }
-
-        overrideConstructor(window, 'Function', function (this: Function, ...args) {
-            const functionBodyArgIndex = args.length - 1;
-
-            if (typeof args[functionBodyArgIndex] === 'string')
-                args[functionBodyArgIndex] = processScript(args[functionBodyArgIndex], false, false, convertToProxyUrl);
-
-            const fn = nativeMethods.Function.apply(this, args);
-
-            WindowSandbox._patchFunctionPrototype(fn, this);
-
-            return fn;
-        }, true);
-
+    private overrideToStringInFunction () {
         overrideFunction(nativeMethods.Function.prototype, 'toString', function (this: Function) {
             if (nativeMethods.objectHasOwnProperty.call(this, INTERNAL_PROPS.nativeStrRepresentation))
                 return this[INTERNAL_PROPS.nativeStrRepresentation];
 
             return nativeMethods.functionToString.call(this);
         });
+    }
 
-        if (isFunction(window.history.pushState)
-            && isFunction(window.history.replaceState)
-            && !this.proxyless) {
-            const createWrapperForHistoryStateManipulationFn = function (nativeFn) {
-                return function (this: History, ...args) {
-                    const url = args[2];
+    private overrideMethodInHistory (name, nativeMethod) {
+        overrideFunction(this.window.history, name, function (this: History, ...args) {
+            const url = args[2];
 
-                    if (args.length > 2 && (url !== null && (isIE || url !== void 0)))
-                        args[2] = getProxyUrl(url);
+            if (args.length > 2 && (url !== null && (isIE || url !== void 0)))
+                args[2] = getProxyUrl(url);
 
-                    return nativeFn.apply(this, args);
-                };
-            };
+            return nativeMethod.apply(this, args);
+        });
+    }
 
-            overrideFunction(window.history, 'pushState', createWrapperForHistoryStateManipulationFn(nativeMethods.historyPushState));
-            overrideFunction(window.history, 'replaceState', createWrapperForHistoryStateManipulationFn(nativeMethods.historyReplaceState));
-        }
+    private overrideSendBeaconInNavigator () {
+        overrideFunction(this.window.Navigator.prototype, 'sendBeacon', function (this: Navigator) {
+            if (typeof arguments[0] === 'string')
+                arguments[0] = getProxyUrl(arguments[0]);
 
-        if (nativeMethods.sendBeacon && !this.proxyless) {
-            overrideFunction(window.Navigator.prototype, 'sendBeacon', function (this: Navigator) {
-                if (typeof arguments[0] === 'string')
-                    arguments[0] = getProxyUrl(arguments[0]);
+            return nativeMethods.sendBeacon.apply(this, arguments);
+        });
+    }
 
-                return nativeMethods.sendBeacon.apply(this, arguments);
-            });
-        }
+    private overrideRegisterProtocolHandlerInNavigator () {
+        overrideFunction(this.window.navigator, 'registerProtocolHandler', function (...args) {
+            const urlIndex = 1;
 
-        if (window.navigator.registerProtocolHandler && !this.proxyless) {
-            overrideFunction(window.navigator, 'registerProtocolHandler', function (...args) {
-                const urlIndex = 1;
+            if (typeof args[urlIndex] === 'string') {
+                // eslint-disable-next-line no-restricted-properties
+                const destHostname = destLocation.getParsed().hostname;
+                let isDestUrl      = false;
 
-                if (typeof args[urlIndex] === 'string') {
+                if (isFirefox) {
+                    const parsedUrl = parseUrl(args[urlIndex]);
+
                     // eslint-disable-next-line no-restricted-properties
-                    const destHostname = destLocation.getParsed().hostname;
-                    let isDestUrl      = false;
+                    isDestUrl = parsedUrl.hostname && destHostname === parsedUrl.hostname;
+                }
+                else
+                    isDestUrl = destLocation.sameOriginCheck(destLocation.get(), args[urlIndex]);
 
-                    if (isFirefox) {
-                        const parsedUrl = parseUrl(args[urlIndex]);
+                if (isDestUrl)
+                    args[urlIndex] = getProxyUrl(args[urlIndex]);
+            }
 
+            return nativeMethods.registerProtocolHandler.apply(navigator, args);
+        });
+    }
+
+    private overrideAppendInFormData () {
+        overrideFunction(this.window.FormData.prototype, 'append', function (this: FormData, ...args: [string, string | Blob, string?]) {
+            const [name, value] = args;
+
+            // NOTE: We should not send our hidden input's value along with the file info,
+            // because our input may have incorrect value if the input with the file has been removed from DOM.
+            if (name === INTERNAL_ATTRS.uploadInfoHiddenInputName)
+                return;
+
+            // NOTE: If we append our file wrapper to FormData, we will lose the file name.
+            // This happens because the file wrapper is an instance of Blob
+            // and a browser thinks that Blob does not contain the "name" property.
+            if (args.length === 2 && isBlob(value) && 'name' in value)
+                args[2] = value['name'] as string;
+
+            nativeMethods.formDataAppend.apply(this, args);
+        });
+    }
+
+    private overrideWebSocketInWindow () {
+        overrideConstructor(this.window, 'WebSocket', function (url, protocols) {
+            if (arguments.length === 0)
+                return new nativeMethods.WebSocket();
+
+            const proxyUrl = getProxyUrl(url, { resourceType: stringifyResourceType({ isWebSocket: true }) });
+
+            if (arguments.length === 1)
+                return new nativeMethods.WebSocket(proxyUrl);
+            else if (arguments.length === 2)
+                return new nativeMethods.WebSocket(proxyUrl, protocols);
+
+            return new nativeMethods.WebSocket(proxyUrl, protocols, arguments[2]);
+        });
+
+        //@ts-ignore
+        this.window.WebSocket.CONNECTING = nativeMethods.WebSocket.CONNECTING;
+        //@ts-ignore
+        this.window.WebSocket.OPEN = nativeMethods.WebSocket.OPEN;
+        //@ts-ignore
+        this.window.WebSocket.CLOSING = nativeMethods.WebSocket.CLOSING;
+        //@ts-ignore
+        this.window.WebSocket.CLOSED = nativeMethods.WebSocket.CLOSED;
+    }
+
+    private overrideUrlInWebSocket () {
+        overrideDescriptor(this.window.WebSocket.prototype, 'url', {
+            getter: function () {
+                const url       = nativeMethods.webSocketUrlGetter.call(this);
+                const parsedUrl = parseProxyUrl(url);
+
+                if (parsedUrl && parsedUrl.destUrl)
+                    return parsedUrl.destUrl.replace(HTTP_PROTOCOL_RE, 'ws');
+
+                return url;
+            },
+        });
+    }
+
+    private overrideOriginInMessageEvent () {
+        overrideDescriptor(this.window.MessageEvent.prototype, 'origin', {
+            getter: function (this: MessageEvent) {
+                const target = nativeMethods.eventTargetGetter.call(this);
+                const origin = nativeMethods.messageEventOriginGetter.call(this);
+
+                if (isWebSocket(target)) {
+                    const parsedUrl = parseUrl(target.url);
+
+                    if (parsedUrl)
                         // eslint-disable-next-line no-restricted-properties
-                        isDestUrl = parsedUrl.hostname && destHostname === parsedUrl.hostname;
-                    }
-                    else
-                        isDestUrl = destLocation.sameOriginCheck(destLocation.get(), args[urlIndex]);
+                        return parsedUrl.protocol + '//' + parsedUrl.host;
+                }
+                else if (isWindow(target)) {
+                    const data = nativeMethods.messageEventDataGetter.call(this);
 
-                    if (isDestUrl)
-                        args[urlIndex] = getProxyUrl(args[urlIndex]);
+                    if (data)
+                        return data.originUrl;
                 }
 
-                return nativeMethods.registerProtocolHandler.apply(navigator, args);
-            });
-        }
+                return origin;
+            },
+        });
+    }
 
-        if (window.FormData) {
-            overrideFunction(window.FormData.prototype, 'append', function (this: FormData, ...args: [string, string | Blob, string?]) {
-                const [name, value] = args;
+    private overrideLengthInHTMLCollection () {
+        const windowSandbox = this;
 
-                // NOTE: We should not send our hidden input's value along with the file info,
-                // because our input may have incorrect value if the input with the file has been removed from DOM.
-                if (name === INTERNAL_ATTRS.uploadInfoHiddenInputName)
-                    return;
-
-                // NOTE: If we append our file wrapper to FormData, we will lose the file name.
-                // This happens because the file wrapper is an instance of Blob
-                // and a browser thinks that Blob does not contain the "name" property.
-                if (args.length === 2 && isBlob(value) && 'name' in value)
-                    args[2] = value['name'] as string;
-
-                nativeMethods.formDataAppend.apply(this, args);
-            });
-        }
-
-        if (window.WebSocket && !this.proxyless) {
-            overrideConstructor(window, 'WebSocket', function (url, protocols) {
-                if (arguments.length === 0)
-                    return new nativeMethods.WebSocket();
-
-                const proxyUrl = getProxyUrl(url, { resourceType: stringifyResourceType({ isWebSocket: true }) });
-
-                if (arguments.length === 1)
-                    return new nativeMethods.WebSocket(proxyUrl);
-                else if (arguments.length === 2)
-                    return new nativeMethods.WebSocket(proxyUrl, protocols);
-
-                return new nativeMethods.WebSocket(proxyUrl, protocols, arguments[2]);
-            });
-
-            window.WebSocket.CONNECTING = nativeMethods.WebSocket.CONNECTING;
-            window.WebSocket.OPEN       = nativeMethods.WebSocket.OPEN;
-            window.WebSocket.CLOSING    = nativeMethods.WebSocket.CLOSING;
-            window.WebSocket.CLOSED     = nativeMethods.WebSocket.CLOSED;
-
-            if (nativeMethods.webSocketUrlGetter) {
-                overrideDescriptor(window.WebSocket.prototype, 'url', {
-                    getter: function () {
-                        const url       = nativeMethods.webSocketUrlGetter.call(this);
-                        const parsedUrl = parseProxyUrl(url);
-
-                        if (parsedUrl && parsedUrl.destUrl)
-                            return parsedUrl.destUrl.replace(HTTP_PROTOCOL_RE, 'ws');
-
-                        return url;
-                    },
-                });
-            }
-        }
-
-        if (!this.proxyless) {
-            overrideDescriptor(window.MessageEvent.prototype, 'origin', {
-                getter: function (this: MessageEvent) {
-                    const target = nativeMethods.eventTargetGetter.call(this);
-                    const origin = nativeMethods.messageEventOriginGetter.call(this);
-
-                    if (isWebSocket(target)) {
-                        const parsedUrl = parseUrl(target.url);
-
-                        if (parsedUrl)
-                            // eslint-disable-next-line no-restricted-properties
-                            return parsedUrl.protocol + '//' + parsedUrl.host;
-                    }
-                    else if (isWindow(target)) {
-                        const data = nativeMethods.messageEventDataGetter.call(this);
-
-                        if (data)
-                            return data.originUrl;
-                    }
-
-                    return origin;
-                },
-            });
-        }
-
-        overrideDescriptor(window.HTMLCollection.prototype, 'length', {
+        overrideDescriptor(this.window.HTMLCollection.prototype, 'length', {
             getter: function () {
                 const length = nativeMethods.htmlCollectionLengthGetter.call(this);
 
@@ -986,8 +1067,12 @@ export default class WindowSandbox extends SandboxBase {
                 return length;
             },
         });
+    }
 
-        overrideDescriptor(window.NodeList.prototype, 'length', {
+    private overrideLengthInNodeList () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.NodeList.prototype, 'length', {
             getter: function () {
                 const length = nativeMethods.nodeListLengthGetter.call(this);
 
@@ -997,8 +1082,12 @@ export default class WindowSandbox extends SandboxBase {
                 return length;
             },
         });
+    }
 
-        overrideDescriptor(window.Element.prototype, 'childElementCount', {
+    private overrideChildElementCountInElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.Element.prototype, 'childElementCount', {
             getter: function (this: Element) {
                 if (ShadowUI.isShadowContainer(this)) {
                     const children = nativeMethods.elementChildrenGetter.call(this);
@@ -1011,24 +1100,27 @@ export default class WindowSandbox extends SandboxBase {
             },
         });
 
-        if (nativeMethods.performanceEntryNameGetter && !this.proxyless) {
-            overrideDescriptor(window.PerformanceEntry.prototype, 'name', {
-                getter: function () {
-                    const name = nativeMethods.performanceEntryNameGetter.call(this);
+    }
 
-                    if (isPerformanceNavigationTiming(this)) {
-                        const parsedProxyUrl = parseProxyUrl(name);
+    private overrideNameInPerformanceEntry () {
+        overrideDescriptor(this.window.PerformanceEntry.prototype, 'name', {
+            getter: function () {
+                const name = nativeMethods.performanceEntryNameGetter.call(this);
 
-                        if (parsedProxyUrl)
-                            return parsedProxyUrl.destUrl;
-                    }
+                if (isPerformanceNavigationTiming(this)) {
+                    const parsedProxyUrl = parseProxyUrl(name);
 
-                    return name;
-                },
-            });
-        }
+                    if (parsedProxyUrl)
+                        return parsedProxyUrl.destUrl;
+                }
 
-        overrideDescriptor(window.HTMLInputElement.prototype, 'files', {
+                return name;
+            },
+        });
+    }
+
+    private overrideFilesInHTMLInputElement () {
+        overrideDescriptor(this.window.HTMLInputElement.prototype, 'files', {
             getter: function (this: HTMLInputElement) {
                 if (this.type.toLowerCase() === 'file')
                     return UploadSandbox.getFiles(this);
@@ -1036,8 +1128,12 @@ export default class WindowSandbox extends SandboxBase {
                 return nativeMethods.inputFilesGetter.call(this);
             },
         });
+    }
 
-        overrideDescriptor(window.HTMLInputElement.prototype, 'value', {
+    private overrideValueInHTMLInputElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.HTMLInputElement.prototype, 'value', {
             getter: function (this: HTMLInputElement) {
                 if (this.type.toLowerCase() === 'file')
                     return UploadSandbox.getUploadElementValue(this);
@@ -1056,28 +1152,33 @@ export default class WindowSandbox extends SandboxBase {
                     windowSandbox.elementEditingWatcher.restartWatchingElementEditing(this);
             },
         });
+    }
 
-        // NOTE: HTMLInputElement raises the `change` event on `disabled` only in Chrome
-        if (isChrome) {
-            overrideDescriptor(window.HTMLInputElement.prototype, 'disabled', {
-                getter: null,
-                setter: function (this: HTMLInputElement, value) {
-                    if (nativeMethods.documentActiveElementGetter.call(document) === this) {
-                        const savedValue   = windowSandbox.elementEditingWatcher.getElementSavedValue(this);
-                        const currentValue = nativeMethods.inputValueGetter.call(this);
+    private overrideDisabledInHTMLInputElement () {
+        const windowSandbox = this;
 
-                        if (windowSandbox.elementEditingWatcher.isEditingObserved(this) && currentValue !== savedValue)
-                            windowSandbox.eventSimulator.change(this);
+        overrideDescriptor(this.window.HTMLInputElement.prototype, 'disabled', {
+            getter: null,
+            setter: function (this: HTMLInputElement, value) {
+                if (nativeMethods.documentActiveElementGetter.call(document) === this) {
+                    const savedValue   = windowSandbox.elementEditingWatcher.getElementSavedValue(this);
+                    const currentValue = nativeMethods.inputValueGetter.call(this);
 
-                        windowSandbox.elementEditingWatcher.stopWatching(this);
-                    }
+                    if (windowSandbox.elementEditingWatcher.isEditingObserved(this) && currentValue !== savedValue)
+                        windowSandbox.eventSimulator.change(this);
 
-                    nativeMethods.inputDisabledSetter.call(this, value);
-                },
-            });
-        }
+                    windowSandbox.elementEditingWatcher.stopWatching(this);
+                }
 
-        overrideDescriptor(window.HTMLInputElement.prototype, 'required', {
+                nativeMethods.inputDisabledSetter.call(this, value);
+            },
+        });
+    }
+
+    private overrideRequiredInHTMLInputElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.HTMLInputElement.prototype, 'required', {
             getter: function (this: HTMLInputElement) {
                 return windowSandbox.nodeSandbox.element.getAttributeCore(this, ['required']) !== null;
             },
@@ -1090,8 +1191,12 @@ export default class WindowSandbox extends SandboxBase {
                     windowSandbox.nodeSandbox.element.removeAttributeCore(this, ['required']);
             },
         });
+    }
 
-        overrideDescriptor(window.HTMLTextAreaElement.prototype, 'value', {
+    private overrideValueInHTMLTextAreaElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.HTMLTextAreaElement.prototype, 'value', {
             getter: null,
             setter: function (this: HTMLTextAreaElement, value) {
                 nativeMethods.textAreaValueSetter.call(this, value);
@@ -1100,44 +1205,108 @@ export default class WindowSandbox extends SandboxBase {
                     windowSandbox.elementEditingWatcher.restartWatchingElementEditing(this);
             },
         });
+    }
 
-        if (!this.proxyless)
-            this._overrideAllUrlAttrDescriptors();
+    private overrideAllUrlAttrDescriptors (): void {
+        this.overrideUrlAttrDescriptors('data', [this.window.HTMLObjectElement]);
 
-        this._overrideAttrDescriptors('target', [
-            window.HTMLAnchorElement,
-            window.HTMLFormElement,
-            window.HTMLAreaElement,
-            window.HTMLBaseElement,
-        ]);
-
-        this._overrideAttrDescriptors('formTarget', [
-            window.HTMLInputElement,
-            window.HTMLButtonElement,
-        ]);
-
-        this._overrideAttrDescriptors('autocomplete', [window.HTMLInputElement]);
-        this._overrideAttrDescriptors('httpEquiv', [window.HTMLMetaElement]);
-
-        // NOTE: Some browsers (for example, Edge, Internet Explorer 11, Safari) don't support the 'integrity' property.
-        if (nativeMethods.scriptIntegrityGetter && nativeMethods.linkIntegrityGetter) {
-            this._overrideAttrDescriptors('integrity', [window.HTMLScriptElement]);
-            this._overrideAttrDescriptors('integrity', [window.HTMLLinkElement]);
+        if (!this.proxyless) {
+            this.overrideUrlAttrDescriptors('src', [
+                this.window.HTMLImageElement,
+                this.window.HTMLScriptElement,
+                this.window.HTMLEmbedElement,
+                this.window.HTMLSourceElement,
+                this.window.HTMLMediaElement,
+                this.window.HTMLInputElement,
+                this.window.HTMLFrameElement,
+                this.window.HTMLIFrameElement,
+            ]);
         }
 
-        this._overrideAttrDescriptors('rel', [window.HTMLLinkElement]);
+        this.overrideUrlAttrDescriptors('action', [this.window.HTMLFormElement]);
 
-        if (nativeMethods.linkAsSetter)
-            this._overrideAttrDescriptors('as', [window.HTMLLinkElement]);
+        this.overrideUrlAttrDescriptors('formAction', [
+            this.window.HTMLInputElement,
+            this.window.HTMLButtonElement,
+        ]);
 
-        overrideDescriptor(window.HTMLInputElement.prototype, 'type', {
+        if (!this.proxyless) {
+            this.overrideUrlAttrDescriptors('href', [
+                this.window.HTMLAnchorElement,
+                this.window.HTMLLinkElement,
+                this.window.HTMLAreaElement,
+                this.window.HTMLBaseElement,
+            ]);
+        }
+
+        if (nativeMethods.htmlManifestGetter)
+            this.overrideUrlAttrDescriptors('manifest', [this.window.HTMLHtmlElement]);
+    }
+
+    private overrideUrlAttrDescriptors (attr, elementConstructors): void {
+        const windowSandbox = this;
+
+        for (const constructor of elementConstructors) {
+            overrideDescriptor(constructor.prototype, attr, {
+                getter: function (this: HTMLElement) {
+                    return WindowSandbox.getUrlAttr(this, attr);
+                },
+                setter: function (this: HTMLElement, value) {
+                    windowSandbox.nodeSandbox.element.setAttributeCore(this, [attr, value]);
+                },
+            });
+        }
+    }
+
+    private static getUrlAttr (el: HTMLElement, attr: string): string {
+        const attrValue       = nativeMethods.getAttribute.call(el, attr);
+        const currentDocument = el.ownerDocument || document;
+
+        if (attrValue === '' || attrValue === null && attr === 'action' && emptyActionAttrFallbacksToTheLocation)
+            return urlResolver.resolve('', currentDocument);
+
+        else if (attrValue === null)
+            return '';
+
+        else if (HASH_RE.test(attrValue))
+            return urlResolver.resolve(attrValue, currentDocument);
+
+        else if (!isValidUrl(attrValue))
+            return urlResolver.resolve(attrValue, currentDocument);
+
+        return resolveUrlAsDest(attrValue, attr === 'srcset');
+    }
+
+    overrideAttrDescriptorsInElement (attr, elementConstructors): void {
+        const windowSandbox = this;
+
+        for (const constructor of elementConstructors) {
+            overrideDescriptor(constructor.prototype, attr, {
+                getter: function (this: HTMLElement) {
+                    return windowSandbox.nodeSandbox.element.getAttributeCore(this, [attr]) || '';
+                },
+                setter: function (this: HTMLElement, value) {
+                    windowSandbox.nodeSandbox.element.setAttributeCore(this, [attr, value]);
+                },
+            });
+        }
+    }
+
+    private overrideTypeInHTMLInputElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.HTMLInputElement.prototype, 'type', {
             getter: null,
             setter: function (this: HTMLInputElement, value) {
                 windowSandbox.nodeSandbox.element.setAttributeCore(this, ['type', value]);
             },
         });
+    }
 
-        overrideDescriptor(window.HTMLIFrameElement.prototype, 'sandbox', {
+    private overrideSandboxInHTMLIFrameElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.HTMLIFrameElement.prototype, 'sandbox', {
             getter: function (this: HTMLIFrameElement) {
                 let domTokenList = this[SANDBOX_DOM_TOKEN_LIST];
 
@@ -1165,131 +1334,145 @@ export default class WindowSandbox extends SandboxBase {
                     this[SANDBOX_DOM_TOKEN_LIST_UPDATE_FN](windowSandbox.nodeSandbox.element.getAttributeCore(this, ['sandbox']) || '');
             },
         });
+    }
 
-        if (nativeMethods.iframeSrcdocGetter) {
-            overrideDescriptor(window.HTMLIFrameElement.prototype, 'srcdoc', {
-                getter: function (this: HTMLIFrameElement) {
-                    return windowSandbox.nodeSandbox.element.getAttributeCore(this, ['srcdoc']) || '';
-                },
-                setter: function (this: HTMLIFrameElement, value) {
-                    windowSandbox.nodeSandbox.element.setAttributeCore(this, ['srcdoc', value]);
-                },
-            });
-        }
+    private overrideSrcdocInHTMLIFrameElement () {
+        const windowSandbox = this;
 
-        if (!this.proxyless) {
-            this._overrideUrlPropDescriptor('port', nativeMethods.anchorPortGetter, nativeMethods.anchorPortSetter);
-            this._overrideUrlPropDescriptor('host', nativeMethods.anchorHostGetter, nativeMethods.anchorHostSetter);
-            this._overrideUrlPropDescriptor('hostname', nativeMethods.anchorHostnameGetter, nativeMethods.anchorHostnameSetter);
-            this._overrideUrlPropDescriptor('pathname', nativeMethods.anchorPathnameGetter, nativeMethods.anchorPathnameSetter);
-            this._overrideUrlPropDescriptor('protocol', nativeMethods.anchorProtocolGetter, nativeMethods.anchorProtocolSetter);
-            this._overrideUrlPropDescriptor('search', nativeMethods.anchorSearchGetter, nativeMethods.anchorSearchSetter);
-        }
+        overrideDescriptor(this.window.HTMLIFrameElement.prototype, 'srcdoc', {
+            getter: function (this: HTMLIFrameElement) {
+                return windowSandbox.nodeSandbox.element.getAttributeCore(this, ['srcdoc']) || '';
+            },
+            setter: function (this: HTMLIFrameElement, value) {
+                windowSandbox.nodeSandbox.element.setAttributeCore(this, ['srcdoc', value]);
+            },
+        });
+    }
 
-        if (!this.proxyless) {
-            overrideDescriptor(window.SVGImageElement.prototype, 'href', {
-                getter: function () {
-                    const imageHref = nativeMethods.svgImageHrefGetter.call(this);
+    private overrideUrlPropInHTMLAnchorElement (prop, nativePropGetter, nativePropSetter): void {
+        overrideDescriptor(this.window.HTMLAnchorElement.prototype, prop, {
+            getter: function (this: HTMLElement) {
+                return getAnchorProperty(this, nativePropGetter);
+            },
+            setter: function (this: HTMLElement, value) {
+                setAnchorProperty(this, nativePropSetter, value);
+            },
+        });
+    }
 
-                    if (!imageHref[CONTEXT_SVG_IMAGE_ELEMENT]) {
-                        nativeMethods.objectDefineProperty(imageHref, CONTEXT_SVG_IMAGE_ELEMENT, {
-                            value:        this,
-                            configurable: true,
-                        });
-                    }
+    private overrideHrefInSVGImageElement () {
+        overrideDescriptor(this.window.SVGImageElement.prototype, 'href', {
+            getter: function () {
+                const imageHref = nativeMethods.svgImageHrefGetter.call(this);
 
-                    return imageHref;
-                },
-            });
-
-            overrideDescriptor(window.SVGAnimatedString.prototype, 'baseVal', {
-                getter: function () {
-                    let baseVal = nativeMethods.svgAnimStrBaseValGetter.call(this);
-
-                    if (this[CONTEXT_SVG_IMAGE_ELEMENT])
-                        baseVal = getDestinationUrl(baseVal);
-
-                    return baseVal;
-                },
-                setter: function (value) {
-                    const contextSVGImageElement = this[CONTEXT_SVG_IMAGE_ELEMENT];
-
-                    if (contextSVGImageElement) {
-                        const hasXlinkHrefAttr = nativeMethods.hasAttributeNS.call(contextSVGImageElement, XLINK_NAMESPACE, 'href');
-
-                        windowSandbox.nodeSandbox.element.setAttributeCore(contextSVGImageElement, [hasXlinkHrefAttr ? 'xlink:href' : 'href', value]);
-                        value = getProxyUrl(value);
-                    }
-
-                    nativeMethods.svgAnimStrBaseValSetter.call(this, value);
-                },
-            });
-
-            overrideDescriptor(window.SVGAnimatedString.prototype, 'animVal', {
-                getter: function () {
-                    const animVal = nativeMethods.svgAnimStrAnimValGetter.call(this);
-
-                    if (this[CONTEXT_SVG_IMAGE_ELEMENT])
-                        return getDestinationUrl(animVal);
-
-                    return animVal;
-                },
-            });
-        }
-
-        if (nativeMethods.anchorOriginGetter && !this.proxyless) {
-            overrideDescriptor(window.HTMLAnchorElement.prototype, 'origin', {
-                getter: function (this: HTMLAnchorElement) {
-                    return getAnchorProperty(this, nativeMethods.anchorOriginGetter);
-                },
-            });
-        }
-
-        if (!this.proxyless) {
-            overrideDescriptor(window.StyleSheet.prototype, 'href', {
-                getter: function () {
-                    return getDestinationUrl(nativeMethods.styleSheetHrefGetter.call(this));
-                },
-            });
-        }
-
-        if (nativeMethods.cssStyleSheetHrefGetter) {
-            overrideDescriptor(window.CSSStyleSheet.prototype, 'href', {
-                getter: function () {
-                    return getDestinationUrl(nativeMethods.cssStyleSheetHrefGetter.call(this));
-                },
-            });
-        }
-
-        if (nativeMethods.nodeBaseURIGetter) {
-            overrideDescriptor(window.Node.prototype, 'baseURI', {
-                getter: function () {
-                    return getDestinationUrl(nativeMethods.nodeBaseURIGetter.call(this));
-                },
-            });
-        }
-
-        if (window.DOMParser) {
-            overrideFunction(window.DOMParser.prototype, 'parseFromString', function (this: DOMParser, ...args) {
-                const str  = args[0];
-                const type = args[1];
-                let processedHtml;
-
-                if (args.length > 1 && typeof str === 'string' && type === 'text/html') {
-                    processedHtml = processHtml(str);
-                    args[0]       = processedHtml;
+                if (!imageHref[CONTEXT_SVG_IMAGE_ELEMENT]) {
+                    nativeMethods.objectDefineProperty(imageHref, CONTEXT_SVG_IMAGE_ELEMENT, {
+                        value:        this,
+                        configurable: true,
+                    });
                 }
 
-                const document = nativeMethods.DOMParserParseFromString.apply(this, args);
+                return imageHref;
+            },
+        });
+    }
 
-                if (processedHtml)
-                    ShadowUI.removeSelfRemovingScripts(document);
+    private overrideBaseValInSVGAnimatedString () {
+        const windowSandbox = this;
 
-                return document;
-            });
-        }
+        overrideDescriptor(this.window.SVGAnimatedString.prototype, 'baseVal', {
+            getter: function () {
+                let baseVal = nativeMethods.svgAnimStrBaseValGetter.call(this);
 
-        overrideDescriptor(window.Node.prototype, 'firstChild', {
+                if (this[CONTEXT_SVG_IMAGE_ELEMENT])
+                    baseVal = getDestinationUrl(baseVal);
+
+                return baseVal;
+            },
+            setter: function (value) {
+                const contextSVGImageElement = this[CONTEXT_SVG_IMAGE_ELEMENT];
+
+                if (contextSVGImageElement) {
+                    const hasXlinkHrefAttr = nativeMethods.hasAttributeNS.call(contextSVGImageElement, XLINK_NAMESPACE, 'href');
+
+                    windowSandbox.nodeSandbox.element.setAttributeCore(contextSVGImageElement, [hasXlinkHrefAttr ? 'xlink:href' : 'href', value]);
+                    value = getProxyUrl(value);
+                }
+
+                nativeMethods.svgAnimStrBaseValSetter.call(this, value);
+            },
+        });
+    }
+
+    private overrideAnimValInSVGAnimatedString () {
+        overrideDescriptor(this.window.SVGAnimatedString.prototype, 'animVal', {
+            getter: function () {
+                const animVal = nativeMethods.svgAnimStrAnimValGetter.call(this);
+
+                if (this[CONTEXT_SVG_IMAGE_ELEMENT])
+                    return getDestinationUrl(animVal);
+
+                return animVal;
+            },
+        });
+    }
+
+    private overrideOriginInHTMLAnchorElement () {
+        overrideDescriptor(this.window.HTMLAnchorElement.prototype, 'origin', {
+            getter: function (this: HTMLAnchorElement) {
+                return getAnchorProperty(this, nativeMethods.anchorOriginGetter);
+            },
+        });
+    }
+
+    private overrideHrefInStyleSheet () {
+        overrideDescriptor(this.window.StyleSheet.prototype, 'href', {
+            getter: function () {
+                return getDestinationUrl(nativeMethods.styleSheetHrefGetter.call(this));
+            },
+        });
+    }
+
+    private overrideHrefInCSSStyleSheet () {
+        overrideDescriptor(this.window.CSSStyleSheet.prototype, 'href', {
+            getter: function () {
+                return getDestinationUrl(nativeMethods.cssStyleSheetHrefGetter.call(this));
+            },
+        });
+    }
+
+    private overrideBaseURIInNode () {
+        overrideDescriptor(this.window.Node.prototype, 'baseURI', {
+            getter: function () {
+                return getDestinationUrl(nativeMethods.nodeBaseURIGetter.call(this));
+            },
+        });
+    }
+
+    private overrideParseFromStringInDOMParser () {
+        overrideFunction(this.window.DOMParser.prototype, 'parseFromString', function (this: DOMParser, ...args) {
+            const str  = args[0];
+            const type = args[1];
+            let processedHtml;
+
+            if (args.length > 1 && typeof str === 'string' && type === 'text/html') {
+                processedHtml = processHtml(str);
+                args[0]       = processedHtml;
+            }
+
+            const document = nativeMethods.DOMParserParseFromString.apply(this, args);
+
+            if (processedHtml)
+                ShadowUI.removeSelfRemovingScripts(document);
+
+            return document;
+        });
+    }
+
+    private overrideFirstChildInNode () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.Node.prototype, 'firstChild', {
             getter: function () {
                 if (ShadowUI.isShadowContainer(this))
                     return windowSandbox.shadowUI.getFirstChild(this);
@@ -1297,8 +1480,12 @@ export default class WindowSandbox extends SandboxBase {
                 return nativeMethods.nodeFirstChildGetter.call(this);
             },
         });
+    }
 
-        overrideDescriptor(window.Element.prototype, 'firstElementChild', {
+    private overrideFirstElementChildInElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.Element.prototype, 'firstElementChild', {
             getter: function () {
                 if (ShadowUI.isShadowContainer(this))
                     return windowSandbox.shadowUI.getFirstElementChild(this);
@@ -1306,8 +1493,12 @@ export default class WindowSandbox extends SandboxBase {
                 return nativeMethods.elementFirstElementChildGetter.call(this);
             },
         });
+    }
 
-        overrideDescriptor(window.Node.prototype, 'lastChild', {
+    private overrideLastChildInNode () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.Node.prototype, 'lastChild', {
             getter: function () {
                 if (ShadowUI.isShadowContainer(this))
                     return windowSandbox.shadowUI.getLastChild(this);
@@ -1315,8 +1506,12 @@ export default class WindowSandbox extends SandboxBase {
                 return nativeMethods.nodeLastChildGetter.call(this);
             },
         });
+    }
 
-        overrideDescriptor(window.Element.prototype, 'lastElementChild', {
+    private overrideLastElementChildInElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.Element.prototype, 'lastElementChild', {
             getter: function () {
                 if (ShadowUI.isShadowContainer(this))
                     return windowSandbox.shadowUI.getLastElementChild(this);
@@ -1324,32 +1519,52 @@ export default class WindowSandbox extends SandboxBase {
                 return nativeMethods.elementLastElementChildGetter.call(this);
             },
         });
+    }
 
-        overrideDescriptor(window.Node.prototype, 'nextSibling', {
+    private overrideNextSiblingInNode () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.Node.prototype, 'nextSibling', {
             getter: function () {
                 return windowSandbox.shadowUI.getNextSibling(this);
             },
         });
+    }
 
-        overrideDescriptor(window.Node.prototype, 'previousSibling', {
+    private overridePreviousSiblingInNode () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.Node.prototype, 'previousSibling', {
             getter: function () {
                 return windowSandbox.shadowUI.getPrevSibling(this);
             },
         });
+    }
 
-        overrideDescriptor(window.Element.prototype, 'nextElementSibling', {
+    private overrideNextElementSiblingInElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.Element.prototype, 'nextElementSibling', {
             getter: function () {
                 return windowSandbox.shadowUI.getNextElementSibling(this);
             },
         });
+    }
 
-        overrideDescriptor(window.Element.prototype, 'previousElementSibling', {
+    private overridePreviousElementSiblingInElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.Element.prototype, 'previousElementSibling', {
             getter: function () {
                 return windowSandbox.shadowUI.getPrevElementSibling(this);
             },
         });
+    }
 
-        overrideDescriptor(window[nativeMethods.elementHTMLPropOwnerName].prototype, 'innerHTML', {
+    private overrideInnerHTMLInElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window[nativeMethods.elementHTMLPropOwnerName].prototype, 'innerHTML', {
             getter: function (this: HTMLElement) {
                 if (windowSandbox._documentTitleStorageInitializer && isTitleElement(this))
                     return windowSandbox._documentTitleStorageInitializer.storage.getTitleElementPropertyValue(this);
@@ -1393,7 +1608,7 @@ export default class WindowSandbox extends SandboxBase {
                     DOMMutationTracker.onChildrenChanged(el);
 
                 nativeMethods.elementInnerHTMLSetter.call(el, processedValue);
-                windowSandbox._setSandboxedTextForTitleElements(el);
+                windowSandbox.setSandboxedTextForTitleElements(el);
 
                 if (isStyleEl || isScriptEl)
                     return;
@@ -1414,11 +1629,11 @@ export default class WindowSandbox extends SandboxBase {
                 const parentWindow   = parentDocument ? parentDocument.defaultView : null;
 
                 // NOTE: For the iframe with an empty src.
-                if (parentWindow && parentWindow !== window &&
+                if (parentWindow && parentWindow !== windowSandbox.window &&
                     parentWindow[INTERNAL_PROPS.processDomMethodName])
                     parentWindow[INTERNAL_PROPS.processDomMethodName](el, parentDocument);
-                else if (window[INTERNAL_PROPS.processDomMethodName])
-                    window[INTERNAL_PROPS.processDomMethodName](el);
+                else if (windowSandbox.window[INTERNAL_PROPS.processDomMethodName])
+                    windowSandbox.window[INTERNAL_PROPS.processDomMethodName](el);
 
                 // NOTE: Fix for B239138 - unroll.me 'Cannot read property 'document' of null' error raised
                 // during recording. There was an issue when the document.body was replaced, so we need to
@@ -1426,15 +1641,19 @@ export default class WindowSandbox extends SandboxBase {
 
                 // NOTE: This check is required because jQuery calls the set innerHTML method for an element
                 // in an unavailable window.
-                if (window.self) {
+                if (windowSandbox.window.self) {
                     // NOTE: Use timeout, so that changes take effect.
                     if (isHtmlElement(el) || isBodyElement(el))
-                        nativeMethods.setTimeout.call(window, () => windowSandbox.nodeMutation.onBodyContentChanged(el), 0);
+                        nativeMethods.setTimeout.call(windowSandbox.window, () => windowSandbox.nodeMutation.onBodyContentChanged(el), 0);
                 }
             },
         });
+    }
 
-        overrideDescriptor(window[nativeMethods.elementHTMLPropOwnerName].prototype, 'outerHTML', {
+    private overrideOuterHTMLInElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window[nativeMethods.elementHTMLPropOwnerName].prototype, 'outerHTML', {
             getter: function () {
                 const outerHTML = nativeMethods.elementOuterHTMLGetter.call(this);
 
@@ -1455,34 +1674,55 @@ export default class WindowSandbox extends SandboxBase {
                         processedContext: el[INTERNAL_PROPS.processedContext],
                     }));
 
-                    windowSandbox._setSandboxedTextForTitleElements(parentEl);
+                    windowSandbox.setSandboxedTextForTitleElements(parentEl);
                     DOMMutationTracker.onChildrenChanged(parentEl);
 
                     // NOTE: For the iframe with an empty src.
-                    if (parentWindow && parentWindow !== window &&
+                    if (parentWindow && parentWindow !== windowSandbox.window &&
                         parentWindow[INTERNAL_PROPS.processDomMethodName])
                         parentWindow[INTERNAL_PROPS.processDomMethodName](parentEl, parentDocument);
-                    else if (window[INTERNAL_PROPS.processDomMethodName])
-                        window[INTERNAL_PROPS.processDomMethodName](parentEl);
+                    else if (windowSandbox.window[INTERNAL_PROPS.processDomMethodName])
+                        windowSandbox.window[INTERNAL_PROPS.processDomMethodName](parentEl);
 
                     // NOTE: This check is required for an element in an unavailable window.
                     // NOTE: Use timeout, so that changes take effect.
-                    if (window.self && isBodyElement(el))
-                        nativeMethods.setTimeout.call(window, () => windowSandbox.shadowUI.onBodyElementMutation(), 0);
+                    if (windowSandbox.window.self && isBodyElement(el))
+                        nativeMethods.setTimeout.call(windowSandbox.window, () => windowSandbox.shadowUI.onBodyElementMutation(), 0);
                 }
                 else
                     nativeMethods.elementOuterHTMLSetter.call(el, value);
             },
         });
+    }
 
-        overrideDescriptor(window.HTMLElement.prototype, 'innerText', {
+    private setSandboxedTextForTitleElements (el: Node & ParentNode): void {
+        if (isIframeWindow(this.window))
+            return;
+
+        const titleElements = getNativeQuerySelectorAll(el).call(el, 'title');
+
+        for (const titleElement of titleElements) {
+            // NOTE: SVGTitleElement can be here (GH-2364)
+            if (!isTitleElement(titleElement))
+                continue;
+
+            const nativeText = nativeMethods.titleElementTextGetter.call(titleElement);
+
+            this._documentTitleStorageInitializer.storage.setTitleElementPropertyValue(titleElement, nativeText);
+        }
+    }
+
+    private overrideInnerTextInHTMLElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.HTMLElement.prototype, 'innerText', {
             getter: function (this: HTMLElement) {
                 if (windowSandbox._documentTitleStorageInitializer && isTitleElement(this))
                     return windowSandbox._documentTitleStorageInitializer.storage.getTitleElementPropertyValue(this);
 
                 const textContent = nativeMethods.htmlElementInnerTextGetter.call(this);
 
-                return WindowSandbox._removeProcessingInstructions(textContent);
+                return WindowSandbox.removeProcessingInstructions(textContent);
             },
             setter: function (this: HTMLElement, value) {
                 if (windowSandbox._documentTitleStorageInitializer && isTitleElement(this)) {
@@ -1491,15 +1731,17 @@ export default class WindowSandbox extends SandboxBase {
                     return;
                 }
 
-                const processedValue = WindowSandbox._processTextPropValue(this, value);
+                const processedValue = WindowSandbox.processTextPropValue(this, value);
 
                 DOMMutationTracker.onChildrenChanged(this);
 
                 nativeMethods.htmlElementInnerTextSetter.call(this, processedValue);
             },
         });
+    }
 
-        overrideDescriptor(window.HTMLScriptElement.prototype, 'text', {
+    private overrideTextInHTMLScriptElement () {
+        overrideDescriptor(this.window.HTMLScriptElement.prototype, 'text', {
             getter: function () {
                 const text = nativeMethods.scriptTextGetter.call(this);
 
@@ -1511,30 +1753,36 @@ export default class WindowSandbox extends SandboxBase {
                 nativeMethods.scriptTextSetter.call(this, processedValue);
             },
         });
+    }
 
-        overrideDescriptor(window.HTMLAnchorElement.prototype, 'text', {
+    private overrideTextInHTMLAnchorElement () {
+        overrideDescriptor(this.window.HTMLAnchorElement.prototype, 'text', {
             getter: function (this: HTMLAnchorElement) {
                 const textContent = nativeMethods.anchorTextGetter.call(this);
 
-                return WindowSandbox._removeProcessingInstructions(textContent);
+                return WindowSandbox.removeProcessingInstructions(textContent);
             },
             setter: function (this: HTMLAnchorElement, value) {
-                const processedValue = WindowSandbox._processTextPropValue(this, value);
+                const processedValue = WindowSandbox.processTextPropValue(this, value);
 
                 DOMMutationTracker.onChildrenChanged(this);
 
                 nativeMethods.anchorTextSetter.call(this, processedValue);
             },
         });
+    }
 
-        overrideDescriptor(window.Node.prototype, 'textContent', {
+    private overrideTextContentInNode () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.Node.prototype, 'textContent', {
             getter: function (this: HTMLElement) {
                 if (windowSandbox._documentTitleStorageInitializer && isTitleElement(this))
                     return windowSandbox._documentTitleStorageInitializer.storage.getTitleElementPropertyValue(this);
 
                 const textContent = nativeMethods.nodeTextContentGetter.call(this);
 
-                return WindowSandbox._removeProcessingInstructions(textContent);
+                return WindowSandbox.removeProcessingInstructions(textContent);
             },
             setter: function (this: HTMLElement, value) {
                 if (windowSandbox._documentTitleStorageInitializer && isTitleElement(this)) {
@@ -1543,119 +1791,167 @@ export default class WindowSandbox extends SandboxBase {
                     return;
                 }
 
-                const processedValue = WindowSandbox._processTextPropValue(this, value);
+                const processedValue = WindowSandbox.processTextPropValue(this, value);
 
                 DOMMutationTracker.onChildrenChanged(this);
 
                 nativeMethods.nodeTextContentSetter.call(this, processedValue);
             },
         });
+    }
 
-        overrideDescriptor(window[nativeMethods.elementAttributesPropOwnerName].prototype, 'attributes', {
+    private static removeProcessingInstructions (text: string): string {
+        if (text) {
+            text = removeProcessingHeader(text);
+
+            return styleProcessor.cleanUp(text, parseProxyUrl);
+        }
+
+        return text;
+    }
+
+    private static processTextPropValue (el: HTMLElement, text: string): string {
+        const processedText = text !== null && text !== void 0 ? String(text) : text;
+
+        if (processedText) {
+            if (isScriptElement(el))
+                return processScript(processedText, true, false, convertToProxyUrl, void 0, settings.get().proxyless);
+            else if (isStyleElement(el))
+                return styleProcessor.process(processedText, getProxyUrl, true);
+        }
+
+        return processedText;
+    }
+
+    private overrideAttributesInElement () {
+        overrideDescriptor(this.window[nativeMethods.elementAttributesPropOwnerName].prototype, 'attributes', {
             getter: function () {
                 return getAttributes(this);
             },
         });
+    }
 
-        overrideFunction(window.DOMTokenList.prototype, 'add', this._createOverriddenDOMTokenListMethod(nativeMethods.tokenListAdd));
-        overrideFunction(window.DOMTokenList.prototype, 'remove', this._createOverriddenDOMTokenListMethod(nativeMethods.tokenListRemove));
-        overrideFunction(window.DOMTokenList.prototype, 'toggle', this._createOverriddenDOMTokenListMethod(nativeMethods.tokenListToggle));
+    private overrideMethodInDOMTokenList (name, nativeMethod) {
+        const windowSandbox = this;
 
-        if (nativeMethods.tokenListReplace)
-            overrideFunction(window.DOMTokenList.prototype, 'replace', this._createOverriddenDOMTokenListMethod(nativeMethods.tokenListReplace));
+        overrideFunction(this.window.DOMTokenList.prototype, name, function (this: DOMTokenList) {
+            const executionResult = nativeMethod.apply(this, arguments);
+            const tokenListOwner  = this[SANDBOX_DOM_TOKEN_LIST_OWNER];
 
-        if (nativeMethods.tokenListSupports) {
-            overrideFunction(window.DOMTokenList.prototype, 'supports', function (this: DOMTokenList) {
-                if (this[SANDBOX_DOM_TOKEN_LIST_OWNER]) {
-                    const nativeTokenList = nativeMethods.iframeSandboxGetter.call(this[SANDBOX_DOM_TOKEN_LIST_OWNER]);
+            if (tokenListOwner)
+                windowSandbox.nodeSandbox.element.setAttributeCore(tokenListOwner, ['sandbox', this.toString()]);
 
-                    return nativeMethods.tokenListSupports.apply(nativeTokenList, arguments);
-                }
+            return executionResult;
+        });
+    }
 
-                return nativeMethods.tokenListSupports.apply(this, arguments);
-            });
-        }
+    private overrideSupportsInDOMTokenList () {
+        overrideFunction(this.window.DOMTokenList.prototype, 'supports', function (this: DOMTokenList) {
+            if (this[SANDBOX_DOM_TOKEN_LIST_OWNER]) {
+                const nativeTokenList = nativeMethods.iframeSandboxGetter.call(this[SANDBOX_DOM_TOKEN_LIST_OWNER]);
 
-        if (nativeMethods.tokenListValueSetter) {
-            overrideDescriptor(window.DOMTokenList.prototype, 'value', {
-                getter: null,
-                setter: function (value) {
-                    const tokenListOwner = this[SANDBOX_DOM_TOKEN_LIST_OWNER];
+                return nativeMethods.tokenListSupports.apply(nativeTokenList, arguments);
+            }
 
-                    nativeMethods.tokenListValueSetter.call(this, value);
+            return nativeMethods.tokenListSupports.apply(this, arguments);
+        });
+    }
 
-                    if (tokenListOwner)
-                        // eslint-disable-next-line no-restricted-properties
-                        windowSandbox.nodeSandbox.element.setAttributeCore(tokenListOwner, ['sandbox', this.value]);
-                },
-            });
-        }
+    private overrideValueInDOMTokenList () {
+        const windowSandbox = this;
 
-        overrideFunction(window.DOMImplementation.prototype, 'createHTMLDocument', function (this: DOMImplementation, ...args) {
+        overrideDescriptor(this.window.DOMTokenList.prototype, 'value', {
+            getter: null,
+            setter: function (value) {
+                const tokenListOwner = this[SANDBOX_DOM_TOKEN_LIST_OWNER];
+
+                nativeMethods.tokenListValueSetter.call(this, value);
+
+                if (tokenListOwner)
+                    // eslint-disable-next-line no-restricted-properties
+                    windowSandbox.nodeSandbox.element.setAttributeCore(tokenListOwner, ['sandbox', this.value]);
+            },
+        });
+    }
+
+    private overrideCreateHTMLDocumentInDOMImplementation () {
+        overrideFunction(this.window.DOMImplementation.prototype, 'createHTMLDocument', function (this: DOMImplementation, ...args) {
             const doc = nativeMethods.createHTMLDocument.apply(this, args);
 
             urlResolver.init(doc);
 
             return doc;
         });
+    }
 
-        overrideDescriptor(window.MutationRecord.prototype, 'nextSibling', {
+    private overrideNextSiblingInMutationRecord () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.MutationRecord.prototype, 'nextSibling', {
             getter: function () {
                 const originNextSibling = nativeMethods.mutationRecordNextSiblingGetter.call(this);
 
                 return windowSandbox.shadowUI.getMutationRecordNextSibling(originNextSibling);
             },
         });
+    }
 
-        overrideDescriptor(window.MutationRecord.prototype, 'previousSibling', {
+    private overridePreviousSiblingInMutationRecord () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.MutationRecord.prototype, 'previousSibling', {
             getter: function () {
                 const originPrevSibling = nativeMethods.mutationRecordPrevSiblingGetter.call(this);
 
                 return windowSandbox.shadowUI.getMutationRecordPrevSibling(originPrevSibling);
             },
         });
+    }
 
-        if (nativeMethods.windowOriginGetter) {
-            overrideDescriptor(window, 'origin', {
-                getter: function (this: Window) {
-                    const proxyOrigin = nativeMethods.windowOriginGetter.call(this);
+    private overrideOriginInWindow () {
+        const windowSandbox = this;
 
-                    if (!proxyOrigin || proxyOrigin === 'null')
-                        return proxyOrigin;
+        overrideDescriptor(this.window, 'origin', {
+            getter: function (this: Window) {
+                const proxyOrigin = nativeMethods.windowOriginGetter.call(this);
 
-                    const frame = getFrameElement(windowSandbox.window);
+                if (!proxyOrigin || proxyOrigin === 'null')
+                    return proxyOrigin;
 
-                    if (frame) {
-                        const sandbox = windowSandbox.nodeSandbox.element.getAttributeCore(frame, ['sandbox']);
+                const frame = getFrameElement(windowSandbox.window);
 
-                        if (typeof sandbox === 'string' && sandbox.indexOf('allow-same-origin') === -1)
-                            return 'null';
-                    }
+                if (frame) {
+                    const sandbox = windowSandbox.nodeSandbox.element.getAttributeCore(frame, ['sandbox']);
 
-                    const parsedDestLocation = destLocation.getParsed();
-
-                    // eslint-disable-next-line no-restricted-properties
-                    if (parsedDestLocation && parsedDestLocation.protocol === 'file:')
+                    if (typeof sandbox === 'string' && sandbox.indexOf('allow-same-origin') === -1)
                         return 'null';
+                }
 
-                    return destLocation.getOriginHeader();
-                },
+                const parsedDestLocation = destLocation.getParsed();
 
-                setter: function (this: Window, value) {
-                    return nativeMethods.windowOriginSetter.call(this, value);
-                },
-            });
-        }
+                // eslint-disable-next-line no-restricted-properties
+                if (parsedDestLocation && parsedDestLocation.protocol === 'file:')
+                    return 'null';
 
-        if (this._documentTitleStorageInitializer) {
-            overrideDescriptor(window.HTMLTitleElement.prototype, 'text', {
-                getter: function (this: HTMLTitleElement) {
-                    return windowSandbox._documentTitleStorageInitializer.storage.getTitleElementPropertyValue(this);
-                },
-                setter: function (this: HTMLTitleElement, value) {
-                    windowSandbox._documentTitleStorageInitializer.storage.setTitleElementPropertyValue(this, value);
-                },
-            });
-        }
+                return destLocation.getOriginHeader();
+            },
+
+            setter: function (this: Window, value) {
+                return nativeMethods.windowOriginSetter.call(this, value);
+            },
+        });
+    }
+
+    private overrideTextInHTMLTitleElement () {
+        const windowSandbox = this;
+
+        overrideDescriptor(this.window.HTMLTitleElement.prototype, 'text', {
+            getter: function (this: HTMLTitleElement) {
+                return windowSandbox._documentTitleStorageInitializer.storage.getTitleElementPropertyValue(this);
+            },
+            setter: function (this: HTMLTitleElement, value) {
+                windowSandbox._documentTitleStorageInitializer.storage.setTitleElementPropertyValue(this, value);
+            },
+        });
     }
 }

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -291,7 +291,7 @@ export default class WindowSandbox extends SandboxBase {
         this.overrideNextSiblingInMutationRecord();
         this.overridePreviousSiblingInMutationRecord();
 
-        if (this.proxyless)
+        if (SandboxBase.isProxyless)
             return;
 
         this.overrideDrawImageInCanvasRenderingContext2D();
@@ -647,7 +647,7 @@ export default class WindowSandbox extends SandboxBase {
                 return new nativeMethods.Blob();
 
             if (WindowSandbox.isProcessableBlob(array, opts))
-                array = [processScript(array.join(''), true, false, convertToProxyUrl, void 0, settings.get().proxyless, WindowSandbox.getBlobProcessingSettings())];
+                array = [processScript(array.join(''), true, false, convertToProxyUrl, void 0, SandboxBase.isProxyless, WindowSandbox.getBlobProcessingSettings())];
 
             // NOTE: IE11 throws an error when the second parameter of the Blob function is undefined (GH-44)
             // If the overridden function is called with one parameter, we need to call the original function
@@ -662,7 +662,7 @@ export default class WindowSandbox extends SandboxBase {
                 return new nativeMethods.File();
 
             if (WindowSandbox.isProcessableBlob(array, opts))
-                array = [processScript(array.join(''), true, false, convertToProxyUrl, void 0, settings.get().proxyless, WindowSandbox.getBlobProcessingSettings())];
+                array = [processScript(array.join(''), true, false, convertToProxyUrl, void 0, SandboxBase.isProxyless, WindowSandbox.getBlobProcessingSettings())];
 
             return new nativeMethods.File(array, fileName, opts);
         });
@@ -1585,7 +1585,7 @@ export default class WindowSandbox extends SandboxBase {
                     if (isStyleEl)
                         processedValue = styleProcessor.process(processedValue, getProxyUrl, true);
                     else if (isScriptEl)
-                        processedValue = processScript(processedValue, true, false, convertToProxyUrl, void 0, settings.get().proxyless);
+                        processedValue = processScript(processedValue, true, false, convertToProxyUrl, void 0, SandboxBase.isProxyless);
                     else {
                         processedValue = processHtml(processedValue, {
                             parentTag:        el.tagName,
@@ -1738,7 +1738,7 @@ export default class WindowSandbox extends SandboxBase {
                 return removeProcessingHeader(text);
             },
             setter: function (value) {
-                const processedValue = value ? processScript(String(value), true, false, convertToProxyUrl, void 0, settings.get().proxyless) : value;
+                const processedValue = value ? processScript(String(value), true, false, convertToProxyUrl, void 0, SandboxBase.isProxyless) : value;
 
                 nativeMethods.scriptTextSetter.call(this, processedValue);
             },
@@ -1805,7 +1805,7 @@ export default class WindowSandbox extends SandboxBase {
 
         if (processedText) {
             if (isScriptElement(el))
-                return processScript(processedText, true, false, convertToProxyUrl, void 0, settings.get().proxyless);
+                return processScript(processedText, true, false, convertToProxyUrl, void 0, SandboxBase.isProxyless);
             else if (isStyleElement(el))
                 return styleProcessor.process(processedText, getProxyUrl, true);
         }

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -258,157 +258,20 @@ export default class WindowSandbox extends SandboxBase {
 
         this.addMessageSandBoxListeners();
 
-        this.overrideDrawImageInCanvasRenderingContext2D();
+        if (window.EventTarget)
+            this.overrideListenerMethodsInEventTarget();
 
-        if (nativeMethods.objectAssign)
-            this.overrideAssignInObject();
+        this.overrideFilesInHTMLInputElement();
 
-        this.overrideOpenInWindow();
-
-        if (window.FontFace && !this.proxyless)
-            this.overrideFontFaceInWindow();
-
-        if (window.Worker && !this.proxyless)
-            this.overrideWorkerInWindow();
-
-        if (window.Blob)
-            this.overrideBlobInWindow();
-
-        // NOTE: non-IE11 case. window.File in IE11 is not constructable.
-        if (nativeMethods.File)
-            this.overrideFileInWindow();
-
-        if (window.EventSource && !this.proxyless)
-            this.overrideEventSourceInWindow();
+        if (this._documentTitleStorageInitializer)
+            this.overrideTextInHTMLTitleElement();
 
         if (window.MutationObserver)
             this.overrideMutationObserverInWindow();
 
-        if (window.Proxy)
-            this.overrideProxyInWindow();
-
-        if (nativeMethods.registerServiceWorker && !this.proxyless)
-            this.overrideRegisterInServiceWorker();
-
-        if (nativeMethods.getRegistrationServiceWorker && !this.proxyless)
-            this.overrideGetRegistrationInNavigator();
-
-        if (window.Range.prototype.createContextualFragment)
-            this.overrideCreateContextualFragmentInRange();
-
-        if (window.EventTarget)
-            this.overrideListenerMethodsInEventTarget();
-
-        if (!this.proxyless)
-            this.overrideImageInWindow();
-
-        this.overrideFunctionInWindow();
-        this.overrideToStringInFunction();
-
-        if (isFunction(window.history.pushState)
-            && isFunction(window.history.replaceState)
-            && !this.proxyless) {
-            this.overrideMethodInHistory('pushState', nativeMethods.historyPushState);
-            this.overrideMethodInHistory('replaceState', nativeMethods.historyReplaceState);
-        }
-
-        if (nativeMethods.sendBeacon && !this.proxyless)
-            this.overrideSendBeaconInNavigator();
-
-        if (window.navigator.registerProtocolHandler && !this.proxyless)
-            this.overrideRegisterProtocolHandlerInNavigator();
-
-        if (window.FormData)
-            this.overrideAppendInFormData();
-
-        if (window.WebSocket && !this.proxyless) {
-            this.overrideWebSocketInWindow();
-
-            if (nativeMethods.webSocketUrlGetter)
-                this.overrideUrlInWebSocket();
-        }
-
-        if (!this.proxyless)
-            this.overrideOriginInMessageEvent();
-
         this.overrideLengthInHTMLCollection();
         this.overrideLengthInNodeList();
         this.overrideChildElementCountInElement();
-
-        if (nativeMethods.performanceEntryNameGetter && !this.proxyless)
-            this.overrideNameInPerformanceEntry();
-
-        this.overrideFilesInHTMLInputElement();
-        this.overrideValueInHTMLInputElement();
-
-        // NOTE: HTMLInputElement raises the `change` event on `disabled` only in Chrome
-        if (isChrome)
-            this.overrideDisabledInHTMLInputElement();
-
-        this.overrideRequiredInHTMLInputElement();
-        this.overrideValueInHTMLTextAreaElement();
-
-        if (!this.proxyless)
-            this.overrideAllUrlAttrDescriptors();
-
-        this.overrideAttrDescriptorsInElement('target', [
-            window.HTMLAnchorElement,
-            window.HTMLFormElement,
-            window.HTMLAreaElement,
-            window.HTMLBaseElement,
-        ]);
-
-        this.overrideAttrDescriptorsInElement('formTarget', [
-            window.HTMLInputElement,
-            window.HTMLButtonElement,
-        ]);
-
-        this.overrideAttrDescriptorsInElement('autocomplete', [window.HTMLInputElement]);
-        this.overrideAttrDescriptorsInElement('httpEquiv', [window.HTMLMetaElement]);
-
-        // NOTE: Some browsers (for example, Edge, Internet Explorer 11, Safari) don't support the 'integrity' property.
-        if (nativeMethods.scriptIntegrityGetter && nativeMethods.linkIntegrityGetter) {
-            this.overrideAttrDescriptorsInElement('integrity', [window.HTMLScriptElement]);
-            this.overrideAttrDescriptorsInElement('integrity', [window.HTMLLinkElement]);
-        }
-
-        this.overrideAttrDescriptorsInElement('rel', [window.HTMLLinkElement]);
-
-        if (nativeMethods.linkAsSetter)
-            this.overrideAttrDescriptorsInElement('as', [window.HTMLLinkElement]);
-
-        this.overrideTypeInHTMLInputElement();
-        this.overrideSandboxInHTMLIFrameElement();
-
-        if (nativeMethods.iframeSrcdocGetter)
-            this.overrideSrcdocInHTMLIFrameElement();
-
-        if (!this.proxyless) {
-            this.overrideUrlPropInHTMLAnchorElement('port', nativeMethods.anchorPortGetter, nativeMethods.anchorPortSetter);
-            this.overrideUrlPropInHTMLAnchorElement('host', nativeMethods.anchorHostGetter, nativeMethods.anchorHostSetter);
-            this.overrideUrlPropInHTMLAnchorElement('hostname', nativeMethods.anchorHostnameGetter, nativeMethods.anchorHostnameSetter);
-            this.overrideUrlPropInHTMLAnchorElement('pathname', nativeMethods.anchorPathnameGetter, nativeMethods.anchorPathnameSetter);
-            this.overrideUrlPropInHTMLAnchorElement('protocol', nativeMethods.anchorProtocolGetter, nativeMethods.anchorProtocolSetter);
-            this.overrideUrlPropInHTMLAnchorElement('search', nativeMethods.anchorSearchGetter, nativeMethods.anchorSearchSetter);
-        }
-
-        if (!this.proxyless) {
-            this.overrideHrefInSVGImageElement();
-            this.overrideBaseValInSVGAnimatedString();
-            this.overrideAnimValInSVGAnimatedString();
-        }
-
-        if (nativeMethods.anchorOriginGetter && !this.proxyless)
-            this.overrideOriginInHTMLAnchorElement();
-
-        if (!this.proxyless)
-            this.overrideHrefInStyleSheet();
-
-        if (nativeMethods.cssStyleSheetHrefGetter)
-            this.overrideHrefInCSSStyleSheet();
-
-        if (nativeMethods.nodeBaseURIGetter)
-            this.overrideBaseURIInNode();
 
         if (window.DOMParser)
             this.overrideParseFromStringInDOMParser();
@@ -424,10 +287,179 @@ export default class WindowSandbox extends SandboxBase {
         this.overrideInnerHTMLInElement();
         this.overrideOuterHTMLInElement();
         this.overrideInnerTextInHTMLElement();
+        this.overrideAttributesInElement();
+        this.overrideNextSiblingInMutationRecord();
+        this.overridePreviousSiblingInMutationRecord();
+
+        if (this.proxyless)
+            return;
+
+        this.overrideDrawImageInCanvasRenderingContext2D();
+
+        if (nativeMethods.objectAssign)
+            this.overrideAssignInObject();
+
+        this.overrideOpenInWindow();
+
+        if (window.FontFace)
+            this.overrideFontFaceInWindow();
+
+        if (window.Worker)
+            this.overrideWorkerInWindow();
+
+        if (window.Blob)
+            this.overrideBlobInWindow();
+
+        // NOTE: non-IE11 case. window.File in IE11 is not constructable.
+        if (nativeMethods.File)
+            this.overrideFileInWindow();
+
+        if (window.EventSource)
+            this.overrideEventSourceInWindow();
+
+        if (window.Proxy)
+            this.overrideProxyInWindow();
+
+        if (nativeMethods.registerServiceWorker)
+            this.overrideRegisterInServiceWorker();
+
+        if (nativeMethods.getRegistrationServiceWorker)
+            this.overrideGetRegistrationInServiceWorker();
+
+        if (window.Range.prototype.createContextualFragment)
+            this.overrideCreateContextualFragmentInRange();
+
+        this.overrideImageInWindow();
+
+        this.overrideFunctionInWindow();
+
+        this.overrideToStringInFunction();
+
+        if (isFunction(window.history.pushState) && isFunction(window.history.replaceState)) {
+            this.overrideMethodInHistory('pushState', nativeMethods.historyPushState);
+            this.overrideMethodInHistory('replaceState', nativeMethods.historyReplaceState);
+        }
+
+        if (nativeMethods.sendBeacon)
+            this.overrideSendBeaconInNavigator();
+
+        if (window.navigator.registerProtocolHandler)
+            this.overrideRegisterProtocolHandlerInNavigator();
+
+        if (window.FormData)
+            this.overrideAppendInFormData();
+
+        if (window.WebSocket) {
+            this.overrideWebSocketInWindow();
+
+            if (nativeMethods.webSocketUrlGetter)
+                this.overrideUrlInWebSocket();
+        }
+
+        this.overrideOriginInMessageEvent();
+
+        if (nativeMethods.performanceEntryNameGetter)
+            this.overrideNameInPerformanceEntry();
+
+        this.overrideValueInHTMLInputElement();
+
+        // NOTE: HTMLInputElement raises the `change` event on `disabled` only in Chrome
+        if (isChrome)
+            this.overrideDisabledInHTMLInputElement();
+
+        this.overrideRequiredInHTMLInputElement();
+
+        this.overrideValueInHTMLTextAreaElement();
+
+        this.overrideUrlAttrDescriptors('data', [window.HTMLObjectElement]);
+
+        this.overrideUrlAttrDescriptors('src', [
+            window.HTMLImageElement,
+            window.HTMLScriptElement,
+            window.HTMLEmbedElement,
+            window.HTMLSourceElement,
+            window.HTMLMediaElement,
+            window.HTMLInputElement,
+            window.HTMLFrameElement,
+            window.HTMLIFrameElement,
+        ]);
+
+        this.overrideUrlAttrDescriptors('action', [window.HTMLFormElement]);
+
+        this.overrideUrlAttrDescriptors('formAction', [
+            window.HTMLInputElement,
+            window.HTMLButtonElement,
+        ]);
+
+        this.overrideUrlAttrDescriptors('href', [
+            window.HTMLAnchorElement,
+            window.HTMLLinkElement,
+            window.HTMLAreaElement,
+            window.HTMLBaseElement,
+        ]);
+
+        if (nativeMethods.htmlManifestGetter)
+            this.overrideUrlAttrDescriptors('manifest', [window.HTMLHtmlElement]);
+
+        this.overrideAttrDescriptorsInElement('target', [
+            window.HTMLAnchorElement,
+            window.HTMLFormElement,
+            window.HTMLAreaElement,
+            window.HTMLBaseElement,
+        ]);
+
+        this.overrideAttrDescriptorsInElement('formTarget', [
+            window.HTMLInputElement,
+            window.HTMLButtonElement,
+        ]);
+
+        this.overrideAttrDescriptorsInElement('autocomplete', [window.HTMLInputElement]);
+
+        this.overrideAttrDescriptorsInElement('httpEquiv', [window.HTMLMetaElement]);
+
+        // NOTE: Some browsers (for example, Edge, Internet Explorer 11, Safari) don't support the 'integrity' property.
+        if (nativeMethods.scriptIntegrityGetter && nativeMethods.linkIntegrityGetter) {
+            this.overrideAttrDescriptorsInElement('integrity', [window.HTMLScriptElement]);
+            this.overrideAttrDescriptorsInElement('integrity', [window.HTMLLinkElement]);
+        }
+
+        this.overrideAttrDescriptorsInElement('rel', [window.HTMLLinkElement]);
+
+        if (nativeMethods.linkAsSetter)
+            this.overrideAttrDescriptorsInElement('as', [window.HTMLLinkElement]);
+
+        this.overrideTypeInHTMLInputElement();
+
+        this.overrideSandboxInHTMLIFrameElement();
+
+        if (nativeMethods.iframeSrcdocGetter)
+            this.overrideSrcdocInHTMLIFrameElement();
+
+        this.overrideUrlPropInHTMLAnchorElement('port', nativeMethods.anchorPortGetter, nativeMethods.anchorPortSetter);
+        this.overrideUrlPropInHTMLAnchorElement('host', nativeMethods.anchorHostGetter, nativeMethods.anchorHostSetter);
+        this.overrideUrlPropInHTMLAnchorElement('hostname', nativeMethods.anchorHostnameGetter, nativeMethods.anchorHostnameSetter);
+        this.overrideUrlPropInHTMLAnchorElement('pathname', nativeMethods.anchorPathnameGetter, nativeMethods.anchorPathnameSetter);
+        this.overrideUrlPropInHTMLAnchorElement('protocol', nativeMethods.anchorProtocolGetter, nativeMethods.anchorProtocolSetter);
+        this.overrideUrlPropInHTMLAnchorElement('search', nativeMethods.anchorSearchGetter, nativeMethods.anchorSearchSetter);
+
+        this.overrideHrefInSVGImageElement();
+        this.overrideBaseValInSVGAnimatedString();
+        this.overrideAnimValInSVGAnimatedString();
+
+        if (nativeMethods.anchorOriginGetter)
+            this.overrideOriginInHTMLAnchorElement();
+
+        this.overrideHrefInStyleSheet();
+
+        if (nativeMethods.cssStyleSheetHrefGetter)
+            this.overrideHrefInCSSStyleSheet();
+
+        if (nativeMethods.nodeBaseURIGetter)
+            this.overrideBaseURIInNode();
+
         this.overrideTextInHTMLScriptElement();
         this.overrideTextInHTMLAnchorElement();
         this.overrideTextContentInNode();
-        this.overrideAttributesInElement();
         this.overrideMethodInDOMTokenList('add', nativeMethods.tokenListAdd);
         this.overrideMethodInDOMTokenList('remove', nativeMethods.tokenListRemove);
         this.overrideMethodInDOMTokenList('toggle', nativeMethods.tokenListToggle);
@@ -442,14 +474,9 @@ export default class WindowSandbox extends SandboxBase {
             this.overrideValueInDOMTokenList();
 
         this.overrideCreateHTMLDocumentInDOMImplementation();
-        this.overrideNextSiblingInMutationRecord();
-        this.overridePreviousSiblingInMutationRecord();
 
         if (nativeMethods.windowOriginGetter)
             this.overrideOriginInWindow();
-
-        if (this._documentTitleStorageInitializer)
-            this.overrideTextInHTMLTitleElement();
     }
 
     private initElementListening () {
@@ -816,7 +843,7 @@ export default class WindowSandbox extends SandboxBase {
         /*eslint-enable no-restricted-properties*/
     }
 
-    private overrideGetRegistrationInNavigator () {
+    private overrideGetRegistrationInServiceWorker () {
         const windowSandbox = this;
 
         overrideFunction(this.window.navigator.serviceWorker, 'getRegistration', (...args) => {
@@ -888,7 +915,6 @@ export default class WindowSandbox extends SandboxBase {
 
             return fn;
         }, true);
-
     }
 
     private static patchFunctionPrototype (fn: Function, ctx: any): void {
@@ -1207,42 +1233,6 @@ export default class WindowSandbox extends SandboxBase {
         });
     }
 
-    private overrideAllUrlAttrDescriptors (): void {
-        this.overrideUrlAttrDescriptors('data', [this.window.HTMLObjectElement]);
-
-        if (!this.proxyless) {
-            this.overrideUrlAttrDescriptors('src', [
-                this.window.HTMLImageElement,
-                this.window.HTMLScriptElement,
-                this.window.HTMLEmbedElement,
-                this.window.HTMLSourceElement,
-                this.window.HTMLMediaElement,
-                this.window.HTMLInputElement,
-                this.window.HTMLFrameElement,
-                this.window.HTMLIFrameElement,
-            ]);
-        }
-
-        this.overrideUrlAttrDescriptors('action', [this.window.HTMLFormElement]);
-
-        this.overrideUrlAttrDescriptors('formAction', [
-            this.window.HTMLInputElement,
-            this.window.HTMLButtonElement,
-        ]);
-
-        if (!this.proxyless) {
-            this.overrideUrlAttrDescriptors('href', [
-                this.window.HTMLAnchorElement,
-                this.window.HTMLLinkElement,
-                this.window.HTMLAreaElement,
-                this.window.HTMLBaseElement,
-            ]);
-        }
-
-        if (nativeMethods.htmlManifestGetter)
-            this.overrideUrlAttrDescriptors('manifest', [this.window.HTMLHtmlElement]);
-    }
-
     private overrideUrlAttrDescriptors (attr, elementConstructors): void {
         const windowSandbox = this;
 
@@ -1277,7 +1267,7 @@ export default class WindowSandbox extends SandboxBase {
         return resolveUrlAsDest(attrValue, attr === 'srcset');
     }
 
-    overrideAttrDescriptorsInElement (attr, elementConstructors): void {
+    private overrideAttrDescriptorsInElement (attr, elementConstructors): void {
         const windowSandbox = this;
 
         for (const constructor of elementConstructors) {

--- a/test/client/fixtures/sandbox/node/window-test.js
+++ b/test/client/fixtures/sandbox/node/window-test.js
@@ -517,7 +517,7 @@ test('UNCAUGHT_JS_ERROR_EVENT', function () {
             };
 
             windowSandox.on(hammerhead.EVENTS.uncaughtJsError, handler);
-            windowSandox._raiseUncaughtJsErrorEvent(hammerhead.EVENTS.uncaughtJsError, testCase.event, window);
+            windowSandox.raiseUncaughtJsErrorEvent(hammerhead.EVENTS.uncaughtJsError, testCase.event, window);
         });
     };
 
@@ -565,7 +565,7 @@ if (nativeMethods.winOnUnhandledRejectionSetter) {
                 };
 
                 windowSandox.on(hammerhead.EVENTS.unhandledRejection, handler);
-                windowSandox._raiseUncaughtJsErrorEvent(hammerhead.EVENTS.unhandledRejection, { reason: testCase.reason }, window);
+                windowSandox.raiseUncaughtJsErrorEvent(hammerhead.EVENTS.unhandledRejection, { reason: testCase.reason }, window);
             });
         };
 


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Turned off useless overriding in proxyless mode for optimization

## Approach
Turned off overriding for:
<details>
  <summary>sandbox-node-window</summary>

* overrideDrawImageInCanvasRenderingContext2D
* overrideAssignInObject
* overrideOpenInWindow
* overrideBlobInWindow
* overrideFileInWindow
* overrideProxyInWindow
* overrideCreateContextualFragmentInRange
* overrideFunctionInWindow
* overrideToStringInFunction
* overrideAppendInFormData
* overrideValueInHTMLInputElement
* overrideDisabledInHTMLInputElement
* overrideRequiredInHTMLInputElement
* overrideValueInHTMLTextAreaElement
* overrideAttrDescriptorsInElement('target’
* overrideAttrDescriptorsInElement('formTarget’
* overrideAttrDescriptorsInElement('autocomplete’
* overrideAttrDescriptorsInElement('httpEquiv’
* this.overrideAttrDescriptorsInElement('integrity’
* this.overrideAttrDescriptorsInElement('integrity’
* this.overrideAttrDescriptorsInElement('rel'
* this.overrideAttrDescriptorsInElement('as'
* overrideTypeInHTMLInputElement
* overrideSandboxInHTMLIFrameElement
* overrideSrcdocInHTMLIFrameElement
* overrideHrefInCSSStyleSheet
* overrideBaseURIInNode
* overrideTextInHTMLScriptElement
* overrideTextInHTMLAnchorElement
* overrideTextContentInNode
* overrideMethodInDOMTokenList('add'
* overrideMethodInDOMTokenList('remove'
* overrideMethodInDOMTokenList('toggle'
* overrideMethodInDOMTokenList
* overrideSupportsInDOMTokenList
* overrideValueInDOMTokenList
* overrideCreateHTMLDocumentInDOMImplementation
* overrideOriginInWindow

</details>
<details>
  <summary>sandbox-node-element</summary>

* overrideFunction(window.Element.prototype, 'setAttribute', this.overriddenMethods.setAttribute);
* overrideFunction(window.Element.prototype, 'setAttributeNS', this.overriddenMethods.setAttributeNS);
* overrideFunction(window.Element.prototype, 'getAttribute', this.overriddenMethods.getAttribute);
* overrideFunction(window.Element.prototype, 'getAttributeNS', this.overriddenMethods.getAttributeNS);
* overrideFunction(window.Element.prototype, 'removeAttribute', this.overriddenMethods.removeAttribute);
* overrideFunction(window.Element.prototype, 'removeAttributeNS', this.overriddenMethods.removeAttributeNS);
* overrideFunction(window.Element.prototype, 'removeAttributeNode', this.overriddenMethods.removeAttributeNode);
* overrideFunction(window.Element.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
* overrideFunction(window.Element.prototype, 'querySelector', this.overriddenMethods.querySelector);
* overrideFunction(window.Element.prototype, 'querySelectorAll', this.overriddenMethods.querySelectorAll);
* overrideFunction(window.Element.prototype, 'hasAttribute', this.overriddenMethods.hasAttribute);
* overrideFunction(window.Element.prototype, 'hasAttributeNS', this.overriddenMethods.hasAttributeNS);
* overrideFunction(window.Element.prototype, 'hasAttributes', this.overriddenMethods.hasAttributes);
* overrideFunction(window.Node.prototype, 'cloneNode', this.overriddenMethods.cloneNode);
* overrideFunction(window.Node.prototype, 'replaceChild', this.overriddenMethods.replaceChild);
* overrideFunction(window.DocumentFragment.prototype, 'querySelector', this.overriddenMethods.querySelector);
* overrideFunction(window.DocumentFragment.prototype, 'querySelectorAll', this.overriddenMethods.querySelectorAll);
* overrideFunction(window.HTMLTableElement.prototype, 'insertRow', this.overriddenMethods.insertRow);
* overrideFunction(window.HTMLTableSectionElement.prototype, 'insertRow', this.overriddenMethods.insertRow);
* overrideFunction(window.HTMLTableRowElement.prototype, 'insertCell', this.overriddenMethods.insertCell);
* overrideFunction(window.HTMLFormElement.prototype, 'submit', this.overriddenMethods.formSubmit);
* overrideFunction(window.HTMLAnchorElement.prototype, 'toString', this.overriddenMethods.anchorToString);
* overrideFunction(window.CharacterData.prototype, 'appendData', this.overriddenMethods.appendData);

</details>
<details>
  <summary>sandbox-node-document-index</summary>

* overrideOpen
* overrideClose
* overrideWrite
* overrideWriteln
* overrideCreateElement
* overrideCreateElementNS
* overrideCreateDocumentFragment
* overrideDocumentURI
* overrideReferrer 
* overrideURL
* overrideDomain

</details>


## References
https://github.com/DevExpress/testcafe/pull/7569 - testcafe PR with custom build

https://github.com/DevExpress/testcafe-private/issues/123

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
