### PR TITLE
Fix matchUrl

### DIFF
--- a/src/request-pipeline/request-hooks/request-is-match-rule.ts
+++ b/src/request-pipeline/request-hooks/request-is-match-rule.ts
@@ -14,6 +14,7 @@ function matchUrl (optionValue: any, checkedValue: any): boolean {
 
     if (typeof optionValue === 'string') {
         optionValue = ensureOriginTrailingSlash(optionValue);
+        checkedValue = ensureOriginTrailingSlash(checkedValue);
 
         return optionValue === checkedValue;
     }


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Fix issue with RequestHook match when running with `--disable-native-automation`

## Approach
Calling the method on both values will ensure that their format is the same, which will be more reliable.

## References
#3048 

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
