### PR TITLE
test(client/sandbox/code-instrumentation): add test case for private identifiers and property definition

### DIFF
--- a/test/client/fixtures/sandbox/code-instrumentation/process-script-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/process-script-test.js
@@ -225,6 +225,14 @@ test('should process script arg', function () {
     strictEqual(execScript('({ a: b } = { a: null }).a'), null);
 });
 
+test('private identifier and property definition', function () {
+    var script = `const {T:xc}={},Nc=class s{static#e=this.field="test";}; window.output = Nc.field`;
+
+    eval(processScript(script));
+
+    strictEqual(window.output, 'test');
+});
+
 module('others');
 
 test('optional chaining', function () {


### PR DESCRIPTION
Currently fails, passes with these two patches:
 - https://github.com/DevExpress/esotope-hammerhead/pull/21
 - https://github.com/DevExpress/esotope-hammerhead/pull/22

See https://github.com/DevExpress/testcafe/issues/7632.