### PR TITLE
fix: added moving hidden input to the form bottom

### DIFF
--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -1004,8 +1004,10 @@ export default class ElementSandbox extends SandboxBase {
 
     addFileInputInfo (el: HTMLElement): void {
         const infoManager = this._uploadSandbox.infoManager;
+        const files       = infoManager.getFiles(el);
 
-        hiddenInfo.addInputInfo(el, infoManager.getFiles(el), infoManager.getValue(el));
+        if (files.length)
+            hiddenInfo.addInputInfo(el, files, infoManager.getValue(el));
     }
 
     onIframeAddedToDOM (iframe: HTMLIFrameElement | HTMLFrameElement): void {

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -545,6 +545,9 @@ export default class ElementSandbox extends SandboxBase {
         for (const child of childNodesArray)
             this._onElementAdded(child);
 
+        if (domUtils.getTagName(parent) === 'form')
+            hiddenInfo.moveInputToFormBottom(parent as HTMLFormElement);
+
         return result;
     }
 
@@ -1006,8 +1009,7 @@ export default class ElementSandbox extends SandboxBase {
         const infoManager = this._uploadSandbox.infoManager;
         const files       = infoManager.getFiles(el);
 
-        if (files.length)
-            hiddenInfo.addInputInfo(el, files, infoManager.getValue(el));
+        hiddenInfo.addInputInfo(el, files, infoManager.getValue(el));
     }
 
     onIframeAddedToDOM (iframe: HTMLIFrameElement | HTMLFrameElement): void {

--- a/src/client/sandbox/upload/hidden-info.ts
+++ b/src/client/sandbox/upload/hidden-info.ts
@@ -3,6 +3,9 @@ import { parse as parseJSON, stringify as stringifyJSON } from '../../../utils/j
 import nativeMethods from '../native-methods';
 import ShadowUI from '../shadow-ui';
 
+
+const INPUT_SELECTOR = '[name="' + INTERNAL_ATTRS.uploadInfoHiddenInputName + '"]';
+
 function createInput (form: HTMLFormElement) {
     const hiddenInput = nativeMethods.createElement.call(document, 'input') as HTMLInputElement;
 
@@ -20,9 +23,7 @@ function createInput (form: HTMLFormElement) {
 }
 
 function getInput (form: HTMLFormElement) {
-    const inputSelector = '[name="' + INTERNAL_ATTRS.uploadInfoHiddenInputName + '"]';
-
-    return nativeMethods.elementQuerySelector.call(form, inputSelector) || createInput(form);
+    return nativeMethods.elementQuerySelector.call(form, INPUT_SELECTOR) || createInput(form);
 }
 
 function indexOf (info, input) {
@@ -99,8 +100,7 @@ export function removeInputInfo (input) {
 }
 
 export function moveInputToFormBottom (form: HTMLFormElement) {
-    const inputSelector = '[name="' + INTERNAL_ATTRS.uploadInfoHiddenInputName + '"]';
-    const inputElement  = nativeMethods.elementQuerySelector.call(form, inputSelector);
+    const inputElement  = nativeMethods.elementQuerySelector.call(form, INPUT_SELECTOR);
 
     if (inputElement)
         nativeMethods.appendChild.call(form, inputElement);

--- a/src/client/sandbox/upload/hidden-info.ts
+++ b/src/client/sandbox/upload/hidden-info.ts
@@ -4,7 +4,7 @@ import nativeMethods from '../native-methods';
 import ShadowUI from '../shadow-ui';
 
 
-const INPUT_SELECTOR = '[name="' + INTERNAL_ATTRS.uploadInfoHiddenInputName + '"]';
+const INPUT_SELECTOR = `[name="${INTERNAL_ATTRS.uploadInfoHiddenInputName}"]`;
 
 function createInput (form: HTMLFormElement) {
     const hiddenInput = nativeMethods.createElement.call(document, 'input') as HTMLInputElement;

--- a/src/client/sandbox/upload/hidden-info.ts
+++ b/src/client/sandbox/upload/hidden-info.ts
@@ -97,3 +97,11 @@ export function removeInputInfo (input) {
 
     return false;
 }
+
+export function moveInputToFormBottom (form: HTMLFormElement) {
+    const inputSelector = '[name="' + INTERNAL_ATTRS.uploadInfoHiddenInputName + '"]';
+    const inputElement  = nativeMethods.elementQuerySelector.call(form, inputSelector);
+
+    if (inputElement)
+        nativeMethods.appendChild.call(form, inputElement);
+}

--- a/test/client/fixtures/sandbox/upload-test.js
+++ b/test/client/fixtures/sandbox/upload-test.js
@@ -217,6 +217,23 @@ test('hidden input should not affect both the length/count value and the element
         });
 });
 
+test('hidden input should not affect on getting element by index in multilevel form', function () {
+    var form   = document.createElement('form');
+
+    var input1 = $('<label><input type="file"></label>')[0];
+    var input2 = $('<input type="checkbox">')[0];
+
+    document.body.appendChild(form);
+
+    form.appendChild(input1);
+    form.appendChild(input2);
+
+    strictEqual(input1, form.childNodes[0]);
+    strictEqual(input2, form.childNodes[1]);
+
+    form.parentNode.removeChild(form);
+});
+
 test('get/set upload info', function () {
     var fileInputWithoutForm = $('<input type="file">')[0];
     var fileInputWithForm    = $('<form><input type="file"></form>').children()[0];


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->
[closes DevExpress/testcafe#7489]

## Purpose
Fix the issue with getting elements in form by index. 

## Approach
Move the custom hidden input element to the form bottom each time when a new element is added to that form.

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
