### PR TITLE
do not prevent opening a new window in Native Automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe-hammerhead",
   "description": "A powerful web-proxy used as a core for the TestCafe testing framework (https://github.com/DevExpress/testcafe).",
-  "version": "31.4.12",
+  "version": "31.4.13",
   "homepage": "https://github.com/DevExpress/testcafe-hammerhead",
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe-hammerhead/issues"

--- a/src/client/sandbox/child-window/index.ts
+++ b/src/client/sandbox/child-window/index.ts
@@ -82,7 +82,7 @@ export default class ChildWindowSandbox extends SandboxBase {
     }
 
     handleClickOnLinkOrArea (el: HTMLLinkElement | HTMLAreaElement): void {
-        if (!settings.get().allowMultipleWindows)
+        if (!settings.canOpenNewWindow)
             return;
 
         this._listeners.initElementListening(el, ['click']);
@@ -136,7 +136,7 @@ export default class ChildWindowSandbox extends SandboxBase {
     handleWindowOpen (window: Window, args: [string?, string?, string?, boolean?]): Window {
         const [url, target, parameters] = args;
 
-        if (settings.get().allowMultipleWindows && ChildWindowSandbox._shouldOpenInNewWindow(target, DefaultTarget.windowOpen)) {
+        if (settings.canOpenNewWindow && ChildWindowSandbox._shouldOpenInNewWindow(target, DefaultTarget.windowOpen)) {
             const openedWindowInfo = this._openUrlInNewWindow(url, target, parameters, window);
 
             return openedWindowInfo?.wnd;
@@ -151,7 +151,7 @@ export default class ChildWindowSandbox extends SandboxBase {
     }
 
     _handleFormSubmitting (window: Window): void {
-        if (!settings.get().allowMultipleWindows)
+        if (!settings.canOpenNewWindow)
             return;
 
         this._listeners.initElementListening(window, ['submit']);

--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -354,7 +354,7 @@ export default class ElementSandbox extends SandboxBase {
     }
 
     getCorrectedTarget (target = ''): string {
-        if (settings.get().allowMultipleWindows)
+        if (settings.canOpenNewWindow)
             return target;
 
         if (target && !isKeywordTarget(target) && !windowsStorage.findByName(target) ||

--- a/src/client/sandbox/node/window.ts
+++ b/src/client/sandbox/node/window.ts
@@ -284,6 +284,7 @@ export default class WindowSandbox extends SandboxBase {
         this.overrideNextSiblingInMutationRecord();
         this.overridePreviousSiblingInMutationRecord();
         this.overrideValueInHTMLInputElement();
+        this.overrideOpenInWindow();
 
         if (settings.nativeAutomation)
             return;
@@ -295,8 +296,6 @@ export default class WindowSandbox extends SandboxBase {
 
         if (nativeMethods.objectAssign)
             this.overrideAssignInObject();
-
-        this.overrideOpenInWindow();
 
         if (window.FontFace)
             this.overrideFontFaceInWindow();
@@ -587,7 +586,7 @@ export default class WindowSandbox extends SandboxBase {
         if (originTarget)
             return this.nodeSandbox.element.getCorrectedTarget(String(originTarget));
 
-        return settings.get().allowMultipleWindows ? DefaultTarget.windowOpen : '_self';
+        return settings.canOpenNewWindow ? DefaultTarget.windowOpen : '_self';
     }
 
     private overrideFontFaceInWindow () {

--- a/src/client/settings.ts
+++ b/src/client/settings.ts
@@ -33,6 +33,10 @@ class Settings {
     get nativeAutomation () {
         return this._settings.nativeAutomation;
     }
+
+    get canOpenNewWindow () {
+        return this._settings.nativeAutomation || this._settings.allowMultipleWindows;
+    }
 }
 
 const settings = new Settings();

--- a/test/client/fixtures/sandbox/child-window-test.js
+++ b/test/client/fixtures/sandbox/child-window-test.js
@@ -57,6 +57,56 @@ test('window.open', function () {
     settings.get().allowMultipleWindows = false;
 });
 
+test('window.open. Native Automation. Multiple windows are disabled', function () {
+    settings.get().nativeAutomation = true;
+
+    var storedOpenUrlInNewWindow = windowSandbox._childWindowSandbox._openUrlInNewWindow;
+    var handled = false;
+
+    windowSandbox._childWindowSandbox._openUrlInNewWindow = function (url, target) {
+        handled = true;
+
+        strictEqual(target, '_blank');
+    };
+
+    window.open('/test');
+
+    windowSandbox._childWindowSandbox._openUrlInNewWindow = storedOpenUrlInNewWindow;
+
+    settings.get().nativeAutomation = false;
+
+    strictEqual(handled, true);
+});
+
+test('Should open a new window in Native Automation by clicking a link', function () {
+    settings.get().nativeAutomation = true;
+
+    var storedOpenUrlInNewWindow = windowSandbox._childWindowSandbox._openUrlInNewWindow;
+    var handled = false;
+
+    hammerhead.sandbox.childWindow._openUrlInNewWindow = function () {
+        handled = true;
+    };
+
+    var link  = document.createElement('a');
+
+    link.innerText = 'link';
+    link.href      = 'http://example.com';
+    link.target    = '_blank';
+
+    document.body.appendChild(link);
+
+    nativeMethods.click.call(link);
+
+    windowSandbox._childWindowSandbox._openUrlInNewWindow = storedOpenUrlInNewWindow;
+
+    settings.get().nativeAutomation = false;
+
+    document.body.removeChild(link);
+
+    strictEqual(handled, true);
+});
+
 test('open child window considering base element', function () {
     settings.get().allowMultipleWindows = true;
 


### PR DESCRIPTION
Override `window.open` in Native Automation even if multiple windows are disabled.
We need it to show an error in TestCafe.