### PR TITLE
fix: processing script with private identifier (closes DevExpress/testcafe#8067)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "bowser": "1.6.0",
         "crypto-md5": "^1.0.0",
         "debug": "4.3.1",
-        "esotope-hammerhead": "https://github.com/PavelMor25/builds/raw/master/esotope-hammerhead-0.6.7.tgz",
+        "esotope-hammerhead": "0.6.7",
         "http-cache-semantics": "^4.1.0",
         "httpntlm": "^1.8.10",
         "iconv-lite": "0.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "bowser": "1.6.0",
         "crypto-md5": "^1.0.0",
         "debug": "4.3.1",
-        "esotope-hammerhead": "0.6.6",
+        "esotope-hammerhead": "https://github.com/PavelMor25/builds/raw/master/esotope-hammerhead-0.6.7.tgz",
         "http-cache-semantics": "^4.1.0",
         "httpntlm": "^1.8.10",
         "iconv-lite": "0.5.1",
@@ -3788,9 +3788,10 @@
       }
     },
     "node_modules/esotope-hammerhead": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.6.tgz",
-      "integrity": "sha512-pHTz6hKpCotF/VDMK6UlMo6A1Y8nQsYKuZPtNKWJSKWgvJvB35m91wqeSVz4TlkxTHyIfoeIwMiffdv7Z0JCRA==",
+      "version": "0.6.7",
+      "resolved": "https://github.com/PavelMor25/builds/raw/master/esotope-hammerhead-0.6.7.tgz",
+      "integrity": "sha512-argSa+sEtInDLFYPT4Tymawu0LHvmaUFShcjk54sxTkg6UBL0ux14lm4uommjXJkGk74E82ixQqE5p64gd25Yw==",
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "0.0.46"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bowser": "1.6.0",
     "crypto-md5": "^1.0.0",
     "debug": "4.3.1",
-    "esotope-hammerhead": "0.6.6",
+    "esotope-hammerhead": "https://github.com/PavelMor25/builds/raw/master/esotope-hammerhead-0.6.7.tgz",
     "http-cache-semantics": "^4.1.0",
     "httpntlm": "^1.8.10",
     "iconv-lite": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bowser": "1.6.0",
     "crypto-md5": "^1.0.0",
     "debug": "4.3.1",
-    "esotope-hammerhead": "https://github.com/PavelMor25/builds/raw/master/esotope-hammerhead-0.6.7.tgz",
+    "esotope-hammerhead": "0.6.7",
     "http-cache-semantics": "^4.1.0",
     "httpntlm": "^1.8.10",
     "iconv-lite": "0.5.1",

--- a/src/processing/script/transformers/property-get.ts
+++ b/src/processing/script/transformers/property-get.ts
@@ -32,6 +32,10 @@ const transformer: Transformer<MemberExpression> = {
         if (node.property.type === Syntax.Identifier && !shouldInstrumentProperty(node.property.name))
             return false;
 
+        // Skip: object.#prop
+        if (node.property.type === Syntax.PrivateIdentifier)
+            return false;
+
         // Skip: super.prop
         if (node.object.type === Syntax.Super)
             return false;

--- a/src/processing/script/transformers/property-get.ts
+++ b/src/processing/script/transformers/property-get.ts
@@ -33,6 +33,7 @@ const transformer: Transformer<MemberExpression> = {
             return false;
 
         // Skip: object.#prop
+        // @ts-ignore
         if (node.property.type === Syntax.PrivateIdentifier)
             return false;
 

--- a/test/client/fixtures/sandbox/code-instrumentation/process-script-test.js
+++ b/test/client/fixtures/sandbox/code-instrumentation/process-script-test.js
@@ -235,7 +235,7 @@ if (!browserUtils.isIOS) {
     });
 
     test('private identifier and property definition without value', function () {
-        var script = `const Nc = new class {#a; constructor(){this.#a = 4;}; output(){return this.#a;};}; window.prop = Nc.output()`;
+        var script = `class s{#a; constructor(){this.#a = 4;}; output(){return this.#a;};}; window.prop = new s().output()`;
 
         eval(processScript(script));
 


### PR DESCRIPTION
Added new condition to `property-get transformer` which excludes from transform the expression "object.#prop" into "__get$(object, '#prop')"

`ts-ignore` was added because updating `@types/estree` is required; the last update was three years ago. Updating now would require time for refactoring.

[esotope-hammerhead PR](https://github.com/DevExpress/esotope-hammerhead/pull/28)