### PR TITLE
fix: Handling of native dialogs inconsistent with handling in Firefox (closes #6815)

### DIFF
--- a/src/client/sandbox/event/unload.ts
+++ b/src/client/sandbox/event/unload.ts
@@ -1,7 +1,7 @@
 import SandboxBase from '../base';
 import nativeMethods from '../native-methods';
 import createPropertyDesc from '../../utils/create-property-desc.js';
-import { isFirefox, isIOS } from '../../utils/browser';
+import { isIOS } from '../../utils/browser';
 import { overrideDescriptor } from '../../utils/overriding';
 import Listeners from './listeners';
 import { isFunction } from '../../utils/types';
@@ -83,11 +83,9 @@ export default class UnloadSandbox extends SandboxBase {
             nativeMethods.objectDefineProperty(e, 'returnValue', createPropertyDesc({
                 get: () => eventProperties.storedReturnValue,
                 set: value => {
-                    // NOTE: In all browsers, if the property is set to any value, unload is prevented. In FireFox,
-                    // only if a value is set to an empty string, the unload operation is prevented.
                     eventProperties.storedReturnValue = UnloadSandbox._prepareStoredReturnValue(value);
 
-                    eventProperties.prevented = isFirefox ? value !== '' : true;
+                    eventProperties.prevented = true;
                 },
             }));
 

--- a/src/client/sandbox/event/unload.ts
+++ b/src/client/sandbox/event/unload.ts
@@ -86,8 +86,7 @@ export default class UnloadSandbox extends SandboxBase {
                     // NOTE: In all browsers, if the property is set to any value except empty string, unload is prevented.
                     eventProperties.storedReturnValue = UnloadSandbox._prepareStoredReturnValue(value);
 
-                    if (!eventProperties.prevented)
-                        eventProperties.prevented = value !== '';
+                    eventProperties.prevented = eventProperties.prevented || value !== '';
                 },
             }));
 

