### PR TITLE
test(client/sandbox/code-instrumentation): add test case for static blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "bowser": "1.6.0",
         "crypto-md5": "^1.0.0",
         "debug": "4.3.1",
-        "esotope-hammerhead": "0.6.4",
+        "esotope-hammerhead": "https://github.com/brandwatch/esotope-hammerhead.git#feat-static-block",
         "http-cache-semantics": "^4.1.0",
         "httpntlm": "^1.8.10",
         "iconv-lite": "0.5.1",
@@ -4074,8 +4074,8 @@
     },
     "node_modules/esotope-hammerhead": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.4.tgz",
-      "integrity": "sha512-QY4HXqvjLSFGoGgHvm3H1QUMNcpwnUpGRBaVVFWE5uqbPQh9HSWcA1YD7KwwL/IrgerDwZn00z5dtYT9Ot/C/A==",
+      "resolved": "git+ssh://git@github.com/brandwatch/esotope-hammerhead.git#ed2737c4900546cde9f5ab2b114ee9b6ea9bf25d",
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "0.0.46"
       }
@@ -16863,9 +16863,8 @@
       "dev": true
     },
     "esotope-hammerhead": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.4.tgz",
-      "integrity": "sha512-QY4HXqvjLSFGoGgHvm3H1QUMNcpwnUpGRBaVVFWE5uqbPQh9HSWcA1YD7KwwL/IrgerDwZn00z5dtYT9Ot/C/A==",
+      "version": "git+ssh://git@github.com/brandwatch/esotope-hammerhead.git#ed2737c4900546cde9f5ab2b114ee9b6ea9bf25d",
+      "from": "esotope-hammerhead@https://github.com/brandwatch/esotope-hammerhead.git#feat-static-block",
       "requires": {
         "@types/estree": "0.0.46"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "bowser": "1.6.0",
         "crypto-md5": "^1.0.0",
         "debug": "4.3.1",
-        "esotope-hammerhead": "https://github.com/brandwatch/esotope-hammerhead.git#feat-static-block",
+        "esotope-hammerhead": "0.6.5",
         "http-cache-semantics": "^4.1.0",
         "httpntlm": "^1.8.10",
         "iconv-lite": "0.5.1",
@@ -4073,9 +4073,9 @@
       }
     },
     "node_modules/esotope-hammerhead": {
-      "version": "0.6.4",
-      "resolved": "git+ssh://git@github.com/brandwatch/esotope-hammerhead.git#ed2737c4900546cde9f5ab2b114ee9b6ea9bf25d",
-      "license": "MIT",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.5.tgz",
+      "integrity": "sha512-vjncN4nG+RvsUNFC0idHNw1Xzse8GUWn15tr8In0Q4EBscnELTdpQVfsF/cRsMlvSbJdd0gUrW6gK5U+LTmVCg==",
       "dependencies": {
         "@types/estree": "0.0.46"
       }
@@ -16863,8 +16863,9 @@
       "dev": true
     },
     "esotope-hammerhead": {
-      "version": "git+ssh://git@github.com/brandwatch/esotope-hammerhead.git#ed2737c4900546cde9f5ab2b114ee9b6ea9bf25d",
-      "from": "esotope-hammerhead@https://github.com/brandwatch/esotope-hammerhead.git#feat-static-block",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.5.tgz",
+      "integrity": "sha512-vjncN4nG+RvsUNFC0idHNw1Xzse8GUWn15tr8In0Q4EBscnELTdpQVfsF/cRsMlvSbJdd0gUrW6gK5U+LTmVCg==",
       "requires": {
         "@types/estree": "0.0.46"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bowser": "1.6.0",
     "crypto-md5": "^1.0.0",
     "debug": "4.3.1",
-    "esotope-hammerhead": "0.6.4",
+    "esotope-hammerhead": "https://github.com/brandwatch/esotope-hammerhead.git#feat-static-block",
     "http-cache-semantics": "^4.1.0",
     "httpntlm": "^1.8.10",
     "iconv-lite": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bowser": "1.6.0",
     "crypto-md5": "^1.0.0",
     "debug": "4.3.1",
-    "esotope-hammerhead": "https://github.com/brandwatch/esotope-hammerhead.git#feat-static-block",
+    "esotope-hammerhead": "0.6.5",
     "http-cache-semantics": "^4.1.0",
     "httpntlm": "^1.8.10",
     "iconv-lite": "0.5.1",

--- a/test/client/fixtures/sandbox/code-instrumentation/process-script-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/process-script-test.js
@@ -235,6 +235,14 @@ if (!browserUtils.isIOS) {
     });
 }
 
+test('static blocks', function () {
+    var script = `const {T:xc}={},Nc=class s{static{this.field="test"};}; window.output = Nc.field`;
+
+    eval(processScript(script));
+
+    strictEqual(window.output, 'test');
+});
+
 module('others');
 
 test('optional chaining', function () {

--- a/test/client/fixtures/sandbox/code-instrumentation/process-script-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/process-script-test.js
@@ -235,13 +235,15 @@ if (!browserUtils.isIOS) {
     });
 }
 
-test('static blocks', function () {
-    var script = `const {T:xc}={},Nc=class s{static{this.field="test"};}; window.output = Nc.field`;
+if (!browserUtils.isSafari || browserUtils.version >= 16.4) {
+    test('static blocks', function () {
+        var script = `const {T:xc}={},Nc=class s{static{this.field="test"};}; window.output = Nc.field`;
 
-    eval(processScript(script));
+        eval(processScript(script));
 
-    strictEqual(window.output, 'test');
-});
+        strictEqual(window.output, 'test');
+    });
+}
 
 module('others');
 


### PR DESCRIPTION
Currently fails, passes with this patch: https://github.com/DevExpress/esotope-hammerhead/pull/24.