### PR TITLE
Potential fix for code scanning alert no. 98: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-functional-testcafe.yml
+++ b/.github/workflows/test-functional-testcafe.yml
@@ -2,6 +2,8 @@ name: Test Functional Proxy (TestCafe)
 
 permissions:
   contents: read
+  statuses: write
+  actions: read
 
 on:
   workflow_call:

--- a/.github/workflows/test-functional-testcafe.yml
+++ b/.github/workflows/test-functional-testcafe.yml
@@ -1,5 +1,8 @@
 name: Test Functional Proxy (TestCafe)
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/DevExpress/testcafe-hammerhead/security/code-scanning/98](https://github.com/DevExpress/testcafe-hammerhead/security/code-scanning/98)

Add an explicit top-level `permissions` block in `.github/workflows/test-functional-testcafe.yml` so all jobs inherit least-privilege defaults.  
Best single fix (without changing existing functionality): set baseline read-only access for repository contents (`contents: read`) at workflow root. This satisfies CodeQL’s requirement for explicit permissions while minimizing privilege. If later a specific job/action needs write access, it can be granted at that job only.

Change region: near the top of the file, after `name` and before `on:`.

No imports, methods, or dependencies are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
