### PR TITLE
move tests to Safari 16

### DIFF
--- a/gulp/saucelabs-settings.js
+++ b/gulp/saucelabs-settings.js
@@ -13,18 +13,13 @@ const CLIENT_TESTS_BROWSERS = [
     },
     {
         browserName: 'safari',
-        platform:    'macOS 11.00',
-        version:     '14',
-    },
-    {
-        browserName: 'safari',
         platform:    'macOS 13',
         version:     '16',
     },
     {
         browserName:     'Safari',
-        deviceName:      'iPhone 7 Plus Simulator',
-        platformVersion: '11.3',
+        deviceName:      'iPhone Simulator',
+        platformVersion: '16.2',
         platformName:    'iOS',
     },
     {

--- a/gulp/saucelabs-settings.js
+++ b/gulp/saucelabs-settings.js
@@ -17,9 +17,10 @@ const CLIENT_TESTS_BROWSERS = [
         version:     '16',
     },
     {
-        platformName: 'iOS',
-        browserName:  'Safari',
-        deviceName:   'iPhone Simulator',
+        platformName:    'iOS',
+        browserName:     'Safari',
+        deviceName:      'iPhone 14 Simulator',
+        platformVersion: '16.2',
     },
     {
         deviceName:      'Android GoogleAPI Emulator',

--- a/gulp/saucelabs-settings.js
+++ b/gulp/saucelabs-settings.js
@@ -18,8 +18,8 @@ const CLIENT_TESTS_BROWSERS = [
     },
     {
         browserName:     'Safari',
-        deviceName:      'iPhone 7 Plus Simulator',
-        platformVersion: '15.5',
+        deviceName:      'iPhone 14 Plus Simulator',
+        platformVersion: '16.0',
         platformName:    'iOS',
     },
     {

--- a/gulp/saucelabs-settings.js
+++ b/gulp/saucelabs-settings.js
@@ -17,10 +17,9 @@ const CLIENT_TESTS_BROWSERS = [
         version:     '16',
     },
     {
-        browserName:     'Safari',
-        deviceName:      'iPhone Simulator',
-        platformVersion: '16.2',
-        platformName:    'iOS',
+        platformName: 'iOS',
+        browserName:  'Safari',
+        deviceName:   'iPhone Simulator',
     },
     {
         deviceName:      'Android GoogleAPI Emulator',

--- a/gulp/saucelabs-settings.js
+++ b/gulp/saucelabs-settings.js
@@ -18,7 +18,7 @@ const CLIENT_TESTS_BROWSERS = [
     },
     {
         browserName:     'Safari',
-        deviceName:      'iPhone 14 Plus Simulator',
+        deviceName:      'iPhone 8 Plus Simulator',
         platformVersion: '16.0',
         platformName:    'iOS',
     },

--- a/gulp/saucelabs-settings.js
+++ b/gulp/saucelabs-settings.js
@@ -19,7 +19,7 @@ const CLIENT_TESTS_BROWSERS = [
     {
         browserName:     'Safari',
         deviceName:      'iPhone 7 Plus Simulator',
-        platformVersion: '11.3',
+        platformVersion: '15.5',
         platformName:    'iOS',
     },
     {

--- a/gulp/saucelabs-settings.js
+++ b/gulp/saucelabs-settings.js
@@ -17,10 +17,10 @@ const CLIENT_TESTS_BROWSERS = [
         version:     '16',
     },
     {
-        platformName:    'iOS',
         browserName:     'Safari',
-        deviceName:      'iPhone 14 Simulator',
-        platformVersion: '16.2',
+        deviceName:      'iPhone 7 Plus Simulator',
+        platformVersion: '11.3',
+        platformName:    'iOS',
     },
     {
         deviceName:      'Android GoogleAPI Emulator',

--- a/gulp/saucelabs-settings.js
+++ b/gulp/saucelabs-settings.js
@@ -18,8 +18,8 @@ const CLIENT_TESTS_BROWSERS = [
     },
     {
         browserName: 'safari',
-        platform:    'macOS 12',
-        version:     '15',
+        platform:    'macOS 13',
+        version:     '16',
     },
     {
         browserName:     'Safari',

--- a/test/client/fixtures/sandbox/node/attributes-test.js
+++ b/test/client/fixtures/sandbox/node/attributes-test.js
@@ -267,12 +267,15 @@ if (nativeMethods.scriptIntegrityGetter && nativeMethods.linkIntegrityGetter) {
     });
 }
 
-test('iframe with "javascript: <html>...</html>" src', function () {
-    return createTestIframe({ src: 'javascript:"<script>var d = {}; d.src = 1; window.test = true;<' + '/script>"' })
-        .then(function (iframe) {
-            ok(iframe.contentWindow.test);
-        });
-});
+// TODO: Bug in Safari 16.1. It doesn't reproduced in 16.5.
+if (browserUtils.isSafari && browserUtils.fullVersion !== '16.1') {
+    test('iframe with "javascript: <html>...</html>" src', function () {
+        return createTestIframe({ src: 'javascript:"<script>var d = {}; d.src = 1; window.test = true;<' + '/script>"' })
+            .then(function (iframe) {
+                ok(iframe.contentWindow.test);
+            });
+    });
+}
 
 asyncTest('iframe html src', function () {
     var iframe = document.createElement('iframe');

--- a/test/client/fixtures/utils/dom-test.js
+++ b/test/client/fixtures/utils/dom-test.js
@@ -961,10 +961,8 @@ test('inspect html elements', function () {
         { tagName: 'td', assertFn: domUtils.isTableDataCellElement },
         { tagName: 'input', assertFn: domUtils.isRadioButtonElement, attributes: { type: 'radio' } },
         { tagName: 'input', assertFn: domUtils.isCheckboxElement, attributes: { type: 'checkbox' } },
+        { tagName: 'input', assertFn: domUtils.isColorInputElement, attributes: { type: 'color' } },
     ];
-
-    if (!browserUtils.isSafari)
-        htmlElements.push({ tagName: 'input', assertFn: domUtils.isColorInputElement, attributes: { type: 'color' } });
 
     htmlElements.forEach(function (info) {
         var existingTags = ['html', 'body', 'script', 'head'];

--- a/test/client/fixtures/utils/dom-test.js
+++ b/test/client/fixtures/utils/dom-test.js
@@ -819,15 +819,8 @@ test('isInputWithoutSelectionProperties', function () {
     input2.type = 'number';
     input3.type = 'text';
 
-    if (browserUtils.isSafari) {
-        notOk(domUtils.isInputWithoutSelectionProperties(input1));
-        notOk(domUtils.isInputWithoutSelectionProperties(input2));
-    }
-    else {
-        ok(domUtils.isInputWithoutSelectionProperties(input1));
-        ok(domUtils.isInputWithoutSelectionProperties(input2));
-    }
-
+    ok(domUtils.isInputWithoutSelectionProperties(input1));
+    ok(domUtils.isInputWithoutSelectionProperties(input2));
     notOk(domUtils.isInputWithoutSelectionProperties(input3));
 });
 

--- a/test/client/fixtures/utils/url-test.js
+++ b/test/client/fixtures/utils/url-test.js
@@ -248,10 +248,7 @@ test('destination with port', function () {
 });
 
 test('undefined or null', function () {
-    // NOTE: In Safari, a.href = null  leads to the empty url, not <current_url>/null.
-    if (!browserUtils.isSafari)
-        strictEqual(getProxyUrl(null), 'http://' + PROXY_HOST + '/sessionId/https://example.com/null');
-
+    strictEqual(getProxyUrl(null), 'http://' + PROXY_HOST + '/sessionId/https://example.com/null');
     strictEqual(getProxyUrl(void 0), 'http://' + PROXY_HOST + '/sessionId/https://example.com/undefined');
 });
 


### PR DESCRIPTION
There is an issue with running tests on iOS mobile emulator 16.0 and later. I've reported an issue to its Support Center - https://support.saucelabs.com/hc/en-us. The answer should be received at `testcafebot@gmail.com` email.