--- a/src/client/sandbox/event/unload.ts
+++ b/src/client/sandbox/event/unload.ts
@@ -83,9 +83,11 @@ export default class UnloadSandbox extends SandboxBase {
             nativeMethods.objectDefineProperty(e, 'returnValue', createPropertyDesc({
                 get: () => eventProperties.storedReturnValue,
                 set: value => {
+                    // NOTE: In all browsers, if the property is set to any value except empty string, unload is prevented.
                     eventProperties.storedReturnValue = UnloadSandbox._prepareStoredReturnValue(value);
 
-                    eventProperties.prevented = true;
+                    if (!eventProperties.prevented)
+                        eventProperties.prevented = value !== '';
                 },
             }));
 

--- a/test/client/data/unload/iframe-beforeunload.html
+++ b/test/client/data/unload/iframe-beforeunload.html
@@ -1,35 +1,33 @@
 <!DOCTYPE HTML>
 <html>
-<head>
-    <meta charset="utf-8">
-    <script src="/hammerhead.js" class="script-hammerhead-shadow-ui"></script>
-</head>
-<body>
-<script type="text/javascript">
-    var hammerhead = window['%hammerhead%'];
-    var hhPostMessage = hammerhead.sandbox.event.message.postMessage;
+    <head>
+        <meta charset="utf-8">
+        <script src="/hammerhead.js" class="script-hammerhead-shadow-ui"></script>
+    </head>
+    <body>
+        <script type="text/javascript">
+            var hammerhead = window['%hammerhead%'];
+            var hhPostMessage = hammerhead.sandbox.event.message.postMessage;
 
-    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
-    hammerhead.start({ crossDomainProxyPort: 2000 });
+            hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
+            hammerhead.start({ crossDomainProxyPort: 2000 });
 
-    hammerhead.on(hammerhead.EVENTS.beforeUnload, e => {
-            hhPostMessage(window.parent, [e.prevented, '*']);
-        });
-</script>
-<script>
-    window.addEventListener('message', function (m) {
-        const { returnValue, needPrevented } = m.data;
+            hammerhead.on(hammerhead.EVENTS.beforeUnload, e => {
+                    hhPostMessage(window.parent, [e.prevented, '*']);
+                });
+                
+            window.addEventListener('message', function (m) {
+                const { returnValue, needPrevent } = m.data;
 
-        window.addEventListener('beforeunload', function (e) {
+                window.addEventListener('beforeunload', function (e) {
+                    if (needPrevent)
+                        e.preventDefault();
 
-            if (needPrevented)
-                e.preventDefault();
+                    e.returnValue = returnValue;
+                });
 
-            e.returnValue = returnValue;
-        });
-
-        location.reload();
-    });
-</script>
-</body>
+                location.reload();
+            });
+        </script>
+    </body>
 </html>

--- a/test/client/data/unload/iframe-beforeunload.html
+++ b/test/client/data/unload/iframe-beforeunload.html
@@ -6,7 +6,7 @@
     </head>
     <body>
         <script type="text/javascript">
-            var hammerhead = window['%hammerhead%'];
+            var hammerhead    = window['%hammerhead%'];
             var hhPostMessage = hammerhead.sandbox.event.message.postMessage;
 
             hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');

--- a/test/client/data/unload/iframe-beforeunload.html
+++ b/test/client/data/unload/iframe-beforeunload.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="/hammerhead.js" class="script-hammerhead-shadow-ui"></script>
+</head>
+<body>
+<button id="reload">reload</button>
+<script type="text/javascript">
+    var hammerhead = window['%hammerhead%'];
+    var hhPostMessage = hammerhead.sandbox.event.message.postMessage;
+
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.start({ crossDomainProxyPort: 2000 });
+
+    hammerhead.on(hammerhead.EVENTS.beforeUnload, e => {
+            if (e.prevented) {
+                hhPostMessage(window.parent, [true, '*'])
+            } else {
+                hhPostMessage(window.parent, [false, '*'])
+            }
+        });
+
+    var reload = document.querySelector('#reload');
+</script>
+<script>
+    window.addEventListener('message', function (m) {
+        const {state, returnValue} = m.data;
+
+        if (state !== 'reload')
+            return;
+
+        window.addEventListener('beforeunload', function (e) {
+            e.preventDefault();
+            e.returnValue = returnValue;
+        });
+
+        location.reload();
+    });
+</script>
+</body>
+</html>

--- a/test/client/data/unload/iframe-beforeunload.html
+++ b/test/client/data/unload/iframe-beforeunload.html
@@ -5,7 +5,6 @@
     <script src="/hammerhead.js" class="script-hammerhead-shadow-ui"></script>
 </head>
 <body>
-<button id="reload">reload</button>
 <script type="text/javascript">
     var hammerhead = window['%hammerhead%'];
     var hhPostMessage = hammerhead.sandbox.event.message.postMessage;
@@ -14,25 +13,16 @@
     hammerhead.start({ crossDomainProxyPort: 2000 });
 
     hammerhead.on(hammerhead.EVENTS.beforeUnload, e => {
-            if (e.prevented) {
-                hhPostMessage(window.parent, [true, '*'])
-            } else {
-                hhPostMessage(window.parent, [false, '*'])
-            }
+            hhPostMessage(window.parent, [e.prevented, '*']);
         });
-
-    var reload = document.querySelector('#reload');
 </script>
 <script>
     window.addEventListener('message', function (m) {
-        const { reload, returnValue, prevented } = m.data;
-
-        if (!reload)
-            return;
+        const { returnValue, needPrevented } = m.data;
 
         window.addEventListener('beforeunload', function (e) {
 
-            if (prevented)
+            if (needPrevented)
                 e.preventDefault();
 
             e.returnValue = returnValue;

--- a/test/client/data/unload/iframe-beforeunload.html
+++ b/test/client/data/unload/iframe-beforeunload.html
@@ -25,13 +25,16 @@
 </script>
 <script>
     window.addEventListener('message', function (m) {
-        const {state, returnValue} = m.data;
+        const { reload, returnValue, prevented } = m.data;
 
-        if (state !== 'reload')
+        if (!reload)
             return;
 
         window.addEventListener('beforeunload', function (e) {
-            e.preventDefault();
+
+            if (prevented)
+                e.preventDefault();
+
             e.returnValue = returnValue;
         });
 

--- a/test/client/fixtures/sandbox/event/unload-test.js
+++ b/test/client/fixtures/sandbox/event/unload-test.js
@@ -108,4 +108,19 @@ if (!browserUtils.isSafari) {
                 ok(returnValue);
             });
     });
+
+    test('onbeforeunload handler must be called with and prevented native dialog with returnValue and e.preventDefault (GH-6815)', function () {
+        return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
+            .then(function (iframe) {
+                postMessage(iframe.contentWindow, [{
+                    state:       'reload',
+                    returnValue: 'message',
+                }, '*']);
+
+                return waitForMessage(window);
+            })
+            .then(function (returnValue) {
+                ok(returnValue);
+            });
+    });
 }

--- a/test/client/fixtures/sandbox/event/unload-test.js
+++ b/test/client/fixtures/sandbox/event/unload-test.js
@@ -97,40 +97,39 @@ if (!browserUtils.isSafari) {
     const testCasesOnbeforeunloadNativeDialog = [
         {
             returnValue:   '',
-            prevented:     true,
+            needPrevented: true,
             expectPrevent: true,
-            title:         ' and prevented native dialog with empty returnValue and e.preventDefault',
+            title:         'and prevented native dialog with empty returnValue and e.preventDefault',
         },
         {
             returnValue:   '',
-            prevented:     false,
+            needPrevented: false,
             expectPrevent: false,
-            title:         ' without prevented native dialog',
+            title:         'without prevented native dialog',
         },
         {
             returnValue:   'message',
-            prevented:     true,
+            needPrevented: true,
             expectPrevent: true,
-            title:         ' and prevented native dialog with returnValue and e.preventDefault',
+            title:         'and prevented native dialog with returnValue and e.preventDefault',
         },
         {
             returnValue:   'message',
-            prevented:     false,
+            needPrevented: false,
             expectPrevent: true,
-            title:         ' and prevented native dialog with returnValue',
+            title:         'and prevented native dialog with returnValue',
         },
     ];
 
     testCasesOnbeforeunloadNativeDialog.forEach(testCase => {
-        const { returnValue, prevented, expectPrevent, title } = testCase;
+        const { returnValue, needPrevented, expectPrevent, title } = testCase;
 
-        test(`onbeforeunload handler must be called${title} (GH-6815)`, function () {
+        test(`onbeforeunload handler must be called ${title} (GH-6815)`, function () {
             return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
                 .then(function (iframe) {
                     postMessage(iframe.contentWindow, [{
-                        reload: true,
                         returnValue,
-                        prevented,
+                        needPrevented,
                     }, '*']);
 
                     return waitForMessage(window);

--- a/test/client/fixtures/sandbox/event/unload-test.js
+++ b/test/client/fixtures/sandbox/event/unload-test.js
@@ -77,6 +77,36 @@ if (browserUtils.isSafari && !browserUtils.isIOS) {
     });
 }
 
+test('onbeforeunload handler must be called with and prevented native dialog with empty return value(GH-6815)', function () {
+    return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
+        .then(function (iframe) {
+            postMessage(iframe.contentWindow, [{
+                state:       'reload',
+                returnValue: '',
+            }, '*']);
+
+            return waitForMessage(window);
+        })
+        .then(function (returnValue) {
+            ok(returnValue);
+        });
+});
+
+test('onbeforeunload handler must be called with and prevented native dialog with return value(GH-6815)', function () {
+    return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
+        .then(function (iframe) {
+            postMessage(iframe.contentWindow, [{
+                state:       'reload',
+                returnValue: 'message',
+            }, '*']);
+
+            return waitForMessage(window);
+        })
+        .then(function (returnValue) {
+            ok(returnValue);
+        });
+});
+
 if (!browserUtils.isSafari) {
     test('Should save the returnValue as string', function () {
         return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe.html') })

--- a/test/client/fixtures/sandbox/event/unload-test.js
+++ b/test/client/fixtures/sandbox/event/unload-test.js
@@ -77,36 +77,6 @@ if (browserUtils.isSafari && !browserUtils.isIOS) {
     });
 }
 
-test('onbeforeunload handler must be called with and prevented native dialog with empty return value(GH-6815)', function () {
-    return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
-        .then(function (iframe) {
-            postMessage(iframe.contentWindow, [{
-                state:       'reload',
-                returnValue: '',
-            }, '*']);
-
-            return waitForMessage(window);
-        })
-        .then(function (returnValue) {
-            ok(returnValue);
-        });
-});
-
-test('onbeforeunload handler must be called with and prevented native dialog with return value(GH-6815)', function () {
-    return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
-        .then(function (iframe) {
-            postMessage(iframe.contentWindow, [{
-                state:       'reload',
-                returnValue: 'message',
-            }, '*']);
-
-            return waitForMessage(window);
-        })
-        .then(function (returnValue) {
-            ok(returnValue);
-        });
-});
-
 if (!browserUtils.isSafari) {
     test('Should save the returnValue as string', function () {
         return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe.html') })
@@ -121,6 +91,36 @@ if (!browserUtils.isSafari) {
             })
             .then(function (returnValue) {
                 strictEqual(returnValue, '[object BeforeUnloadEvent]');
+            });
+    });
+
+    test('onbeforeunload handler must be called with and prevented native dialog with empty return value(GH-6815)', function () {
+        return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
+            .then(function (iframe) {
+                postMessage(iframe.contentWindow, [{
+                    state:       'reload',
+                    returnValue: '',
+                }, '*']);
+
+                return waitForMessage(window);
+            })
+            .then(function (returnValue) {
+                ok(returnValue);
+            });
+    });
+
+    test('onbeforeunload handler must be called with and prevented native dialog with return value(GH-6815)', function () {
+        return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
+            .then(function (iframe) {
+                postMessage(iframe.contentWindow, [{
+                    state:       'reload',
+                    returnValue: 'message',
+                }, '*']);
+
+                return waitForMessage(window);
+            })
+            .then(function (returnValue) {
+                ok(returnValue);
             });
     });
 }

--- a/test/client/fixtures/sandbox/event/unload-test.js
+++ b/test/client/fixtures/sandbox/event/unload-test.js
@@ -94,33 +94,50 @@ if (!browserUtils.isSafari) {
             });
     });
 
-    test('onbeforeunload handler must be called and prevented native dialog with empty returnValue and e.preventDefault (GH-6815)', function () {
-        return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
-            .then(function (iframe) {
-                postMessage(iframe.contentWindow, [{
-                    state:       'reload',
-                    returnValue: '',
-                }, '*']);
+    const testCasesOnbeforeunloadNativeDialog = [
+        {
+            returnValue:   '',
+            prevented:     true,
+            expectPrevent: true,
+            title:         ' and prevented native dialog with empty returnValue and e.preventDefault',
+        },
+        {
+            returnValue:   '',
+            prevented:     false,
+            expectPrevent: false,
+            title:         ' without prevented native dialog',
+        },
+        {
+            returnValue:   'message',
+            prevented:     true,
+            expectPrevent: true,
+            title:         ' and prevented native dialog with returnValue and e.preventDefault',
+        },
+        {
+            returnValue:   'message',
+            prevented:     false,
+            expectPrevent: true,
+            title:         ' and prevented native dialog with returnValue',
+        },
+    ];
 
-                return waitForMessage(window);
-            })
-            .then(function (returnValue) {
-                ok(returnValue);
-            });
-    });
+    testCasesOnbeforeunloadNativeDialog.forEach(testCase => {
+        const { returnValue, prevented, expectPrevent, title } = testCase;
 
-    test('onbeforeunload handler must be called with and prevented native dialog with returnValue and e.preventDefault (GH-6815)', function () {
-        return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
-            .then(function (iframe) {
-                postMessage(iframe.contentWindow, [{
-                    state:       'reload',
-                    returnValue: 'message',
-                }, '*']);
+        test(`onbeforeunload handler must be called${title} (GH-6815)`, function () {
+            return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
+                .then(function (iframe) {
+                    postMessage(iframe.contentWindow, [{
+                        reload: true,
+                        returnValue,
+                        prevented,
+                    }, '*']);
 
-                return waitForMessage(window);
-            })
-            .then(function (returnValue) {
-                ok(returnValue);
-            });
+                    return waitForMessage(window);
+                })
+                .then(function (isPrevented) {
+                    expectPrevent ? ok(isPrevented) : notOk(isPrevented);
+                });
+        });
     });
 }

--- a/test/client/fixtures/sandbox/event/unload-test.js
+++ b/test/client/fixtures/sandbox/event/unload-test.js
@@ -111,13 +111,13 @@ if (!browserUtils.isSafari) {
             returnValue:   'message',
             needPrevent:   true,
             expectPrevent: true,
-            title:         'the handler must be called to prevent opening native dialog with return Value and e.preventDefault',
+            title:         'to prevent opening native dialog with return Value and e.preventDefault',
         },
         {
             returnValue:   'message',
             needPrevent:   false,
             expectPrevent: true,
-            title:         'the handler must be called to prevent opening native dialog with returnValue',
+            title:         'to prevent opening native dialog with returnValue',
         },
     ];
 

--- a/test/client/fixtures/sandbox/event/unload-test.js
+++ b/test/client/fixtures/sandbox/event/unload-test.js
@@ -97,45 +97,45 @@ if (!browserUtils.isSafari) {
     const testCasesOnbeforeunloadNativeDialog = [
         {
             returnValue:   '',
-            needPrevented: true,
+            needPrevent:   true,
             expectPrevent: true,
-            title:         'and prevented native dialog with empty returnValue and e.preventDefault',
+            title:         'to prevent opening native dialog with empty return Value and e.preventDefault',
         },
         {
             returnValue:   '',
-            needPrevented: false,
+            needPrevent:   false,
             expectPrevent: false,
-            title:         'without prevented native dialog',
+            title:         'without preventing the opening native dialog',
         },
         {
             returnValue:   'message',
-            needPrevented: true,
+            needPrevent:   true,
             expectPrevent: true,
-            title:         'and prevented native dialog with returnValue and e.preventDefault',
+            title:         'the handler must be called to prevent opening native dialog with return Value and e.preventDefault',
         },
         {
             returnValue:   'message',
-            needPrevented: false,
+            needPrevent:   false,
             expectPrevent: true,
-            title:         'and prevented native dialog with returnValue',
+            title:         'the handler must be called to prevent opening native dialog with returnValue',
         },
     ];
 
     testCasesOnbeforeunloadNativeDialog.forEach(testCase => {
-        const { returnValue, needPrevented, expectPrevent, title } = testCase;
+        const { returnValue, needPrevent, expectPrevent, title } = testCase;
 
         test(`onbeforeunload handler must be called ${title} (GH-6815)`, function () {
             return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
                 .then(function (iframe) {
                     postMessage(iframe.contentWindow, [{
                         returnValue,
-                        needPrevented,
+                        needPrevent,
                     }, '*']);
 
                     return waitForMessage(window);
                 })
                 .then(function (isPrevented) {
-                    expectPrevent ? ok(isPrevented) : notOk(isPrevented);
+                    strictEqual(isPrevented, expectPrevent);
                 });
         });
     });

--- a/test/client/fixtures/sandbox/event/unload-test.js
+++ b/test/client/fixtures/sandbox/event/unload-test.js
@@ -94,27 +94,12 @@ if (!browserUtils.isSafari) {
             });
     });
 
-    test('onbeforeunload handler must be called with and prevented native dialog with empty return value(GH-6815)', function () {
+    test('onbeforeunload handler must be called and prevented native dialog with empty returnValue and e.preventDefault (GH-6815)', function () {
         return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
             .then(function (iframe) {
                 postMessage(iframe.contentWindow, [{
                     state:       'reload',
                     returnValue: '',
-                }, '*']);
-
-                return waitForMessage(window);
-            })
-            .then(function (returnValue) {
-                ok(returnValue);
-            });
-    });
-
-    test('onbeforeunload handler must be called with and prevented native dialog with return value(GH-6815)', function () {
-        return createTestIframe({ src: getCrossDomainPageUrl('../../../data/unload/iframe-beforeunload.html') })
-            .then(function (iframe) {
-                postMessage(iframe.contentWindow, [{
-                    state:       'reload',
-                    returnValue: 'message',
                 }, '*']);
 
                 return waitForMessage(window);


### PR DESCRIPTION

When adding the `onbeforeunload` event to a page, inside of which there is `e.preventDefault()` and `e.returnResult` with an empty string, Hammerhead overrides the prevented property, causing the native dialog not to be recorded in the TestCafe session storage.