### PR TITLE
fix: getClientRectangle method fixed

### DIFF
--- a/src/client/utils/dom.ts
+++ b/src/client/utils/dom.ts
@@ -900,5 +900,11 @@ export function getAssociatedElement (el: HTMLElement): HTMLElement | null {
 }
 
 export function getClientRectangle (el: HTMLElement): DOMRect {
-    return el.getClientRects()[0] ?? el.getBoundingClientRect();
+    const rects = el.getClientRects();
+
+    for (let i = 0; i < rects.length; i++) {
+        if (rects[i].height > 0 && rects[i].width > 0)
+            return rects[i];
+    }
+    return el.getBoundingClientRect();
 }


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Sometime the first rectangle might have zero width/height which results in error.

## Approach
Filter through all rectangles from getClientRects.

## References
Testcafe PR: https://github.com/DevExpress/testcafe/pull/8261

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
