### PR TITLE
fix: support postMessage options overload and handle transferable clone failures in Firefox

### DIFF
--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -107,14 +107,22 @@ export default class MessageSandbox extends SandboxBase {
     private _onWindowMessage (e: MessageEvent, originListener): void {
         const data = MessageSandbox._getMessageData(e);
 
-        if (data.type !== MessageType.Service) {
+        if (data.type === MessageType.Service)
+            return null;
+
+        if (data.type === MessageType.User) {
             const originUrl = destLocation.get();
 
             if (data.targetUrl === '*' || destLocation.sameOriginCheck(originUrl, data.targetUrl))
                 return callEventListener(this.window, originListener, e);
+
+            return null;
         }
 
-        return null;
+        // NOTE: unwrapped messages arrive when the Hammerhead envelope could not be structured-cloned
+        // (e.g. Firefox with MessagePort transfers). The browser already validated the target origin
+        // before delivering the MessageEvent, so it is safe to pass through to the listener.
+        return callEventListener(this.window, originListener, e);
     }
 
     private static _wrapMessage (type: MessageType, message, targetUrl?: string) {
@@ -189,7 +197,10 @@ export default class MessageSandbox extends SandboxBase {
                 const target = nativeMethods.eventTargetGetter.call(this);
                 const data   = nativeMethods.messageEventDataGetter.call(this);
 
-                if (data && data.type !== MessageType.Service && isWindow(target))
+                // NOTE: only unwrap messages that carry the Hammerhead user-message envelope.
+                // Raw (unwrapped) messages — which may arrive when the envelope could not be
+                // structured-cloned alongside transferable objects — are returned as-is.
+                if (data && data.type === MessageType.User && isWindow(target))
                     return MessageSandbox._getOriginMessageData(data);
 
                 return data;
@@ -215,21 +226,59 @@ export default class MessageSandbox extends SandboxBase {
     postMessage (contentWindow: Window, args) {
         const targetUrl = args[1] || destLocation.getOriginHeader();
 
-        // NOTE: We do NOT support the postMessage(message, options) overload.
-        // The second argument is expected to be `targetOrigin` (string).
-        // If an options object is provided instead, the call is considered invalid and will be aborted.
+        // NOTE: postMessage has two overloads:
+        //   1. postMessage(message, targetOrigin, transfer?) — legacy
+        //   2. postMessage(message, { targetOrigin, transfer? }) — modern options overload
         if (typeof targetUrl !== 'string') {
-            nativeMethods.consoleMeths.log(`testcafe-hammerhead: postMessage called with invalid targetOrigin; aborting call (type: ${typeof targetUrl})`);
+            if (targetUrl && typeof targetUrl === 'object')
+                return this._postMessageWithOptionsOverload(contentWindow, args, targetUrl);
+
             return null;
         }
 
-        // NOTE: Here, we pass all messages as "no preference" ("*").
-        // We do an origin check in "_onWindowMessage" to access the target origin.
+        return this._postMessageWrapped(contentWindow, args, targetUrl);
+    }
+
+    private _postMessageWithOptionsOverload (contentWindow: Window, args, options) {
+        const resolvedTargetUrl = typeof options.targetOrigin === 'string'
+            ? options.targetOrigin
+            : destLocation.getOriginHeader();
+
+        const originalMessage = args[0];
+
+        args[0] = MessageSandbox._wrapMessage(MessageType.User, originalMessage, resolvedTargetUrl);
+        args[1] = nativeMethods.objectAssign({}, options, { targetOrigin: '*' });
+
+        try {
+            return fastApply(contentWindow, 'postMessage', args);
+        }
+        catch (err) {
+            args[0] = originalMessage;
+            args[1] = nativeMethods.objectAssign({}, options, { targetOrigin: '*' });
+
+            return fastApply(contentWindow, 'postMessage', args);
+        }
+    }
+
+    private _postMessageWrapped (contentWindow: Window, args, targetUrl: string) {
+        const originalMessage = args[0];
+
         args[1] = '*';
-        args[0] = MessageSandbox._wrapMessage(MessageType.User, args[0], targetUrl);
+        args[0] = MessageSandbox._wrapMessage(MessageType.User, originalMessage, targetUrl);
 
+        try {
+            return fastApply(contentWindow, 'postMessage', args);
+        }
+        catch (err) {
+            // NOTE: structured clone may fail when transferable objects (e.g. MessagePort) are
+            // present in the transfer list. This is observed in Firefox where the Hammerhead
+            // message envelope breaks the clone+transfer semantics. Fall back to sending the
+            // original message without wrapping — the receiving side handles unwrapped messages.
+            args[0] = originalMessage;
+            args[1] = '*';
 
-        return fastApply(contentWindow, 'postMessage', args);
+            return fastApply(contentWindow, 'postMessage', args);
+        }
     }
 
     sendServiceMsg (msg, targetWindow: Window, ports?: Transferable[]) {

--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -219,6 +219,7 @@ export default class MessageSandbox extends SandboxBase {
             if (targetUrl && typeof targetUrl === 'object')
                 return this._postMessageWithOptionsOverload(contentWindow, args, targetUrl);
 
+            nativeMethods.consoleMeths.log(`testcafe-hammerhead: postMessage called with invalid targetOrigin; aborting call (type: ${typeof targetUrl})`);
             return null;
         }
 
@@ -239,6 +240,8 @@ export default class MessageSandbox extends SandboxBase {
     }
 
     private _postMessageWrapped (contentWindow: Window, args, targetUrl: string) {
+        // NOTE: Here, we pass all messages as "no preference" ("*").
+        // We do an origin check in "_onWindowMessage" to access the target origin.
         args[1] = '*';
         args[0] = MessageSandbox._wrapMessage(MessageType.User, args[0], targetUrl);
 

--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -107,22 +107,14 @@ export default class MessageSandbox extends SandboxBase {
     private _onWindowMessage (e: MessageEvent, originListener): void {
         const data = MessageSandbox._getMessageData(e);
 
-        if (data.type === MessageType.Service)
-            return null;
-
-        if (data.type === MessageType.User) {
+        if (data.type !== MessageType.Service) {
             const originUrl = destLocation.get();
 
             if (data.targetUrl === '*' || destLocation.sameOriginCheck(originUrl, data.targetUrl))
                 return callEventListener(this.window, originListener, e);
-
-            return null;
         }
 
-        // NOTE: unwrapped messages arrive when the Hammerhead envelope could not be structured-cloned
-        // (e.g. Firefox with MessagePort transfers). The browser already validated the target origin
-        // before delivering the MessageEvent, so it is safe to pass through to the listener.
-        return callEventListener(this.window, originListener, e);
+        return null;
     }
 
     private static _wrapMessage (type: MessageType, message, targetUrl?: string) {
@@ -197,10 +189,7 @@ export default class MessageSandbox extends SandboxBase {
                 const target = nativeMethods.eventTargetGetter.call(this);
                 const data   = nativeMethods.messageEventDataGetter.call(this);
 
-                // NOTE: only unwrap messages that carry the Hammerhead user-message envelope.
-                // Raw (unwrapped) messages — which may arrive when the envelope could not be
-                // structured-cloned alongside transferable objects — are returned as-is.
-                if (data && data.type === MessageType.User && isWindow(target))
+                if (data && data.type !== MessageType.Service && isWindow(target))
                     return MessageSandbox._getOriginMessageData(data);
 
                 return data;
@@ -226,9 +215,6 @@ export default class MessageSandbox extends SandboxBase {
     postMessage (contentWindow: Window, args) {
         const targetUrl = args[1] || destLocation.getOriginHeader();
 
-        // NOTE: postMessage has two overloads:
-        //   1. postMessage(message, targetOrigin, transfer?) — legacy
-        //   2. postMessage(message, { targetOrigin, transfer? }) — modern options overload
         if (typeof targetUrl !== 'string') {
             if (targetUrl && typeof targetUrl === 'object')
                 return this._postMessageWithOptionsOverload(contentWindow, args, targetUrl);
@@ -249,36 +235,14 @@ export default class MessageSandbox extends SandboxBase {
         args[0] = MessageSandbox._wrapMessage(MessageType.User, originalMessage, resolvedTargetUrl);
         args[1] = nativeMethods.objectAssign({}, options, { targetOrigin: '*' });
 
-        try {
-            return fastApply(contentWindow, 'postMessage', args);
-        }
-        catch (err) {
-            args[0] = originalMessage;
-            args[1] = nativeMethods.objectAssign({}, options, { targetOrigin: '*' });
-
-            return fastApply(contentWindow, 'postMessage', args);
-        }
+        return fastApply(contentWindow, 'postMessage', args);
     }
 
     private _postMessageWrapped (contentWindow: Window, args, targetUrl: string) {
-        const originalMessage = args[0];
-
         args[1] = '*';
-        args[0] = MessageSandbox._wrapMessage(MessageType.User, originalMessage, targetUrl);
+        args[0] = MessageSandbox._wrapMessage(MessageType.User, args[0], targetUrl);
 
-        try {
-            return fastApply(contentWindow, 'postMessage', args);
-        }
-        catch (err) {
-            // NOTE: structured clone may fail when transferable objects (e.g. MessagePort) are
-            // present in the transfer list. This is observed in Firefox where the Hammerhead
-            // message envelope breaks the clone+transfer semantics. Fall back to sending the
-            // original message without wrapping — the receiving side handles unwrapped messages.
-            args[0] = originalMessage;
-            args[1] = '*';
-
-            return fastApply(contentWindow, 'postMessage', args);
-        }
+        return fastApply(contentWindow, 'postMessage', args);
     }
 
     sendServiceMsg (msg, targetWindow: Window, ports?: Transferable[]) {

--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -216,7 +216,7 @@ export default class MessageSandbox extends SandboxBase {
         if (!args[1] || typeof args[1] === 'string')
             return this._postMessage(contentWindow, args);
         else if (typeof args[1] === 'object')
-            return this._postMessageWithOptions(contentWindow, args, args[1]);
+            return this._postMessageWithOptions(contentWindow, args);
 
         nativeMethods.consoleMeths.log(`testcafe-hammerhead: postMessage called with invalid targetOrigin; aborting call (type: ${typeof args[1]})`);
 

--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -229,9 +229,7 @@ export default class MessageSandbox extends SandboxBase {
             ? options.targetOrigin
             : destLocation.getOriginHeader();
 
-        const originalMessage = args[0];
-
-        args[0] = MessageSandbox._wrapMessage(MessageType.User, originalMessage, resolvedTargetUrl);
+        args[0] = MessageSandbox._wrapMessage(MessageType.User, args[0], resolvedTargetUrl);
         args[1] = nativeMethods.objectAssign({}, options, { targetOrigin: '*' });
 
         return fastApply(contentWindow, 'postMessage', args);

--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -214,16 +214,16 @@ export default class MessageSandbox extends SandboxBase {
 
     postMessage (contentWindow: Window, args) {
         if (!args[1] || typeof args[1] === 'string')
-            return this._postMessage(contentWindow, args);
+            return MessageSandbox._postMessage(contentWindow, args);
         else if (typeof args[1] === 'object')
-            return this._postMessageWithOptions(contentWindow, args);
+            return MessageSandbox._postMessageWithOptions(contentWindow, args);
 
         nativeMethods.consoleMeths.log(`testcafe-hammerhead: postMessage called with invalid targetOrigin; aborting call (type: ${typeof args[1]})`);
 
         return null;
     }
 
-    private _postMessageWithOptions (contentWindow: Window, args) {
+    private static _postMessageWithOptions (contentWindow: Window, args) {
         const options = args[1];
         const resolvedTargetUrl = typeof options.targetOrigin === 'string'
             ? options.targetOrigin
@@ -235,7 +235,7 @@ export default class MessageSandbox extends SandboxBase {
         return fastApply(contentWindow, 'postMessage', args);
     }
 
-    private _postMessage (contentWindow: Window, args) {
+    private static _postMessage (contentWindow: Window, args) {
         const targetUrl = args[1] || destLocation.getOriginHeader();
 
         // NOTE: Here, we pass all messages as "no preference" ("*").

--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -223,7 +223,8 @@ export default class MessageSandbox extends SandboxBase {
         return null;
     }
 
-    private _postMessageWithOptions (contentWindow: Window, args, options) {
+    private _postMessageWithOptions (contentWindow: Window, args) {
+        const options = args[1];
         const resolvedTargetUrl = typeof options.targetOrigin === 'string'
             ? options.targetOrigin
             : destLocation.getOriginHeader();

--- a/src/client/sandbox/event/message.ts
+++ b/src/client/sandbox/event/message.ts
@@ -213,20 +213,17 @@ export default class MessageSandbox extends SandboxBase {
     }
 
     postMessage (contentWindow: Window, args) {
-        const targetUrl = args[1] || destLocation.getOriginHeader();
+        if (!args[1] || typeof args[1] === 'string')
+            return this._postMessage(contentWindow, args);
+        else if (typeof args[1] === 'object')
+            return this._postMessageWithOptions(contentWindow, args, args[1]);
 
-        if (typeof targetUrl !== 'string') {
-            if (targetUrl && typeof targetUrl === 'object')
-                return this._postMessageWithOptionsOverload(contentWindow, args, targetUrl);
+        nativeMethods.consoleMeths.log(`testcafe-hammerhead: postMessage called with invalid targetOrigin; aborting call (type: ${typeof args[1]})`);
 
-            nativeMethods.consoleMeths.log(`testcafe-hammerhead: postMessage called with invalid targetOrigin; aborting call (type: ${typeof targetUrl})`);
-            return null;
-        }
-
-        return this._postMessageWrapped(contentWindow, args, targetUrl);
+        return null;
     }
 
-    private _postMessageWithOptionsOverload (contentWindow: Window, args, options) {
+    private _postMessageWithOptions (contentWindow: Window, args, options) {
         const resolvedTargetUrl = typeof options.targetOrigin === 'string'
             ? options.targetOrigin
             : destLocation.getOriginHeader();
@@ -239,7 +236,9 @@ export default class MessageSandbox extends SandboxBase {
         return fastApply(contentWindow, 'postMessage', args);
     }
 
-    private _postMessageWrapped (contentWindow: Window, args, targetUrl: string) {
+    private _postMessage (contentWindow: Window, args) {
+        const targetUrl = args[1] || destLocation.getOriginHeader();
+
         // NOTE: Here, we pass all messages as "no preference" ("*").
         // We do an origin check in "_onWindowMessage" to access the target origin.
         args[1] = '*';

--- a/test/client/fixtures/sandbox/event/message-test.js
+++ b/test/client/fixtures/sandbox/event/message-test.js
@@ -35,20 +35,46 @@ asyncTest('should pass "transfer" argument for "postMessage" (GH-1535)', functio
     callMethod(window, 'postMessage', ['test', '*', [channel.port1]]);
 });
 
-asyncTest('should not accept an object as "targetOrigin"', function () {
-    var called = false;
-    var handler = function () {
-        called = true;
+asyncTest('should support postMessage(message, options) overload', function () {
+    var eventHandlerObject = {
+        handleEvent: function (e) {
+            strictEqual(e.data, 'options-overload-test');
+            window.removeEventListener('message', eventHandlerObject);
+            start();
+        },
+    };
+
+    window.addEventListener('message', eventHandlerObject);
+    callMethod(window, 'postMessage', ['options-overload-test', { targetOrigin: '*' }]);
+});
+
+asyncTest('should support postMessage(message, options) overload with transfer', function () {
+    var channel = new MessageChannel();
+
+    var eventHandlerObject = {
+        handleEvent: function (e) {
+            strictEqual(e.data, 'options-transfer-test');
+            strictEqual(e.ports.length, 1);
+            window.removeEventListener('message', eventHandlerObject);
+            start();
+        },
+    };
+
+    window.addEventListener('message', eventHandlerObject);
+    callMethod(window, 'postMessage', ['options-transfer-test', { targetOrigin: '*', transfer: [channel.port1] }]);
+});
+
+asyncTest('should deliver message when postMessage is called with an object as second argument', function () {
+    var handler = function (e) {
+        if (e.data === 'object-arg-test') {
+            ok(true, 'message should be delivered via options overload');
+            window.removeEventListener('message', handler);
+            start();
+        }
     };
 
     window.addEventListener('message', handler);
-    callMethod(window, 'postMessage', ['message', { test: 1 }]);
-
-    window.setTimeout(function () {
-        ok(!called, 'message should not be delivered');
-        window.removeEventListener('message', handler);
-        start();
-    }, 100);
+    callMethod(window, 'postMessage', ['object-arg-test', { test: 1 }]);
 });
 
 asyncTest('onmessage event', function () {


### PR DESCRIPTION
Closes #3077

## Problem

`MessageSandbox.postMessage` did not support the modern `postMessage(message, { targetOrigin, transfer })` overload.
When the second argument was an object, the call was treated as invalid and returned early, so messages were not delivered.

This also caused issues for `MessageChannel`-based communication in Firefox, because the options object (which may include `transfer`) was being handled as `targetUrl` instead of a proper overload shape.

## Solution

### 1. Support the `postMessage(message, options)` overload

`postMessage` now detects when the second argument is an object and delegates to `_postMessageWithOptionsOverload`.

### 2. Handle options and transferables using native semantics

`_postMessageWithOptionsOverload`:
- extracts `targetOrigin` from options (falls back to current origin when missing),
- wraps only the user message with Hammerhead metadata,
- forwards options with `targetOrigin: '*'` so transferable handling remains native.

### 3. Keep legacy signature behavior intact

The existing wrapped flow for `postMessage(message, targetOrigin, transfer?)` remains in place.

Per maintainer feedback, the additional clone-error fallback path and related receive-side handling were removed.

## Tests

- Added test for `postMessage(message, { targetOrigin })` options overload.
- Added test for `postMessage(message, { targetOrigin, transfer })` with `MessagePort`.
- Updated the existing object-second-argument test to verify message delivery via the options-overload path.

Made with [Cursor](https://cursor.com)