### PR TITLE
proxyless: turned off overriding in XhrSandbox for proxyless 

### DIFF
--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -98,11 +98,11 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
         this.overrideSend();
         this.overrideSetRequestHeader();
 
-        if (nativeMethods.xhrResponseURLGetter)
-            this.overrideResponseURL();
-
         if (XhrSandbox.isProxyless)
             return;
+
+        if (nativeMethods.xhrResponseURLGetter)
+            this.overrideResponseURL();
 
         this.overrideGetResponseHeader();
         this.overrideGetAllResponseHeaders();

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -103,14 +103,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
         if (nativeMethods.xhrResponseURLGetter)
             this.overrideResponseURL();
 
-        overrideFunction(xmlHttpRequestProto, 'getResponseHeader', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['getResponseHeader']>) {
-            let value = nativeMethods.xhrGetResponseHeader.apply(this, args);
-
-            if (value && isAuthenticateHeader(args[0]))
-                value = removeAuthenticatePrefix(value);
-
-            return value;
-        });
+        this.overrideGetResponseHeader();
 
         overrideFunction(xmlHttpRequestProto, 'getAllResponseHeaders', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['getAllResponseHeaders']>) {
             let allHeaders = nativeMethods.xhrGetAllResponseHeaders.apply(this, args);
@@ -276,6 +269,17 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
 
                 return xhrSandbox.proxyless ? nativeResponseURL : getDestinationUrl(nativeResponseURL);
             },
+        });
+    }
+
+    private overrideGetResponseHeader () {
+        overrideFunction(this.window.XMLHttpRequest.prototype, 'getResponseHeader', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['getResponseHeader']>) {
+            let value = nativeMethods.xhrGetResponseHeader.apply(this, args);
+
+            if (value && isAuthenticateHeader(args[0]))
+                value = removeAuthenticatePrefix(value);
+
+            return value;
         });
     }
 }

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -102,6 +102,10 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
             this.overrideResponseURL();
 
         this.overrideGetResponseHeader();
+
+        if (XhrSandbox.isProxyless)
+            return;
+
         this.overrideGetAllResponseHeaders();
     }
 

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -101,11 +101,10 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
         if (nativeMethods.xhrResponseURLGetter)
             this.overrideResponseURL();
 
-        this.overrideGetResponseHeader();
-
         if (XhrSandbox.isProxyless)
             return;
 
+        this.overrideGetResponseHeader();
         this.overrideGetAllResponseHeaders();
     }
 

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -92,8 +92,6 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
     attach (window): void {
         super.attach(window);
 
-        const xmlHttpRequestProto = window.XMLHttpRequest.prototype;
-
         this.overrideXMLHttpRequest();
         this.overrideAbort();
         this.overrideOpen();
@@ -104,15 +102,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
             this.overrideResponseURL();
 
         this.overrideGetResponseHeader();
-
-        overrideFunction(xmlHttpRequestProto, 'getAllResponseHeaders', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['getAllResponseHeaders']>) {
-            let allHeaders = nativeMethods.xhrGetAllResponseHeaders.apply(this, args);
-
-            while (hasAuthenticatePrefix(allHeaders))
-                allHeaders = removeAuthenticatePrefix(allHeaders);
-
-            return allHeaders;
-        });
+        this.overrideGetAllResponseHeaders();
     }
 
     private overrideXMLHttpRequest () {
@@ -280,6 +270,17 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
                 value = removeAuthenticatePrefix(value);
 
             return value;
+        });
+    }
+
+    private overrideGetAllResponseHeaders () {
+        overrideFunction(this.window.XMLHttpRequest.prototype, 'getAllResponseHeaders', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['getAllResponseHeaders']>) {
+            let allHeaders = nativeMethods.xhrGetAllResponseHeaders.apply(this, args);
+
+            while (hasAuthenticatePrefix(allHeaders))
+                allHeaders = removeAuthenticatePrefix(allHeaders);
+
+            return allHeaders;
         });
     }
 }

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -95,11 +95,10 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
         const xhrSandbox          = this;
         const xmlHttpRequestProto = window.XMLHttpRequest.prototype;
 
-        this.overrideXMLHttpRequestInWindow();
-        this.overrideAbortInXMLHttpRequest();
-        this.overrideOpenInXMLHttpRequest();
-
-        this.overrideSendInXMLHttpRequest();
+        this.overrideXMLHttpRequest();
+        this.overrideAbort();
+        this.overrideOpen();
+        this.overrideSend();
         this.overrideSetRequestHeader();
 
         if (nativeMethods.xhrResponseURLGetter) {
@@ -131,7 +130,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
         });
     }
 
-    private overrideXMLHttpRequestInWindow () {
+    private overrideXMLHttpRequest () {
         const emitXhrCompletedEvent           = this.createEmitXhrCompletedEvent();
         const syncCookieWithClientIfNecessary = this.createSyncCookieWithClientIfNecessary();
 
@@ -159,7 +158,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
         });
     }
 
