### PR TITLE
fix: support non-canonicalised srcset attribute name #2958

### DIFF
--- a/src/client/sandbox/node/element.ts
+++ b/src/client/sandbox/node/element.ts
@@ -152,7 +152,7 @@ export default class ElementSandbox extends SandboxBase {
         const tagName     = domUtils.getTagName(el);
         const isUrlAttr   = domProcessor.isUrlAttr(el, attr, ns);
         const isEventAttr = domProcessor.EVENTS.indexOf(attr) !== -1;
-        const isUrlsSet   = attr === 'srcset';
+        const isUrlsSet   = loweredAttr === 'srcset';
 
         let needToCallTargetChanged = false;
         let needToRecalcHref        = false;

--- a/test/client/fixtures/sandbox/node/methods-test.js
+++ b/test/client/fixtures/sandbox/node/methods-test.js
@@ -243,6 +243,16 @@ test('setAttribute: img src', function () {
     strictEqual(nativeMethods.getAttribute.call(img, 'src'), urlUtils.resolveUrlAsDest('/image.gif?param=value'));
 });
 
+test('setAttribute: img srcSet', function () {
+    var img = nativeMethods.createElement.call(document, 'img');
+
+    processDomMeth(img);
+
+    img.setAttribute('srcSet', '/image.gif?param=value 1x, /imagex2.gif?param=value 2x');
+
+    strictEqual(nativeMethods.getAttribute.call(img, 'srcset'), urlUtils.resolveUrlAsDest('/image.gif?param=value 1x, /imagex2.gif?param=value 2x', true));
+});
+
 test('canvasRenderingContext2D.drawImage', function () {
     var storedNativeMethod  = nativeMethods.canvasContextDrawImage;
     var crossDomainUrl      = 'http://crossdomain.com/image.png';


### PR DESCRIPTION
Some frameworks, like React, use non-canonicalised attribute names. The spec and browsers allow this, but hammerhead is only checking if the attribute name without canonicalisation matches `srcset`.

By using the `loweredAttr` for the comparison, hammerhead will be more accepting of inputs and resolve srcset issues with React projects (fixes #2958).

See https://github.com/facebook/react/issues/10863 for more background.


## Purpose

Fixes #2958 to better support `srcSet` attributes in React applications.

## Approach

Canonicalises the attribute name before comparing to `srcset`.

## References
Related react issue (and there are various duplicates of this) - https://github.com/facebook/react/issues/10863

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail (unable to get the tests to run)
