### PR TITLE
native automation: fix lowercasing headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "31.4.5",
+  "version": "31.4.6",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/request-pipeline/request-hooks/events/configure-response-event.ts
+++ b/src/request-pipeline/request-hooks/events/configure-response-event.ts
@@ -1,14 +1,7 @@
 import RequestFilterRule from '../request-filter-rule';
-import RequestPipelineContext from '../../context';
 import ConfigureResponseEventOptions from './configure-response-event-options';
 import generateUniqueId from '../../../utils/generate-unique-id';
 
-interface SerializedConfigureResponseEvent {
-    requestFilterRule: RequestFilterRule;
-    _requestContext: RequestPipelineContext;
-    opts: ConfigureResponseEventOptions;
-    id: string;
-}
 
 interface ModifyResponseFunctions {
     setHeader: (name: string, value: string) => void;
@@ -40,15 +33,5 @@ export default class ConfigureResponseEvent {
             return;
 
         this._modifyResponseFunctions.removeHeader(name);
-    }
-
-    public static from (data: unknown): ConfigureResponseEvent {
-        const { id, opts, requestFilterRule } = data as SerializedConfigureResponseEvent;
-
-        const configureResponseEvent = new ConfigureResponseEvent(requestFilterRule, null, opts);
-
-        configureResponseEvent.id = id;
-
-        return configureResponseEvent;
     }
 }

--- a/src/request-pipeline/request-hooks/events/response-event.ts
+++ b/src/request-pipeline/request-hooks/events/response-event.ts
@@ -3,17 +3,6 @@ import { PreparedResponseInfo } from './info';
 import generateUniqueId from '../../../utils/generate-unique-id';
 import { OutgoingHttpHeaders } from 'http';
 
-interface SerializedResponseEvent {
-    requestFilterRule: RequestFilterRule;
-    id: string;
-    requestId: string;
-    statusCode: number;
-    sessionId: string;
-    isSameOriginPolicyFailed: boolean;
-    headers?: OutgoingHttpHeaders;
-    body?: Buffer;
-}
-
 export default class ResponseEvent {
     public requestFilterRule: RequestFilterRule;
     public readonly requestId: string;
@@ -43,31 +32,5 @@ export default class ResponseEvent {
 
         this.id                = generateUniqueId();
         this.requestFilterRule = requestFilterRule;
-    }
-
-    public static from (data: unknown): ResponseEvent {
-        const {
-            requestFilterRule,
-            id,
-            requestId,
-            statusCode,
-            sessionId,
-            isSameOriginPolicyFailed,
-            headers,
-            body,
-        } = data as SerializedResponseEvent;
-
-        const responseEvent = new ResponseEvent(requestFilterRule, {
-            requestId,
-            statusCode,
-            sessionId,
-            isSameOriginPolicyFailed,
-            headers,
-            body,
-        });
-
-        responseEvent.id = id;
-
-        return responseEvent;
     }
 }

--- a/src/request-pipeline/request-hooks/response-mock/get-response.ts
+++ b/src/request-pipeline/request-hooks/response-mock/get-response.ts
@@ -33,6 +33,9 @@ export default async function (mock: ResponseMock): Promise<IncomingMessageLike>
 
         try {
             response = Object.assign(response, await mock.body(mock.requestOptions, response));
+
+            if (typeof response.statusCode !== 'number')
+                response.statusCode = Number(response.statusCode);
         }
         catch (err) {
             response.statusCode = 500;

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -563,7 +563,7 @@ declare module 'testcafe-hammerhead' {
         isAjax: boolean;
 
         /** Creates a RequestOptions instance **/
-        constructor (params: RequestOptionsParams);
+        constructor (params: RequestOptionsParams, trackChanges?: boolean);
     }
 
     /** The ResponseMock class is used to send request **/


### PR DESCRIPTION
Part of https://github.com/DevExpress/testcafe/pull/7802

Changes:
* remove the `RequestEvent.from`, `ConfigureResponseEvent.from` and `Response.from` methods (artifacts of the `experimental-debug` feature)
* add tracking and synchronization of request option changes (connected with working RequestHooks in the native automation mode)