### PR TITLE
fix IE11 failing in TestCafe (closes #7741)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "31.4.2",
+  "version": "31.4.3",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/processing/style.ts
+++ b/src/processing/style.ts
@@ -11,8 +11,6 @@ import { URL_ATTR_TAGS } from './dom/attributes';
 import DomProcessor from './dom';
 import { Dictionary } from '../typings/common';
 
-// NOTE: We should avoid using native object prototype methods,
-// since they can be overriden by the client code.
 const arrayJoin  = Array.prototype.join;
 const objectKeys = Object.keys;
 

--- a/src/processing/style.ts
+++ b/src/processing/style.ts
@@ -11,10 +11,10 @@ import { URL_ATTR_TAGS } from './dom/attributes';
 import DomProcessor from './dom';
 import { Dictionary } from '../typings/common';
 
-function getTagsString (tagsDict: Dictionary<string>[]) {
+function getTagsString (tagsDict: Dictionary<string[]>) {
     const tags: string[] = [];
 
-    for (const key of Object.keys(tagsDict)) {
+    for (const key in tagsDict) {
         for (const tag of tagsDict[key])
             tags.push(tag);
     }
@@ -24,7 +24,7 @@ function getTagsString (tagsDict: Dictionary<string>[]) {
 
 const SOURCE_MAP_RE                       = /\/\*\s*[#@]\s*sourceMappingURL\s*=[\s\S]*?\*\/|\/\/[\t ]*[#@][\t ]*sourceMappingURL[\t ]*=.*/ig;
 const CSS_URL_PROPERTY_VALUE_RE           = /(url\s*\(\s*(['"]?))([^\s]*?)(\2\s*\))|(@import\s+(['"]))([^\s]*?)(\6)/g;
-const TAGS_STRING                         = getTagsString(URL_ATTR_TAGS as unknown as Dictionary<string>[]);
+const TAGS_STRING                         = getTagsString(URL_ATTR_TAGS);
 const ATTRS_STRING                        = Object.keys(URL_ATTR_TAGS).join('|');
 const ATTRIBUTE_SELECTOR_RE               = new RegExp(`(([#.])?(?:${TAGS_STRING})\\[\\s*)(${ATTRS_STRING})(\\s*(?:\\^)?=)`, 'g');
 const STYLESHEET_PROCESSING_START_COMMENT = '/*hammerhead|stylesheet|start*/';

--- a/src/processing/style.ts
+++ b/src/processing/style.ts
@@ -9,10 +9,22 @@ import INTERNAL_ATTRS from '../processing/dom/internal-attributes';
 import { isSpecialPage } from '../utils/url';
 import { URL_ATTR_TAGS } from './dom/attributes';
 import DomProcessor from './dom';
+import { Dictionary } from '../typings/common';
+
+function getTagsString (tagsDict: Dictionary<string>[]) {
+    const tags: string[] = [];
+
+    for (const key of Object.keys(tagsDict)) {
+        for (const tag of tagsDict[key])
+            tags.push(tag);
+    }
+
+    return tags.join().replace(/,/g, '|');
+}
 
 const SOURCE_MAP_RE                       = /\/\*\s*[#@]\s*sourceMappingURL\s*=[\s\S]*?\*\/|\/\/[\t ]*[#@][\t ]*sourceMappingURL[\t ]*=.*/ig;
 const CSS_URL_PROPERTY_VALUE_RE           = /(url\s*\(\s*(['"]?))([^\s]*?)(\2\s*\))|(@import\s+(['"]))([^\s]*?)(\6)/g;
-const TAGS_STRING                         = Object.values(URL_ATTR_TAGS).join().replace(/,/g, '|');
+const TAGS_STRING                         = getTagsString(URL_ATTR_TAGS as unknown as Dictionary<string>[]);
 const ATTRS_STRING                        = Object.keys(URL_ATTR_TAGS).join('|');
 const ATTRIBUTE_SELECTOR_RE               = new RegExp(`(([#.])?(?:${TAGS_STRING})\\[\\s*)(${ATTRS_STRING})(\\s*(?:\\^)?=)`, 'g');
 const STYLESHEET_PROCESSING_START_COMMENT = '/*hammerhead|stylesheet|start*/';

--- a/src/processing/style.ts
+++ b/src/processing/style.ts
@@ -11,6 +11,11 @@ import { URL_ATTR_TAGS } from './dom/attributes';
 import DomProcessor from './dom';
 import { Dictionary } from '../typings/common';
 
+// NOTE: We should avoid using native object prototype methods,
+// since they can be overriden by the client code.
+const arrayJoin  = Array.prototype.join;
+const objectKeys = Object.keys;
+
 function getTagsString (tagsDict: Dictionary<string[]>) {
     const tags: string[] = [];
 
@@ -19,13 +24,13 @@ function getTagsString (tagsDict: Dictionary<string[]>) {
             tags.push(tag);
     }
 
-    return tags.join().replace(/,/g, '|');
+    return arrayJoin.call(tags).replace(/,/g, '|');
 }
 
 const SOURCE_MAP_RE                       = /\/\*\s*[#@]\s*sourceMappingURL\s*=[\s\S]*?\*\/|\/\/[\t ]*[#@][\t ]*sourceMappingURL[\t ]*=.*/ig;
 const CSS_URL_PROPERTY_VALUE_RE           = /(url\s*\(\s*(['"]?))([^\s]*?)(\2\s*\))|(@import\s+(['"]))([^\s]*?)(\6)/g;
 const TAGS_STRING                         = getTagsString(URL_ATTR_TAGS);
-const ATTRS_STRING                        = Object.keys(URL_ATTR_TAGS).join('|');
+const ATTRS_STRING                        = arrayJoin.call(objectKeys(URL_ATTR_TAGS), '|');
 const ATTRIBUTE_SELECTOR_RE               = new RegExp(`(([#.])?(?:${TAGS_STRING})\\[\\s*)(${ATTRS_STRING})(\\s*(?:\\^)?=)`, 'g');
 const STYLESHEET_PROCESSING_START_COMMENT = '/*hammerhead|stylesheet|start*/';
 const STYLESHEET_PROCESSING_END_COMMENT   = '/*hammerhead|stylesheet|end*/';
@@ -108,7 +113,7 @@ class StyleProcessor {
         }
 
 
-        return parts.join('');
+        return arrayJoin.call(parts, '');
     }
 
     private _replaceStylesheetUrls (css: string, processor: Function): string {


### PR DESCRIPTION
we cannot use `Object.values` in IE11