### PR TITLE
fix(processing/script/transformers/location): handle class property definitions

### DIFF
--- a/src/processing/script/transformers/location-get.ts
+++ b/src/processing/script/transformers/location-get.ts
@@ -68,6 +68,11 @@ const transformer: Transformer<Identifier> = {
         if (parent.type === Syntax.MethodDefinition)
             return false;
 
+        // Skip: class X { location }
+        // @ts-ignore
+        if (parent.type === Syntax.PropertyDefinition)
+            return false;
+
         // Skip: class location { x () {} }
         if (parent.type === Syntax.ClassDeclaration)
             return false;

--- a/test/server/script-processor-test.js
+++ b/test/server/script-processor-test.js
@@ -289,6 +289,11 @@ describe('Script processor', () => {
                           ': function(){var _hh$temp1 = "#123"; return __set$Loc(location,_hh$temp1)||(location=_hh$temp1);}.call(this);',
             },
             {
+                src: 'class C { location }',
+
+                expected: 'class C { location }',
+            },
+            {
                 src: 'if (location) { location = newLocation; } else location = "#123";',
 
                 expected: 'if (__get$Loc(location)) {' +


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
The transformers generates wrong (and invalid) JavaScript if a class contains a property named `locations`.

The generated code for `class C { location }` currently is `class C { __get$Loc(location) }`.

## Approach
Extend the transformer to handle class property definitions in the same way other processing exceptions are handled.

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
