### PR TITLE
Bump `tough-coockie` package version to 4.1.3 to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "pinkie": "2.0.4",
     "read-file-relative": "^1.2.0",
     "semver": "7.5.3",
-    "tough-cookie": "4.0.0",
+    "tough-cookie": "4.1.3",
     "tunnel-agent": "0.6.0",
     "ws": "^7.4.6"
   },

--- a/src/session/cookies.ts
+++ b/src/session/cookies.ts
@@ -125,7 +125,7 @@ export default class Cookies {
             const {
                 key, value, domain,
                 path, expires, maxAge,
-                secure, httpOnly, sameSite,
+                secure, httpOnly, sameSite = 'none',
             } = cookie;
 
             return {

--- a/src/session/cookies.ts
+++ b/src/session/cookies.ts
@@ -125,16 +125,17 @@ export default class Cookies {
             const {
                 key, value, domain,
                 path, expires, maxAge,
-                secure, httpOnly, sameSite = 'none',
+                secure, httpOnly, sameSite,
             } = cookie;
 
             return {
-                name:    key,
-                domain:  domain || void 0,
-                path:    path || void 0,
-                expires: expires === 'Infinity' ? void 0 : expires,
-                maxAge:  maxAge || void 0,
-                value, secure, httpOnly, sameSite,
+                name:     key,
+                domain:   domain || void 0,
+                path:     path || void 0,
+                expires:  expires === 'Infinity' ? void 0 : expires,
+                maxAge:   maxAge || void 0,
+                sameSite: sameSite || 'none',
+                value, secure, httpOnly,
             };
         });
     }


### PR DESCRIPTION
Updated `tough-coockie` package version to 4.1.3 to fix `npm audit`