### PR TITLE
Fix reprocessElementsAssociatedWithIframe throwing an DOMException error

### DIFF
--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -1,37 +1,37 @@
-import INTERNAL_PROPS from '../../../processing/dom/internal-properties';
-import SandboxBase from '../base';
-import NodeSandbox from '../node/index';
 import DomProcessor from '../../../processing/dom';
-import nativeMethods from '../native-methods';
-import domProcessor from '../../dom-processor';
+import { ATTRS_WITH_SPECIAL_PROXYING_LOGIC } from '../../../processing/dom/attributes';
+import INTERNAL_PROPS from '../../../processing/dom/internal-properties';
 import { processScript } from '../../../processing/script';
 import styleProcessor from '../../../processing/style';
-import * as urlUtils from '../../utils/url';
-import * as domUtils from '../../utils/dom';
-import * as hiddenInfo from '../upload/hidden-info';
-import urlResolver from '../../utils/url-resolver';
-import { sameOriginCheck, get as getDestLocation } from '../../utils/destination-location';
-import { isValidEventListener, stopPropagation } from '../../utils/event';
-import { processHtml, isInternalHtmlParserElement } from '../../utils/html';
-import { getNativeQuerySelector, getNativeQuerySelectorAll } from '../../utils/query-selector';
-import { HASH_RE } from '../../../utils/url';
+import BUILTIN_HEADERS from '../../../request-pipeline/builtin-header-names';
+import isKeywordTarget from '../../../utils/is-keyword-target';
 import trim from '../../../utils/string-trim';
+import { HASH_RE } from '../../../utils/url';
+import domProcessor from '../../dom-processor';
+import settings from '../../settings';
+import { isFirefox, isIE } from '../../utils/browser';
+import { get as getDestLocation, sameOriginCheck } from '../../utils/destination-location';
+import * as domUtils from '../../utils/dom';
+import { isValidEventListener, stopPropagation } from '../../utils/event';
+import { isInternalHtmlParserElement, processHtml } from '../../utils/html';
+import InsertPosition from '../../utils/insert-position';
+import { overrideDescriptor, overrideFunction } from '../../utils/overriding';
+import { getNativeQuerySelector, getNativeQuerySelectorAll } from '../../utils/query-selector';
+import toKebabCase from '../../utils/to-kebab-case';
+import * as urlUtils from '../../utils/url';
+import urlResolver from '../../utils/url-resolver';
+import SandboxBase from '../base';
+import ChildWindowSandbox from '../child-window';
+import EventSandbox from '../event';
+import IframeSandbox from '../iframe';
+import nativeMethods from '../native-methods';
+import NodeSandbox from '../node/index';
+import ShadowUI from '../shadow-ui';
+import UploadSandbox from '../upload';
+import * as hiddenInfo from '../upload/hidden-info';
 import * as windowsStorage from '../windows-storage';
 import { refreshAttributesWrapper } from './attributes';
-import ShadowUI from '../shadow-ui';
 import DOMMutationTracker from './live-node-list/dom-mutation-tracker';
-import { ATTRS_WITH_SPECIAL_PROXYING_LOGIC } from '../../../processing/dom/attributes';
-import settings from '../../settings';
-import { overrideDescriptor, overrideFunction } from '../../utils/overriding';
-import InsertPosition from '../../utils/insert-position';
-import { isFirefox, isIE } from '../../utils/browser';
-import UploadSandbox from '../upload';
-import IframeSandbox from '../iframe';
-import EventSandbox from '../event';
-import ChildWindowSandbox from '../child-window';
-import isKeywordTarget from '../../../utils/is-keyword-target';
-import BUILTIN_HEADERS from '../../../request-pipeline/builtin-header-names';
-import toKebabCase from '../../utils/to-kebab-case';
 
 const RESTRICTED_META_HTTP_EQUIV_VALUES = [BUILTIN_HEADERS.refresh, BUILTIN_HEADERS.contentSecurityPolicy];
 
@@ -990,9 +990,11 @@ export default class ElementSandbox extends SandboxBase {
 
         const escapedIframeName  = iframe.name.replace(/"/g, '\\"');
         let elementsWithTarget = [];
+
         try {
             elementsWithTarget = nativeMethods.querySelectorAll.call(this.document, `*[target="${escapedIframeName}"]`);
-        } finally  {
+        }
+        finally {
             for (const el of elementsWithTarget)
                 this._reprocessElementAssociatedWithIframe(el);
         }

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -989,10 +989,13 @@ export default class ElementSandbox extends SandboxBase {
             return;
 
         const escapedIframeName  = iframe.name.replace(/"/g, '\\"');
-        const elementsWithTarget = nativeMethods.querySelectorAll.call(this.document, `*[target="${escapedIframeName}"]`);
-
-        for (const el of elementsWithTarget)
-            this._reprocessElementAssociatedWithIframe(el);
+        let elementsWithTarget = [];
+        try {
+            elementsWithTarget = nativeMethods.querySelectorAll.call(this.document, `*[target="${escapedIframeName}"]`);
+        } finally  {
+            for (const el of elementsWithTarget)
+                this._reprocessElementAssociatedWithIframe(el);
+        }
     }
 
     private _reprocessElementAssociatedWithIframe (el: HTMLFormElement | HTMLLinkElement): void {


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
_This pr fixes a bug with the processing of elements associated with Iframe. When the iframe name contains special characters, the querySelector method throws an exception and removes all the elements on the page._

## Approach
_The fix try catches the querySelectorAll method, in order to prevent exceptions that will remove all elements on the page. This way the expected behaviour is preserved_

## References
_https://github.com/DevExpress/testcafe/issues/7807_

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
