### PR TITLE
fix: optional chaining in case `obj?.property[0]` if obj is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@electron/asar": "^3.2.3",
-    "acorn-hammerhead": "https://github.com/Aleksey28/builds/raw/main/acorn-hammerhead-0.6.2.tgz",
+    "acorn-hammerhead": "0.6.2",
     "bowser": "1.6.0",
     "crypto-md5": "^1.0.0",
     "css": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@electron/asar": "^3.2.3",
-    "acorn-hammerhead": "0.6.1",
+    "acorn-hammerhead": "https://github.com/Aleksey28/builds/raw/main/acorn-hammerhead-0.6.2.tgz",
     "bowser": "1.6.0",
     "crypto-md5": "^1.0.0",
     "css": "2.2.3",

--- a/test/client/fixtures/sandbox/code-instrumentation/process-script-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/process-script-test.js
@@ -255,6 +255,10 @@ test('optional chaining', function () {
             src:      'var obj = null; var counter = 0; window.optionChainingResult = obj?.[counter -1];',
             expected: void 0,
         },
+        {
+            src:      'var obj = null; var counter = 0; window.optionChainingResult = obj?.href[counter];',
+            expected: void 0,
+        },
     ];
 
     var additionalCases = [];

--- a/test/server/script-processor-test.js
+++ b/test/server/script-processor-test.js
@@ -860,6 +860,10 @@ describe('Script processor', () => {
                 src:      'obj?.{0}?.method(args)',
                 expected: '__get$(obj,"{0}",true)?.method(args)',
             },
+            {
+                src:      'obj?.{0}.{0}',
+                expected: '__get$(__get$(obj,"{0}",true),"{0}",true)',
+            },
         ]);
 
         testMethodProcessing([


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->
[closes #2891]

## Purpose
Fix optional chaining in case getting all descendants if an ancestor is optional and undefined.

## Approach
Transmit the optional flag to all descendants of an ancestor 

## References
https://github.com/DevExpress/acorn-hammerhead/pull/8

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
