### PR TITLE
update 'css' module

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "acorn-hammerhead": "0.6.1",
     "bowser": "1.6.0",
     "crypto-md5": "^1.0.0",
-    "css": "2.2.3",
+    "css": "3.0.0",
     "debug": "4.3.1",
     "esotope-hammerhead": "0.6.3",
     "http-cache-semantics": "^4.1.0",


### PR DESCRIPTION
## Purpose
Use newest version of css lib to have the latest dependencies. css 2.3.3 has transitive dependencies to uri-decode 0.2.0 via source-map-resolve 0.5.1/0.5.3. This uri-decode version which is marked as vulnerable.

## Approach
-

## References
https://nvd.nist.gov/vuln/detail/CVE-2022-38900

## Pre-Merge TODO
- [-] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