-    private overrideSendInXMLHttpRequest () {
+    private overrideSend () {
         const xhrSandbox = this;
 
         const emitXhrCompletedEvent           = this.createEmitXhrCompletedEvent();
@@ -216,7 +215,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
         return syncCookieWithClientIfNecessary;
     }
 
-    private overrideAbortInXMLHttpRequest () {
+    private overrideAbort () {
         const xhrSandbox = this;
 
         overrideFunction(window.XMLHttpRequest.prototype, 'abort', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['abort']>) { // eslint-disable-line consistent-return
@@ -231,7 +230,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
         });
     }
 
-    private overrideOpenInXMLHttpRequest () {
+    private overrideOpen () {
         // NOTE: Redirect all requests to the Hammerhead proxy and ensure that requests don't
         // violate Same Origin Policy.
         const xhrSandbox = this;

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -96,10 +96,11 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
         this.overrideAbort();
         this.overrideOpen();
         this.overrideSend();
-        this.overrideSetRequestHeader();
 
         if (XhrSandbox.isProxyless)
             return;
+
+        this.overrideSetRequestHeader();
 
         if (nativeMethods.xhrResponseURLGetter)
             this.overrideResponseURL();
@@ -239,7 +240,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
 
     private overrideSetRequestHeader () {
         overrideFunction(this.window.XMLHttpRequest.prototype, 'setRequestHeader', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['setRequestHeader']>) {
-            if (!XhrSandbox.isProxyless && isAuthorizationHeader(args[0]))
+            if (isAuthorizationHeader(args[0]))
                 args[1] = addAuthorizationPrefix(args[1]);
 
             nativeMethods.xhrSetRequestHeader.apply(this, args);

--- a/src/client/sandbox/xhr.ts
+++ b/src/client/sandbox/xhr.ts
@@ -218,7 +218,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
     private overrideAbort () {
         const xhrSandbox = this;
 
-        overrideFunction(window.XMLHttpRequest.prototype, 'abort', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['abort']>) { // eslint-disable-line consistent-return
+        overrideFunction(this.window.XMLHttpRequest.prototype, 'abort', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['abort']>) { // eslint-disable-line consistent-return
             if (xhrSandbox.gettingSettingInProgress())
                 return void xhrSandbox.delayUntilGetSettings(() => this.abort.apply(this, args));
 
@@ -235,7 +235,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
         // violate Same Origin Policy.
         const xhrSandbox = this;
 
-        overrideFunction(window.XMLHttpRequest.prototype, 'open', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['open']>) { // eslint-disable-line consistent-return
+        overrideFunction(this.window.XMLHttpRequest.prototype, 'open', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['open']>) { // eslint-disable-line consistent-return
             let url = args[1];
 
             if (getProxyUrl(url, {}, xhrSandbox.proxyless) === url) {
@@ -262,7 +262,7 @@ export default class XhrSandbox extends SandboxBaseWithDelayedSettings {
     private overrideSetRequestHeader () {
         const xhrSandbox = this;
 
-        overrideFunction(window.XMLHttpRequest.prototype, 'setRequestHeader', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['setRequestHeader']>) {
+        overrideFunction(this.window.XMLHttpRequest.prototype, 'setRequestHeader', function (this: XMLHttpRequest, ...args: Parameters<XMLHttpRequest['setRequestHeader']>) {
             if (!xhrSandbox.proxyless && isAuthorizationHeader(args[0]))
                 args[1] = addAuthorizationPrefix(args[1]);
 

--- a/test/client/fixtures/sandbox/xhr-test.js
+++ b/test/client/fixtures/sandbox/xhr-test.js
@@ -8,6 +8,7 @@ var nativeMethods = hammerhead.nativeMethods;
 var xhrSandbox    = hammerhead.sandbox.xhr;
 var Promise       = hammerhead.Promise;
 var browserUtils  = hammerhead.utils.browser;
+var settings      = hammerhead.settings;
 
 function getPrototypeFromChainContainsProp (obj, prop) {
     while (obj && !obj.hasOwnProperty(prop))
@@ -514,13 +515,13 @@ test('should handle blob object urls (GH-1397)', function () {
 });
 
 module('proxyless', function (hooks) {
-    var storedProxyless = xhrSandbox.proxyless;
+    var storedSettings = settings.get();
 
     hooks.beforeEach(function () {
-        xhrSandbox.proxyless = true;
+        settings.set({ ...storedSettings, proxyless: true });
     });
     hooks.afterEach(function () {
-        xhrSandbox.proxyless = storedProxyless;
+        settings.set(storedSettings);
     });
 
     test('xhr.open method', function () {


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Turned off useless overriding in proxyless mode for optimization

## Approach
Turned off overriding for:
<details>
  <summary>sandbox-node-window</summary>

* overrideSetRequestHeader
* overrideResponseURL
* overrideGetResponseHeader
* overrideGetAllResponseHeaders 

</details>

## References
https://github.com/DevExpress/testcafe/pull/7569 - testcafe PR with custom build

https://github.com/DevExpress/testcafe-private/issues/123

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
