### PR TITLE
fix `test-server` test:  incorrect `socket hang up` processing error in Node v21

### DIFF
--- a/src/request-pipeline/destination-request/index.ts
+++ b/src/request-pipeline/destination-request/index.ts
@@ -235,7 +235,13 @@ export default class DestinationRequest extends EventEmitter implements Destinat
         return err.message && SOCKET_HANG_UP_ERR_RE.test(err.message) &&
         // NOTE: At this moment, we determinate the socket hand up error by internal stack trace.
         // TODO: After what we will change minimal node.js version up to 8 need to rethink this code.
-        err.stack && (err.stack.includes('createHangUpError') || err.stack.includes('connResetException'));
+        err.stack && this._isSocketHangUpErrHasNeededStack(err.stack);
+    }
+
+    _isSocketHangUpErrHasNeededStack (errStack): boolean {
+        const stacks = ['createHangUpError', 'connResetException', 'socketCloseListener', 'socketOnEnd'];
+
+        return stacks.some( stack => errStack.includes(stack));
     }
 
     _onTimeout (): void {

--- a/src/request-pipeline/destination-request/index.ts
+++ b/src/request-pipeline/destination-request/index.ts
@@ -236,7 +236,7 @@ export default class DestinationRequest extends EventEmitter implements Destinat
         // NOTE: At this moment, we determinate the socket hand up error by internal stack trace.
         // TODO: After what we will change minimal node.js version up to 8 need to rethink this code.
         // NOTE: In Node.js v21.2, the error trace preparation process was modified,
-        // and the way to invoke the "socket hang out" error was changed
+        // and the way to invoke the "socket hang up" error was changed
         // from the `connResetException` function call to a constructor (https://github.com/nodejs/node/commit/14e3675b13#diff-cf533721360d04a028e31659e9b6cde7e4bd871200d13ce37d4a358be65bfd43).
         // As a result, the connResetException no longer appears in the stack.
         err.stack && this._isSocketHangUpErrHasNeededStack(err.stack);

--- a/src/request-pipeline/destination-request/index.ts
+++ b/src/request-pipeline/destination-request/index.ts
@@ -235,6 +235,10 @@ export default class DestinationRequest extends EventEmitter implements Destinat
         return err.message && SOCKET_HANG_UP_ERR_RE.test(err.message) &&
         // NOTE: At this moment, we determinate the socket hand up error by internal stack trace.
         // TODO: After what we will change minimal node.js version up to 8 need to rethink this code.
+        // NOTE: In Node.js v21.2, the error trace preparation process was modified,
+        // and the way to invoke the "socket hang out" error was changed
+        // from the `connResetException` function call to a constructor (https://github.com/nodejs/node/commit/14e3675b13#diff-cf533721360d04a028e31659e9b6cde7e4bd871200d13ce37d4a358be65bfd43).
+        // As a result, the connResetException no longer appears in the stack.
         err.stack && this._isSocketHangUpErrHasNeededStack(err.stack);
     }
 


### PR DESCRIPTION
In Node.js version 21.2.0, hideStackFrames has been improved: [ commit - errors: improve hideStackFrames
](https://github.com/nodejs/node/commit/14e3675b13) and [Pull request - errors: improve hideStackFrames](https://github.com/nodejs/node/pull/49990).  As a result, the error stack that appears when the socket hangs has changed.

Update method `_isSocketHangUpErr` and method `_isSocketHangUpErrHasNeededStack`  of class `DesinationRequest`.
