### PR TITLE
Potential fix for code scanning alert no. 75: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/health-monitor.yml
+++ b/.github/workflows/health-monitor.yml
@@ -134,7 +134,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ fromJSON(steps.get-pr-to-checkout.outputs.result).head.repo.full_name }}
-          ref: ${{ fromJSON(steps.get-pr-to-checkout.outputs.result).head.ref }}
+          ref: ${{ fromJSON(steps.get-pr-to-checkout.outputs.result).head.sha }}
           path: ./HealthMonitor/testcafe-hammerhead
 
       - name: Write the current testcafe-hammerhead abbreviated commit hash to a file


### PR DESCRIPTION
Potential fix for [https://github.com/DevExpress/testcafe-hammerhead/security/code-scanning/75](https://github.com/DevExpress/testcafe-hammerhead/security/code-scanning/75)

Use an immutable PR commit reference for checkout. Specifically, in `.github/workflows/health-monitor.yml`, update the “Checkout the testcafe-hammerhead PR branch” step to checkout `head.sha` instead of `head.ref`. This preserves functionality (still checks out the PR’s head code) while removing the TOCTOU risk because SHA cannot be moved after approval/trigger.

Only one line needs changing in the checkout step:
- Line with `ref: ${{ ...head.ref }}` → `ref: ${{ ...head.sha }}`

No new methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
