### PR TITLE
fix: add id to websocket transport messages, remove injectables for NA

### DIFF
--- a/src/client/transport/transport-in-socket.ts
+++ b/src/client/transport/transport-in-socket.ts
@@ -29,14 +29,14 @@ export default class TransportInSocket extends TransportBase {
 
         return new Promise((resolve, reject) => {
             const handleMessage = (event) => {
-                this._activeServiceMsgCount--;
-
                 const data = parse(event.data);
 
-                if (data.id === id) {
-                    cleanListeners();
-                    resolve(data.result);
-                }
+                if (data.id !== id)
+                    return;
+
+                this._activeServiceMsgCount--;
+                cleanListeners();
+                resolve(data.result);
             };
 
             const handleError = (error) => {

--- a/src/client/transport/transport-in-socket.ts
+++ b/src/client/transport/transport-in-socket.ts
@@ -1,5 +1,5 @@
 import TransportBase from './transport-base';
-import { ServiceMessage, WebSocketServiceMessage } from '../../typings/proxy';
+import { WebSocketServiceMessage } from '../../typings/proxy';
 import Promise from 'pinkie';
 import settings from '../settings';
 import { parse, stringify } from '../../utils/json';
@@ -63,7 +63,7 @@ export default class TransportInSocket extends TransportBase {
             };
 
             msg.sessionId = settings.get().sessionId;
-            msg.id = id;
+            msg.id        = id;
 
             if (this._shouldAddReferer)
                 msg.referer = settings.get().referer;

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -71,6 +71,7 @@ interface SessionOptions {
     windowId: string;
     requestTimeout?: RequestTimeout;
     referer?: string;
+    nativeAutomation?: boolean;
 }
 
 export default abstract class Session extends EventEmitter {
@@ -81,7 +82,7 @@ export default abstract class Session extends EventEmitter {
     externalProxySettings: ExternalProxySettings | null = null;
     pageLoadCount = 0;
     pendingStateSnapshot: StateSnapshot | null = null;
-    injectable: InjectableResources = { scripts: [...SCRIPTS], styles: [], userScripts: [] };
+    injectable: InjectableResources = { scripts: [], styles: [], userScripts: [] };
     private _recordMode = false;
     options: SessionOptions;
     private _disableHttp2 = false;
@@ -95,6 +96,9 @@ export default abstract class Session extends EventEmitter {
         this.options                  = this._getOptions(options);
         this.cookies                  = this.createCookies();
         this.requestHookEventProvider = new RequestHookEventProvider();
+
+        if (!options?.nativeAutomation)
+            this.injectable.scripts.push(...SCRIPTS);
     }
 
     private _getOptions (options: Partial<SessionOptions> = {}): SessionOptions {

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -97,7 +97,7 @@ export default abstract class Session extends EventEmitter {
         this.cookies                  = this.createCookies();
         this.requestHookEventProvider = new RequestHookEventProvider();
 
-        if (!options?.nativeAutomation)
+        if (!this.options.nativeAutomation)
             this.injectable.scripts.push(...SCRIPTS);
     }
 

--- a/src/typings/proxy.d.ts
+++ b/src/typings/proxy.d.ts
@@ -16,6 +16,10 @@ export interface ServiceMessage {
     referer?: string;
 }
 
+export interface WebSocketServiceMessage extends ServiceMessage{
+    id?: number;
+}
+
 export interface StaticContent {
     content: string | Buffer;
     contentType: string;


### PR DESCRIPTION
## Purpose
Support NA in TestCafe Studio

## Approach

### Injectables

Do not fill injactables for NA mode. We inject all scripts in the NA Resource Injector. 
By removing these injectables we can not inject our custom scripts in NA mode on TestRun level

### Transport

Add id field to messages in order to resolve the promises in the correct order. It is required for the TestCafe Studio. It can send multiple messages at the same time and do not await their answer

## References
https://github.com/DevExpress/testcafe/pull/7878

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
