### PR TITLE
Fix null window case in _getCurrentInfoManager()

### DIFF
--- a/src/client/sandbox/upload/index.ts
+++ b/src/client/sandbox/upload/index.ts
@@ -38,6 +38,9 @@ export default class UploadSandbox extends SandboxBase {
 
     static _getCurrentInfoManager (input: HTMLInputElement) {
         const contextWindow = input[INTERNAL_PROPS.processedContext];
+        if (!contextWindow) {
+            return null;
+        }
 
         return getSandboxBackup(contextWindow).upload.infoManager;
     }


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
This is a fix for an issue reported in https://github.com/DevExpress/testcafe/issues/7886. You can find the stacktrace there.

## Approach
I do not know if this is the correct approach but it is logical and it fixes the problem. I tested it by editing hammerhead.js directly in our vendor folder. 
The reasoning: The use case here is when `contextWindow` value is undefined what makes no need to call `getSandboxBackup()`. `getSandboxBackup()` aka `get()` called at the bottom of `_getCurrentInfoManager()` function may return `null` according to https://github.com/DevExpress/testcafe-hammerhead/blob/6607246aca35d9b1f5f3ef1523513641a5b1aefd/src/client/sandbox/backup.ts#L44-L56 but null case was not processed in _getCurrentInfoManager(). So I assume that if it is okay for getSandboxBackup() to return null then it should also be okay for _getCurrentInfoManager() to return null.

I cannot add unit tests as my knowledge of hammerhead is very limited.

Debug for the context:

![Screenshot from 2023-07-19 15-14-26](https://github.com/DevExpress/testcafe-hammerhead/assets/3830106/5e539324-b314-4482-8ddf-2cba39cc8803)

![Screenshot from 2023-07-19 15-14-46](https://github.com/DevExpress/testcafe-hammerhead/assets/3830106/bbf27210-99d6-47a9-a83e-f2f52d0cecdf)


## References
https://github.com/DevExpress/testcafe/issues/7886

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
