### PR TITLE
fix: force reload via location.reload if url is the same

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -311,8 +311,12 @@ class Hammerhead {
         if (!navigationUrl)
             return;
 
-        // @ts-ignore
-        this.win.location = navigationUrl;
+        // eslint-disable-next-line no-restricted-properties
+        if (forceReload && this.win.location.href === navigationUrl)
+            this.win.location.reload();
+        else
+            // @ts-ignore
+            this.win.location = navigationUrl;
 
         if (forceReload) {
             this.sandbox.node.win.on(this.sandbox.node.win.HASH_CHANGE_EVENT, () => {


### PR DESCRIPTION
## Purpose
When calling navigateTo with forceReload flag the page should be reloaded and the Server._onRequest method must be triggered. In case when the URL is the same, this event is not triggered, which leads to the cookies not updated.

## Approach
Call window.reload if the URL is the same

## References
https://github.com/DevExpress/testcafe/pull/7888

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
